### PR TITLE
[package_info_linux] fix platform interface dependency version

### DIFF
--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.3
+
+- Fix base URI resolving for Web
+- Fix platform interface dependency version for Linux
+
 ## 0.6.2
 
 - Fix collision with package_info

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 0.6.2
+version: 0.6.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -25,10 +25,10 @@ dependencies:
   flutter:
     sdk: flutter
   package_info_plus_platform_interface: ^0.3.0
-  package_info_plus_linux: ^0.1.0
+  package_info_plus_linux: ^0.1.1
   package_info_plus_macos: ^0.2.0
   package_info_plus_windows: ^0.2.0
-  package_info_plus_web: ^0.2.0
+  package_info_plus_web: ^0.2.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/package_info_plus_linux/CHANGELOG.md
+++ b/packages/package_info_plus_linux/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+- Fix platform interface dependency version
+
+
 ## [0.1.0]
 
 * Initial version for Linux.

--- a/packages/package_info_plus_linux/pubspec.yaml
+++ b/packages/package_info_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_linux
 description: Linux implementation of the package_info_plus plugin
-version: 0.1.0
+version: 0.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0 <2.0.0"
 
 dependencies:
-  package_info_plus_platform_interface: ^0.1.0
+  package_info_plus_platform_interface: ^0.3.0
   flutter:
     sdk: flutter
   path: ^1.7.0

--- a/packages/package_info_plus_web/CHANGELOG.md
+++ b/packages/package_info_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- Fix base URI resolving
+
 ## 0.2.0
 
 - Use interface plugin 0.3.0

--- a/packages/package_info_plus_web/lib/package_info_plus_web.dart
+++ b/packages/package_info_plus_web/lib/package_info_plus_web.dart
@@ -17,7 +17,8 @@ class PackageInfoPlugin extends PackageInfoPlatform {
 
   @override
   Future<PackageInfoData> getAll() async {
-    String url = "${window.document.baseUri}/version.json";
+    String url =
+        "${Uri.parse(window.document.baseUri).removeFragment()}/version.json";
 
     final response = await get(url);
     if (response.statusCode == 200) {

--- a/packages/package_info_plus_web/pubspec.yaml
+++ b/packages/package_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_web
 description: Web platform implementation of package_info_plus
-version: 0.2.0
+version: 0.2.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
```
Because every version of package_info_plus from path depends on package_info_plus_linux ^0.1.0 which depends on package_info_plus_platform_interface ^0.1.0, every version of package_info_plus from path requires package_info_plus_platform_interface ^0.1.0.
So, because package_info_example depends on package_info_plus from path which depends on package_info_plus_platform_interface ^0.3.0, version solving failed.
```