### PR TITLE
[android_intent_plus] implement send intent as broadcast

### DIFF
--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,6 +1,7 @@
-## pre-release
+## 0.4.2
 
 - Add launchChooser method, which uses Intent.createChooser internally.
+- Add sendBroadcast method, which uses context.sendBroadcast() internally.
 
 ## 0.4.1
 

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
@@ -9,14 +9,19 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
+
 import androidx.annotation.Nullable;
 
-/** Forms and launches intents. */
+/**
+ * Forms and launches intents.
+ */
 public final class IntentSender {
   private static final String TAG = "IntentSender";
 
-  @Nullable private Activity activity;
-  @Nullable private Context applicationContext;
+  @Nullable
+  private Activity activity;
+  @Nullable
+  private Context applicationContext;
 
   /**
    * Caches the given {@code activity} and {@code applicationContext} to use for sending intents
@@ -68,6 +73,19 @@ public final class IntentSender {
   }
 
   /**
+   * Creates an intent and sends it as Broadcast.
+   */
+  public void sendBroadcast(Intent intent) {
+    if (applicationContext == null) {
+      Log.wtf(TAG, "Trying to send broadcast before the applicationContext was initialized.");
+      return;
+    }
+
+    Log.v(TAG, "Sending broadcast " + intent);
+    applicationContext.sendBroadcast(intent);
+  }
+
+  /**
    * Verifies the given intent and returns whether the application context class can resolve it.
    *
    * <p>This will fail to create and send the intent if {@code applicationContext} hasn't been set *
@@ -77,7 +95,7 @@ public final class IntentSender {
    *
    * @param intent Fully built intent.
    * @return Whether the package manager found {@link android.content.pm.ResolveInfo} using its
-   *     {@link PackageManager#resolveActivity(Intent, int)} method.
+   * {@link PackageManager#resolveActivity(Intent, int)} method.
    * @see #buildIntent(String, Integer, String, Uri, Bundle, String, ComponentName, String)
    */
   boolean canResolveActivity(Intent intent) {
@@ -91,12 +109,16 @@ public final class IntentSender {
     return packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null;
   }
 
-  /** Caches the given {@code activity} to use for {@link #send}. */
+  /**
+   * Caches the given {@code activity} to use for {@link #send}.
+   */
   void setActivity(@Nullable Activity activity) {
     this.activity = activity;
   }
 
-  /** Caches the given {@code applicationContext} to use for {@link #send}. */
+  /**
+   * Caches the given {@code applicationContext} to use for {@link #send}.
+   */
   void setApplicationContext(@Nullable Context applicationContext) {
     this.applicationContext = applicationContext;
   }
@@ -104,30 +126,30 @@ public final class IntentSender {
   /**
    * Constructs a new intent with the data specified.
    *
-   * @param action the Intent action, such as {@code ACTION_VIEW}.
-   * @param flags forwarded to {@link Intent#addFlags(int)} if non-null.
-   * @param category forwarded to {@link Intent#addCategory(String)} if non-null.
-   * @param data forwarded to {@link Intent#setData(Uri)} if non-null and 'type' parameter is null.
-   *     If both 'data' and 'type' is non-null they're forwarded to {@link
-   *     Intent#setDataAndType(Uri, String)}
-   * @param arguments forwarded to {@link Intent#putExtras(Bundle)} if non-null.
-   * @param packageName forwarded to {@link Intent#setPackage(String)} if non-null. This is forced
-   *     to null if it can't be resolved.
+   * @param action        the Intent action, such as {@code ACTION_VIEW}.
+   * @param flags         forwarded to {@link Intent#addFlags(int)} if non-null.
+   * @param category      forwarded to {@link Intent#addCategory(String)} if non-null.
+   * @param data          forwarded to {@link Intent#setData(Uri)} if non-null and 'type' parameter is null.
+   *                      If both 'data' and 'type' is non-null they're forwarded to {@link
+   *                      Intent#setDataAndType(Uri, String)}
+   * @param arguments     forwarded to {@link Intent#putExtras(Bundle)} if non-null.
+   * @param packageName   forwarded to {@link Intent#setPackage(String)} if non-null. This is forced
+   *                      to null if it can't be resolved.
    * @param componentName forwarded to {@link Intent#setComponent(ComponentName)} if non-null.
-   * @param type forwarded to {@link Intent#setType(String)} if non-null and 'data' parameter is
-   *     null. If both 'data' and 'type' is non-null they're forwarded to {@link
-   *     Intent#setDataAndType(Uri, String)}
+   * @param type          forwarded to {@link Intent#setType(String)} if non-null and 'data' parameter is
+   *                      null. If both 'data' and 'type' is non-null they're forwarded to {@link
+   *                      Intent#setDataAndType(Uri, String)}
    * @return Fully built intent.
    */
   Intent buildIntent(
-      @Nullable String action,
-      @Nullable Integer flags,
-      @Nullable String category,
-      @Nullable Uri data,
-      @Nullable Bundle arguments,
-      @Nullable String packageName,
-      @Nullable ComponentName componentName,
-      @Nullable String type) {
+    @Nullable String action,
+    @Nullable Integer flags,
+    @Nullable String category,
+    @Nullable Uri data,
+    @Nullable Bundle arguments,
+    @Nullable String packageName,
+    @Nullable ComponentName componentName,
+    @Nullable String type) {
     if (applicationContext == null) {
       Log.wtf(TAG, "Trying to build an intent before the applicationContext was initialized.");
       return null;

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
@@ -9,19 +9,14 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.Log;
-
 import androidx.annotation.Nullable;
 
-/**
- * Forms and launches intents.
- */
+/** Forms and launches intents. */
 public final class IntentSender {
   private static final String TAG = "IntentSender";
 
-  @Nullable
-  private Activity activity;
-  @Nullable
-  private Context applicationContext;
+  @Nullable private Activity activity;
+  @Nullable private Context applicationContext;
 
   /**
    * Caches the given {@code activity} and {@code applicationContext} to use for sending intents
@@ -72,9 +67,7 @@ public final class IntentSender {
     send(Intent.createChooser(intent, title));
   }
 
-  /**
-   * Creates an intent and sends it as Broadcast.
-   */
+  /** Creates an intent and sends it as Broadcast. */
   public void sendBroadcast(Intent intent) {
     if (applicationContext == null) {
       Log.wtf(TAG, "Trying to send broadcast before the applicationContext was initialized.");
@@ -95,7 +88,7 @@ public final class IntentSender {
    *
    * @param intent Fully built intent.
    * @return Whether the package manager found {@link android.content.pm.ResolveInfo} using its
-   * {@link PackageManager#resolveActivity(Intent, int)} method.
+   *     {@link PackageManager#resolveActivity(Intent, int)} method.
    * @see #buildIntent(String, Integer, String, Uri, Bundle, String, ComponentName, String)
    */
   boolean canResolveActivity(Intent intent) {
@@ -109,16 +102,12 @@ public final class IntentSender {
     return packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null;
   }
 
-  /**
-   * Caches the given {@code activity} to use for {@link #send}.
-   */
+  /** Caches the given {@code activity} to use for {@link #send}. */
   void setActivity(@Nullable Activity activity) {
     this.activity = activity;
   }
 
-  /**
-   * Caches the given {@code applicationContext} to use for {@link #send}.
-   */
+  /** Caches the given {@code applicationContext} to use for {@link #send}. */
   void setApplicationContext(@Nullable Context applicationContext) {
     this.applicationContext = applicationContext;
   }
@@ -126,30 +115,30 @@ public final class IntentSender {
   /**
    * Constructs a new intent with the data specified.
    *
-   * @param action        the Intent action, such as {@code ACTION_VIEW}.
-   * @param flags         forwarded to {@link Intent#addFlags(int)} if non-null.
-   * @param category      forwarded to {@link Intent#addCategory(String)} if non-null.
-   * @param data          forwarded to {@link Intent#setData(Uri)} if non-null and 'type' parameter is null.
-   *                      If both 'data' and 'type' is non-null they're forwarded to {@link
-   *                      Intent#setDataAndType(Uri, String)}
-   * @param arguments     forwarded to {@link Intent#putExtras(Bundle)} if non-null.
-   * @param packageName   forwarded to {@link Intent#setPackage(String)} if non-null. This is forced
-   *                      to null if it can't be resolved.
+   * @param action the Intent action, such as {@code ACTION_VIEW}.
+   * @param flags forwarded to {@link Intent#addFlags(int)} if non-null.
+   * @param category forwarded to {@link Intent#addCategory(String)} if non-null.
+   * @param data forwarded to {@link Intent#setData(Uri)} if non-null and 'type' parameter is null.
+   *     If both 'data' and 'type' is non-null they're forwarded to {@link
+   *     Intent#setDataAndType(Uri, String)}
+   * @param arguments forwarded to {@link Intent#putExtras(Bundle)} if non-null.
+   * @param packageName forwarded to {@link Intent#setPackage(String)} if non-null. This is forced
+   *     to null if it can't be resolved.
    * @param componentName forwarded to {@link Intent#setComponent(ComponentName)} if non-null.
-   * @param type          forwarded to {@link Intent#setType(String)} if non-null and 'data' parameter is
-   *                      null. If both 'data' and 'type' is non-null they're forwarded to {@link
-   *                      Intent#setDataAndType(Uri, String)}
+   * @param type forwarded to {@link Intent#setType(String)} if non-null and 'data' parameter is
+   *     null. If both 'data' and 'type' is non-null they're forwarded to {@link
+   *     Intent#setDataAndType(Uri, String)}
    * @return Fully built intent.
    */
   Intent buildIntent(
-    @Nullable String action,
-    @Nullable Integer flags,
-    @Nullable String category,
-    @Nullable Uri data,
-    @Nullable Bundle arguments,
-    @Nullable String packageName,
-    @Nullable ComponentName componentName,
-    @Nullable String type) {
+      @Nullable String action,
+      @Nullable Integer flags,
+      @Nullable String category,
+      @Nullable Uri data,
+      @Nullable Bundle arguments,
+      @Nullable String packageName,
+      @Nullable ComponentName componentName,
+      @Nullable String type) {
     if (applicationContext == null) {
       Log.wtf(TAG, "Trying to build an intent before the applicationContext was initialized.");
       return null;

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
@@ -97,6 +97,9 @@ public final class MethodCallHandlerImpl implements MethodCallHandler {
       String title = call.argument("chooserTitle");
       sender.launchChooser(intent, title);
       result.success(null);
+    } else if ("sendBroadcast".equalsIgnoreCase(call.method)) {
+      sender.sendBroadcast(intent);
+      result.success(null);
     } else if ("canResolveActivity".equalsIgnoreCase(call.method)) {
       result.success(sender.canResolveActivity(intent));
     } else {

--- a/packages/android_intent_plus/example/android/app/build.gradle
+++ b/packages/android_intent_plus/example/android/app/build.gradle
@@ -54,6 +54,7 @@ flutter {
 }
 
 dependencies {
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.1'

--- a/packages/android_intent_plus/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/android_intent_plus/example/android/app/src/main/AndroidManifest.xml
@@ -1,43 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="io.flutter.plugins.androidintentexample">
 
-  <!-- io.flutter.app.FlutterApplication is an android.app.Application that
-       calls FlutterMain.startInitialization(this); in its onCreate method.
-       In most cases you can leave this as-is, but you if you want to provide
-       additional functionality it is fine to subclass or reimplement
-       FlutterApplication and put your custom class here. -->
-  <application
-    android:icon="@mipmap/ic_launcher"
-    android:label="android_intent_example"
-    android:name="io.flutter.app.FlutterApplication">
-    <activity
-      android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale"
-      android:name=".EmbeddingV1Activity"
-      android:theme="@android:style/Theme.Black.NoTitleBar"
-      android:hardwareAccelerated="true"
-      android:windowSoftInputMode="adjustResize">
-    </activity>
+  <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
+  <!--
+ The INTERNET permission is required for development. Specifically,
+       flutter needs it to communicate with the running application
+       to allow setting breakpoints, to provide hot reload, etc.
+    -->
+  <uses-permission android:name="android.permission.INTERNET" />
 
-    <activity android:name="io.flutter.embedding.android.FlutterActivity"
-      android:theme="@android:style/Theme.Black.NoTitleBar"
+  <application
+    android:name="io.flutter.app.FlutterApplication"
+    android:icon="@mipmap/ic_launcher"
+    android:label="android_intent_example">
+    <activity
+      android:name=".EmbeddingV1Activity"
       android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale"
       android:hardwareAccelerated="true"
+      android:theme="@android:style/Theme.Black.NoTitleBar"
+      android:windowSoftInputMode="adjustResize"></activity>
+    <activity
+      android:name=".MainActivity"
+      android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection|fontScale"
+      android:hardwareAccelerated="true"
+      android:theme="@android:style/Theme.Black.NoTitleBar"
       android:windowSoftInputMode="adjustResize">
       <meta-data
         android:name="io.flutter.app.android.SplashScreenUntilFirstFrame"
         android:value="true" />
+
       <intent-filter>
-        <action android:name="android.intent.action.MAIN"/>
-        <category android:name="android.intent.category.LAUNCHER"/>
+        <action android:name="android.intent.action.MAIN" />
+
+        <category android:name="android.intent.category.LAUNCHER" />
       </intent-filter>
     </activity>
-    <meta-data android:name="flutterEmbedding" android:value="2"/>
-  </application>
-  <uses-permission android:name="com.android.alarm.permission.SET_ALARM"/>
 
-  <!-- The INTERNET permission is required for development. Specifically,
-       flutter needs it to communicate with the running application
-       to allow setting breakpoints, to provide hot reload, etc.
-  -->
-  <uses-permission android:name="android.permission.INTERNET"/>
+    <meta-data
+      android:name="flutterEmbedding"
+      android:value="2" />
+
+    <receiver android:name=".MyBroadcastReceiver">
+      <intent-filter>
+        <action android:name="com.example.broadcast"></action>
+      </intent-filter>
+    </receiver>
+  </application>
+
 </manifest>

--- a/packages/android_intent_plus/example/android/app/src/main/java/io/flutter/plugins/androidintentexample/EmbeddingV1Activity.java
+++ b/packages/android_intent_plus/example/android/app/src/main/java/io/flutter/plugins/androidintentexample/EmbeddingV1Activity.java
@@ -4,9 +4,7 @@
 
 package io.flutter.plugins.androidintentexample;
 
-import android.content.IntentFilter;
 import android.os.Bundle;
-
 import dev.fluttercommunity.plus.androidintent.AndroidIntentPlugin;
 import io.flutter.app.FlutterActivity;
 
@@ -15,6 +13,6 @@ public class EmbeddingV1Activity extends FlutterActivity {
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     AndroidIntentPlugin.registerWith(
-      registrarFor("dev.fluttercommunity.plus.androidintent.AndroidIntentPlugin"));
+        registrarFor("dev.fluttercommunity.plus.androidintent.AndroidIntentPlugin"));
   }
 }

--- a/packages/android_intent_plus/example/android/app/src/main/java/io/flutter/plugins/androidintentexample/MainActivity.java
+++ b/packages/android_intent_plus/example/android/app/src/main/java/io/flutter/plugins/androidintentexample/MainActivity.java
@@ -2,7 +2,6 @@ package io.flutter.plugins.androidintentexample;
 
 import android.content.IntentFilter;
 import android.os.Bundle;
-
 import dev.fluttercommunity.plus.androidintent.AndroidIntentPlugin;
 import io.flutter.app.FlutterActivity;
 
@@ -13,7 +12,7 @@ public class MainActivity extends FlutterActivity {
     super.onCreate(savedInstanceState);
 
     AndroidIntentPlugin.registerWith(
-      registrarFor("dev.fluttercommunity.plus.androidintent.AndroidIntentPlugin"));
+        registrarFor("dev.fluttercommunity.plus.androidintent.AndroidIntentPlugin"));
 
     IntentFilter filter = new IntentFilter("com.example.broadcast");
     MyBroadcastReceiver receiver = new MyBroadcastReceiver();

--- a/packages/android_intent_plus/example/android/app/src/main/java/io/flutter/plugins/androidintentexample/MainActivity.java
+++ b/packages/android_intent_plus/example/android/app/src/main/java/io/flutter/plugins/androidintentexample/MainActivity.java
@@ -1,7 +1,3 @@
-// Copyright 2017 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
 package io.flutter.plugins.androidintentexample;
 
 import android.content.IntentFilter;
@@ -10,11 +6,17 @@ import android.os.Bundle;
 import dev.fluttercommunity.plus.androidintent.AndroidIntentPlugin;
 import io.flutter.app.FlutterActivity;
 
-public class EmbeddingV1Activity extends FlutterActivity {
+public class MainActivity extends FlutterActivity {
+
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
+
     AndroidIntentPlugin.registerWith(
       registrarFor("dev.fluttercommunity.plus.androidintent.AndroidIntentPlugin"));
+
+    IntentFilter filter = new IntentFilter("com.example.broadcast");
+    MyBroadcastReceiver receiver = new MyBroadcastReceiver();
+    registerReceiver(receiver, filter);
   }
 }

--- a/packages/android_intent_plus/example/android/app/src/main/java/io/flutter/plugins/androidintentexample/MyBroadcastReceiver.java
+++ b/packages/android_intent_plus/example/android/app/src/main/java/io/flutter/plugins/androidintentexample/MyBroadcastReceiver.java
@@ -1,0 +1,15 @@
+package io.flutter.plugins.androidintentexample;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
+import android.widget.Toast;
+
+public class MyBroadcastReceiver extends BroadcastReceiver {
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    Log.d("MyBroadcastReceiver", "Got Intent: " + intent.toString());
+    Toast.makeText(context, "Broadcast Received!", Toast.LENGTH_LONG).show();
+  }
+}

--- a/packages/android_intent_plus/example/android/app/src/main/res/values/strings.xml
+++ b/packages/android_intent_plus/example/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,1 @@
+<resources></resources>

--- a/packages/android_intent_plus/example/lib/main.dart
+++ b/packages/android_intent_plus/example/lib/main.dart
@@ -65,10 +65,12 @@ class MyHomePage extends StatelessWidget {
               onPressed: _createAlarm,
             ),
             RaisedButton(
-              child: const Text(
-                'Tap here to launch Intent with Chooser',
-              ),
+              child: const Text('Tap here to launch Intent with Chooser'),
               onPressed: _openChooser,
+            ),
+            RaisedButton(
+              child: const Text('Tap here to send Intent as broadcast'),
+              onPressed: _sendBroadcast,
             ),
             RaisedButton(
               child: const Text('Tap here to test explicit intents.'),
@@ -95,6 +97,13 @@ class MyHomePage extends StatelessWidget {
       data: 'text example',
     );
     intent.launchChooser('Chose an app');
+  }
+
+  void _sendBroadcast() {
+    final intent = const AndroidIntent(
+      action: 'com.example.broadcast',
+    );
+    intent.sendBroadcast();
   }
 }
 

--- a/packages/android_intent_plus/example/test_driver/android_intent_plus_e2e.dart
+++ b/packages/android_intent_plus/example/test_driver/android_intent_plus_e2e.dart
@@ -24,7 +24,7 @@ void main() {
           (Widget widget) =>
               widget is Text && widget.data.startsWith('Tap here'),
         ),
-        findsNWidgets(3),
+        findsNWidgets(4),
       );
     } else {
       expect(
@@ -56,6 +56,13 @@ void main() {
       data: 'text example',
     );
     await intent.launchChooser('title');
+  }, skip: !Platform.isAndroid);
+
+  testWidgets('#sendBroadcast should not throw', (WidgetTester tester) async {
+    final intent = const AndroidIntent(
+      action: 'com.example.broadcast',
+    );
+    await intent.sendBroadcast();
   }, skip: !Platform.isAndroid);
 
   testWidgets('#canResolveActivity returns true when example Activity is found',

--- a/packages/android_intent_plus/lib/android_intent.dart
+++ b/packages/android_intent_plus/lib/android_intent.dart
@@ -154,6 +154,20 @@ class AndroidIntent {
     );
   }
 
+  /// Sends intent as broadcast.
+  ///
+  /// This works only on Android platforms.
+  Future<void> sendBroadcast() async {
+    if (!_platform.isAndroid) {
+      return;
+    }
+
+    await _channel.invokeMethod<void>(
+      'sendBroadcast',
+      _buildArguments(),
+    );
+  }
+
   /// Check whether the intent can be resolved to an activity.
   ///
   /// This works only on Android platforms.

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 0.4.1
+version: 0.4.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/android_intent_plus/test/android_intent_test.dart
+++ b/packages/android_intent_plus/test/android_intent_test.dart
@@ -155,6 +155,20 @@ void main() {
         }));
       });
     });
+
+    group('sendBroadcast', () {
+      test('send a broadcast', () async {
+        androidIntent = AndroidIntent.private(
+          action: 'com.example.broadcast',
+          channel: mockChannel,
+          platform: FakePlatform(operatingSystem: 'android'),
+        );
+        await androidIntent.sendBroadcast();
+        verify(mockChannel.invokeMethod<void>('sendBroadcast', <String, Object>{
+          'action': 'com.example.broadcast',
+        }));
+      });
+    });
   });
 
   group('convertFlags ', () {


### PR DESCRIPTION
## Description

Adds method to send Intent as broadcast, as suggested in https://github.com/flutter/flutter/issues/65533

To show this example, a broadcast register is created in the example project on the Android side. It will show a toast when the broadcast is received.

## Related Issues

- https://github.com/flutter/flutter/issues/65533
- https://github.com/fluttercommunity/plus_plugins/issues/75
