### PR TITLE
[android_intent_plus] fix flutter/flutter#71518 by adding launchChooser method.

### DIFF
--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## pre-release
+
+- Add launchChooser method, which uses Intent.createChooser internally.
+
 ## 0.4.1
 
 - Renamed Method Channel and changed Java package to avoid collision with android_intent

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
@@ -9,19 +9,14 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
-
 import androidx.annotation.Nullable;
 
-/**
- * Forms and launches intents.
- */
+/** Forms and launches intents. */
 public final class IntentSender {
   private static final String TAG = "IntentSender";
 
-  @Nullable
-  private Activity activity;
-  @Nullable
-  private Context applicationContext;
+  @Nullable private Activity activity;
+  @Nullable private Context applicationContext;
 
   /**
    * Caches the given {@code activity} and {@code applicationContext} to use for sending intents
@@ -64,10 +59,9 @@ public final class IntentSender {
     }
   }
 
-
   /**
-   * Like with {@code send}, creates and launches an intent with the given params, but wraps
-   * the {@code Intent} with {@code Intent.createChooser}.
+   * Like with {@code send}, creates and launches an intent with the given params, but wraps the
+   * {@code Intent} with {@code Intent.createChooser}.
    */
   public void launchChooser(Intent intent, String title) {
     send(Intent.createChooser(intent, title));
@@ -83,7 +77,7 @@ public final class IntentSender {
    *
    * @param intent Fully built intent.
    * @return Whether the package manager found {@link android.content.pm.ResolveInfo} using its
-   * {@link PackageManager#resolveActivity(Intent, int)} method.
+   *     {@link PackageManager#resolveActivity(Intent, int)} method.
    * @see #buildIntent(String, Integer, String, Uri, Bundle, String, ComponentName, String)
    */
   boolean canResolveActivity(Intent intent) {
@@ -97,16 +91,12 @@ public final class IntentSender {
     return packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null;
   }
 
-  /**
-   * Caches the given {@code activity} to use for {@link #send}.
-   */
+  /** Caches the given {@code activity} to use for {@link #send}. */
   void setActivity(@Nullable Activity activity) {
     this.activity = activity;
   }
 
-  /**
-   * Caches the given {@code applicationContext} to use for {@link #send}.
-   */
+  /** Caches the given {@code applicationContext} to use for {@link #send}. */
   void setApplicationContext(@Nullable Context applicationContext) {
     this.applicationContext = applicationContext;
   }
@@ -114,30 +104,30 @@ public final class IntentSender {
   /**
    * Constructs a new intent with the data specified.
    *
-   * @param action        the Intent action, such as {@code ACTION_VIEW}.
-   * @param flags         forwarded to {@link Intent#addFlags(int)} if non-null.
-   * @param category      forwarded to {@link Intent#addCategory(String)} if non-null.
-   * @param data          forwarded to {@link Intent#setData(Uri)} if non-null and 'type' parameter is null.
-   *                      If both 'data' and 'type' is non-null they're forwarded to {@link
-   *                      Intent#setDataAndType(Uri, String)}
-   * @param arguments     forwarded to {@link Intent#putExtras(Bundle)} if non-null.
-   * @param packageName   forwarded to {@link Intent#setPackage(String)} if non-null. This is forced
-   *                      to null if it can't be resolved.
+   * @param action the Intent action, such as {@code ACTION_VIEW}.
+   * @param flags forwarded to {@link Intent#addFlags(int)} if non-null.
+   * @param category forwarded to {@link Intent#addCategory(String)} if non-null.
+   * @param data forwarded to {@link Intent#setData(Uri)} if non-null and 'type' parameter is null.
+   *     If both 'data' and 'type' is non-null they're forwarded to {@link
+   *     Intent#setDataAndType(Uri, String)}
+   * @param arguments forwarded to {@link Intent#putExtras(Bundle)} if non-null.
+   * @param packageName forwarded to {@link Intent#setPackage(String)} if non-null. This is forced
+   *     to null if it can't be resolved.
    * @param componentName forwarded to {@link Intent#setComponent(ComponentName)} if non-null.
-   * @param type          forwarded to {@link Intent#setType(String)} if non-null and 'data' parameter is
-   *                      null. If both 'data' and 'type' is non-null they're forwarded to {@link
-   *                      Intent#setDataAndType(Uri, String)}
+   * @param type forwarded to {@link Intent#setType(String)} if non-null and 'data' parameter is
+   *     null. If both 'data' and 'type' is non-null they're forwarded to {@link
+   *     Intent#setDataAndType(Uri, String)}
    * @return Fully built intent.
    */
   Intent buildIntent(
-    @Nullable String action,
-    @Nullable Integer flags,
-    @Nullable String category,
-    @Nullable Uri data,
-    @Nullable Bundle arguments,
-    @Nullable String packageName,
-    @Nullable ComponentName componentName,
-    @Nullable String type) {
+      @Nullable String action,
+      @Nullable Integer flags,
+      @Nullable String category,
+      @Nullable Uri data,
+      @Nullable Bundle arguments,
+      @Nullable String packageName,
+      @Nullable ComponentName componentName,
+      @Nullable String type) {
     if (applicationContext == null) {
       Log.wtf(TAG, "Trying to build an intent before the applicationContext was initialized.");
       return null;

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
@@ -9,14 +9,19 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
+
 import androidx.annotation.Nullable;
 
-/** Forms and launches intents. */
+/**
+ * Forms and launches intents.
+ */
 public final class IntentSender {
   private static final String TAG = "IntentSender";
 
-  @Nullable private Activity activity;
-  @Nullable private Context applicationContext;
+  @Nullable
+  private Activity activity;
+  @Nullable
+  private Context applicationContext;
 
   /**
    * Caches the given {@code activity} and {@code applicationContext} to use for sending intents
@@ -59,6 +64,15 @@ public final class IntentSender {
     }
   }
 
+
+  /**
+   * Like with {@code send}, creates and launches an intent with the given params, but wraps
+   * the {@code Intent} with {@code Intent.createChooser}.
+   */
+  public void launchChooser(Intent intent, String title) {
+    send(Intent.createChooser(intent, title));
+  }
+
   /**
    * Verifies the given intent and returns whether the application context class can resolve it.
    *
@@ -68,9 +82,9 @@ public final class IntentSender {
    * <p>This currently only supports resolving activities.
    *
    * @param intent Fully built intent.
-   * @see #buildIntent(String, Integer, String, Uri, Bundle, String, ComponentName, String)
    * @return Whether the package manager found {@link android.content.pm.ResolveInfo} using its
-   *     {@link PackageManager#resolveActivity(Intent, int)} method.
+   * {@link PackageManager#resolveActivity(Intent, int)} method.
+   * @see #buildIntent(String, Integer, String, Uri, Bundle, String, ComponentName, String)
    */
   boolean canResolveActivity(Intent intent) {
     if (applicationContext == null) {
@@ -83,12 +97,16 @@ public final class IntentSender {
     return packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null;
   }
 
-  /** Caches the given {@code activity} to use for {@link #send}. */
+  /**
+   * Caches the given {@code activity} to use for {@link #send}.
+   */
   void setActivity(@Nullable Activity activity) {
     this.activity = activity;
   }
 
-  /** Caches the given {@code applicationContext} to use for {@link #send}. */
+  /**
+   * Caches the given {@code applicationContext} to use for {@link #send}.
+   */
   void setApplicationContext(@Nullable Context applicationContext) {
     this.applicationContext = applicationContext;
   }
@@ -96,30 +114,30 @@ public final class IntentSender {
   /**
    * Constructs a new intent with the data specified.
    *
-   * @param action the Intent action, such as {@code ACTION_VIEW}.
-   * @param flags forwarded to {@link Intent#addFlags(int)} if non-null.
-   * @param category forwarded to {@link Intent#addCategory(String)} if non-null.
-   * @param data forwarded to {@link Intent#setData(Uri)} if non-null and 'type' parameter is null.
-   *     If both 'data' and 'type' is non-null they're forwarded to {@link
-   *     Intent#setDataAndType(Uri, String)}
-   * @param arguments forwarded to {@link Intent#putExtras(Bundle)} if non-null.
-   * @param packageName forwarded to {@link Intent#setPackage(String)} if non-null. This is forced
-   *     to null if it can't be resolved.
+   * @param action        the Intent action, such as {@code ACTION_VIEW}.
+   * @param flags         forwarded to {@link Intent#addFlags(int)} if non-null.
+   * @param category      forwarded to {@link Intent#addCategory(String)} if non-null.
+   * @param data          forwarded to {@link Intent#setData(Uri)} if non-null and 'type' parameter is null.
+   *                      If both 'data' and 'type' is non-null they're forwarded to {@link
+   *                      Intent#setDataAndType(Uri, String)}
+   * @param arguments     forwarded to {@link Intent#putExtras(Bundle)} if non-null.
+   * @param packageName   forwarded to {@link Intent#setPackage(String)} if non-null. This is forced
+   *                      to null if it can't be resolved.
    * @param componentName forwarded to {@link Intent#setComponent(ComponentName)} if non-null.
-   * @param type forwarded to {@link Intent#setType(String)} if non-null and 'data' parameter is
-   *     null. If both 'data' and 'type' is non-null they're forwarded to {@link
-   *     Intent#setDataAndType(Uri, String)}
+   * @param type          forwarded to {@link Intent#setType(String)} if non-null and 'data' parameter is
+   *                      null. If both 'data' and 'type' is non-null they're forwarded to {@link
+   *                      Intent#setDataAndType(Uri, String)}
    * @return Fully built intent.
    */
   Intent buildIntent(
-      @Nullable String action,
-      @Nullable Integer flags,
-      @Nullable String category,
-      @Nullable Uri data,
-      @Nullable Bundle arguments,
-      @Nullable String packageName,
-      @Nullable ComponentName componentName,
-      @Nullable String type) {
+    @Nullable String action,
+    @Nullable Integer flags,
+    @Nullable String category,
+    @Nullable Uri data,
+    @Nullable Bundle arguments,
+    @Nullable String packageName,
+    @Nullable ComponentName componentName,
+    @Nullable String type) {
     if (applicationContext == null) {
       Log.wtf(TAG, "Trying to build an intent before the applicationContext was initialized.");
       return null;

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
@@ -93,6 +93,10 @@ public final class MethodCallHandlerImpl implements MethodCallHandler {
       sender.send(intent);
 
       result.success(null);
+    } else if ("launchChooser".equalsIgnoreCase(call.method)) {
+      String title = call.argument("chooserTitle");
+      sender.launchChooser(intent, title);
+      result.success(null);
     } else if ("canResolveActivity".equalsIgnoreCase(call.method)) {
       result.success(sender.canResolveActivity(intent));
     } else {

--- a/packages/android_intent_plus/example/lib/main.dart
+++ b/packages/android_intent_plus/example/lib/main.dart
@@ -65,8 +65,15 @@ class MyHomePage extends StatelessWidget {
               onPressed: _createAlarm,
             ),
             RaisedButton(
-                child: const Text('Tap here to test explicit intents.'),
-                onPressed: () => _openExplicitIntentsView(context)),
+              child: const Text(
+                'Tap here to launch Intent with Chooser',
+              ),
+              onPressed: _openChooser,
+            ),
+            RaisedButton(
+              child: const Text('Tap here to test explicit intents.'),
+              onPressed: () => _openExplicitIntentsView(context),
+            ),
           ],
         ),
       );
@@ -79,6 +86,15 @@ class MyHomePage extends StatelessWidget {
       ),
       body: Center(child: body),
     );
+  }
+
+  void _openChooser() {
+    final intent = const AndroidIntent(
+      action: 'android.intent.action.SEND',
+      type: 'plain/text',
+      data: 'text example',
+    );
+    intent.launchChooser('Chose an app');
   }
 }
 
@@ -204,7 +220,7 @@ class ExplicitIntentsWidget extends StatelessWidget {
                   'Tap here to open Application Details',
                 ),
                 onPressed: _openApplicationDetails,
-              )
+              ),
             ],
           ),
         ),

--- a/packages/android_intent_plus/example/test_driver/android_intent_plus_e2e.dart
+++ b/packages/android_intent_plus/example/test_driver/android_intent_plus_e2e.dart
@@ -24,7 +24,7 @@ void main() {
           (Widget widget) =>
               widget is Text && widget.data.startsWith('Tap here'),
         ),
-        findsNWidgets(2),
+        findsNWidgets(3),
       );
     } else {
       expect(
@@ -47,6 +47,15 @@ void main() {
       return e is PlatformException &&
           e.message.contains('No Activity found to handle Intent');
     }));
+  }, skip: !Platform.isAndroid);
+
+  testWidgets('#launchChooser should not throw', (WidgetTester tester) async {
+    final intent = const AndroidIntent(
+      action: 'android.intent.action.SEND',
+      type: 'plain/text',
+      data: 'text example',
+    );
+    await intent.launchChooser('title');
   }, skip: !Platform.isAndroid);
 
   testWidgets('#canResolveActivity returns true when example Activity is found',

--- a/packages/android_intent_plus/lib/android_intent.dart
+++ b/packages/android_intent_plus/lib/android_intent.dart
@@ -138,6 +138,22 @@ class AndroidIntent {
     await _channel.invokeMethod<void>('launch', _buildArguments());
   }
 
+  /// Launch the intent with 'createChooser(intent, title)'.
+  ///
+  /// This works only on Android platforms.
+  Future<void> launchChooser(String title) async {
+    if (!_platform.isAndroid) {
+      return;
+    }
+
+    final buildArguments = _buildArguments();
+    buildArguments['chooserTitle'] = title;
+    await _channel.invokeMethod<void>(
+      'launchChooser',
+      buildArguments,
+    );
+  }
+
   /// Check whether the intent can be resolved to an activity.
   ///
   /// This works only on Android platforms.

--- a/packages/android_intent_plus/test/android_intent_test.dart
+++ b/packages/android_intent_plus/test/android_intent_test.dart
@@ -144,8 +144,8 @@ void main() {
     group('launchChooser', () {
       test('pass title', () async {
         androidIntent = AndroidIntent.private(
-            action: 'action_view',
-            channel: mockChannel,
+          action: 'action_view',
+          channel: mockChannel,
           platform: FakePlatform(operatingSystem: 'android'),
         );
         await androidIntent.launchChooser('title');

--- a/packages/android_intent_plus/test/android_intent_test.dart
+++ b/packages/android_intent_plus/test/android_intent_test.dart
@@ -140,6 +140,21 @@ void main() {
         verifyZeroInteractions(mockChannel);
       });
     });
+
+    group('launchChooser', () {
+      test('pass title', () async {
+        androidIntent = AndroidIntent.private(
+            action: 'action_view',
+            channel: mockChannel,
+          platform: FakePlatform(operatingSystem: 'android'),
+        );
+        await androidIntent.launchChooser('title');
+        verify(mockChannel.invokeMethod<void>('launchChooser', <String, Object>{
+          'action': 'action_view',
+          'chooserTitle': 'title',
+        }));
+      });
+    });
   });
 
   group('convertFlags ', () {


### PR DESCRIPTION
## Description

In https://github.com/flutter/flutter/issues/71518 the author requested a way to be able to launch Intents with the createChooser wrapper.

In this PR I have added the method channel `launchChooser` which allows users to do that.

Usage:

```dart
final intent = const AndroidIntent(
  action: 'android.intent.action.SEND',
  type: 'plain/text',
  data: 'text example',
);
intent.launchChooser('Chose an app');
```

## Related Issues

- https://github.com/flutter/flutter/issues/71518
- https://github.com/fluttercommunity/plus_plugins/issues/75

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.

Note: I have added e2e and unit tests, but there's also some Espresso Android tests which won't even run, so I couldn't add anything there.

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

