### PR TITLE
[device_info_plus] Use flutter.dev instead of flutter.io

### DIFF
--- a/packages/device_info_plus/README.md
+++ b/packages/device_info_plus/README.md
@@ -33,6 +33,6 @@ You will find links to the API docs on the [pub page](https://pub.dev/packages/d
 ## Getting Started
 
 For help getting started with Flutter, view our online
-[documentation](https://flutter.io/).
+[documentation](https://flutter.dev/).
 
-For help on editing plugin code, view the [documentation](https://flutter.io/platform-plugins/#edit-code).
+For help on editing plugin code, view the [documentation](https://flutter.dev/platform-plugins/#edit-code).


### PR DESCRIPTION
## Description

Use flutter.dev instead of flutter.io

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- Links -->
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo