### PR TITLE
[package_info_plus] fix web build (broken by windows & ffi)

### DIFF
--- a/packages/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/lib/package_info_plus.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart' show visibleForTesting;
+import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
 import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
 import 'package:package_info_plus_windows/package_info_plus_windows.dart';
 
@@ -40,7 +40,7 @@ class PackageInfo {
   // of dart plugins is implemented.
   // See https://github.com/flutter/flutter/issues/52267 for more details.
   static PackageInfoPlatform get _platform {
-    __platform ??= Platform.isWindows && !_disablePlatformOverride
+    __platform ??= !kIsWeb && Platform.isWindows && !_disablePlatformOverride
         ? PackageInfoWindows()
         : PackageInfoPlatform.instance;
     return __platform;

--- a/packages/package_info_plus_windows/lib/package_info_plus_windows.dart
+++ b/packages/package_info_plus_windows/lib/package_info_plus_windows.dart
@@ -1,36 +1,5 @@
-/// The Windows implementation of `package_info_plus`.
-library package_info_plus_windows;
-
-import 'dart:io';
-import 'dart:ffi';
-
-import 'package:ffi/ffi.dart';
-import 'package:package_info_plus_platform_interface/package_info_data.dart';
-import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
-import 'package:win32/win32.dart';
-
-part 'src/file_version_info.dart';
-
-/// The Windows implementation of [PackageInfoPlatform].
-class PackageInfoWindows extends PackageInfoPlatform {
-  /// Returns a map with the following keys:
-  /// appName, packageName, version, buildNumber
-  @override
-  Future<PackageInfoData> getAll() {
-    final info = _FileVersionInfo(Platform.resolvedExecutable);
-    final versions = info.productVersion.split('+');
-    final data = PackageInfoData(
-      appName: info.productName,
-      packageName: info.internalName,
-      version: versions.getOrNull(0),
-      buildNumber: versions.getOrNull(1),
-    );
-    info.dispose();
-    return Future.value(data);
-  }
-}
-
-extension _GetOrNull<T> on List<T> {
-  T getOrNull(int index) => _checkIndex(index) ? this[index] : null;
-  bool _checkIndex(int index) => index >= 0 && index < length;
-}
+// package_info_plus_windows is implemented using FFI; export a stub for
+// platforms that don't support FFI (e.g., web) to avoid having transitive
+// dependencies break web compilation.
+export 'src/package_info_plus_windows_stub.dart'
+    if (dart.library.ffi) 'src/package_info_plus_windows_real.dart';

--- a/packages/package_info_plus_windows/lib/src/package_info_plus_windows_real.dart
+++ b/packages/package_info_plus_windows/lib/src/package_info_plus_windows_real.dart
@@ -1,0 +1,36 @@
+/// The Windows implementation of `package_info_plus`.
+library package_info_plus_windows;
+
+import 'dart:io';
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:package_info_plus_platform_interface/package_info_data.dart';
+import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
+import 'package:win32/win32.dart';
+
+part 'file_version_info.dart';
+
+/// The Windows implementation of [PackageInfoPlatform].
+class PackageInfoWindows extends PackageInfoPlatform {
+  /// Returns a map with the following keys:
+  /// appName, packageName, version, buildNumber
+  @override
+  Future<PackageInfoData> getAll() {
+    final info = _FileVersionInfo(Platform.resolvedExecutable);
+    final versions = info.productVersion.split('+');
+    final data = PackageInfoData(
+      appName: info.productName,
+      packageName: info.internalName,
+      version: versions.getOrNull(0),
+      buildNumber: versions.getOrNull(1),
+    );
+    info.dispose();
+    return Future.value(data);
+  }
+}
+
+extension _GetOrNull<T> on List<T> {
+  T getOrNull(int index) => _checkIndex(index) ? this[index] : null;
+  bool _checkIndex(int index) => index >= 0 && index < length;
+}

--- a/packages/package_info_plus_windows/lib/src/package_info_plus_windows_stub.dart
+++ b/packages/package_info_plus_windows/lib/src/package_info_plus_windows_stub.dart
@@ -1,0 +1,21 @@
+import 'package:package_info_plus_platform_interface/package_info_data.dart';
+import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
+
+/// A stub implementation to satisfy compilation of multi-platform packages that
+/// depend on package_info_plus_windows. This should never actually be created.
+///
+/// Notably, because package_info_plus needs to manually register
+/// package_info_plus_windows, anything with a transitive dependency on
+/// package_info_plus will also depend on package_info_plus_windows, not just at
+/// the pubspec level but the code level.
+class PackageInfoWindows extends PackageInfoPlatform {
+  /// Errors on attempted instantiation of the stub. It exists only to satisfy
+  /// compile-time dependencies, and should never actually be created.
+  PackageInfoWindows() {
+    assert(false);
+  }
+
+  /// Stub
+  @override
+  Future<PackageInfoData> getAll() => null;
+}


### PR DESCRIPTION
## Description

Same as flutter/plugins@2595703 for path_provider_windows.

Moves the real implementation of package_info_plus_windows behind a
conditional export, instead exporting a stub on platforms that don't
support dart:ffi. This avoids build breakage in web projects that have
transitive dependencies on package_info_plus (and thus
package_info_plus__windows due to manual endorsement).

This will no longer be necessary once
flutter/flutter#52267 is fixed, since only
Windows builds will ever need to have code-level dependency on
package_info_plus_windows.

## Related Issues

flutter/flutter#52267

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
