### PR TITLE
fix(device_info_plus): return Edge for browser name for both new edge and old one

### DIFF
--- a/packages/device_info_plus_platform_interface/lib/model/web_browser_info.dart
+++ b/packages/device_info_plus_platform_interface/lib/model/web_browser_info.dart
@@ -139,7 +139,7 @@ class WebBrowserInfo {
     } else if (userAgent.contains('Trident')) {
       return BrowserName.msie;
       // "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; Zoom 3.6.0; wbx 1.0.0; rv:11.0) like Gecko"
-    } else if (userAgent.contains('Edge') || userAgent.contains('Edg')) {
+    } else if (userAgent.contains('Edg')) {
       return BrowserName.edge;
       // https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-string
       // "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43"

--- a/packages/device_info_plus_platform_interface/lib/model/web_browser_info.dart
+++ b/packages/device_info_plus_platform_interface/lib/model/web_browser_info.dart
@@ -139,8 +139,10 @@ class WebBrowserInfo {
     } else if (userAgent.contains('Trident')) {
       return BrowserName.msie;
       // "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; Zoom 3.6.0; wbx 1.0.0; rv:11.0) like Gecko"
-    } else if (userAgent.contains('Edge')) {
+    } else if (userAgent.contains('Edge') || userAgent.contains('Edg')) {
       return BrowserName.edge;
+      // https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-string
+      // "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43"
       // "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Edge/16.16299"
     } else if (userAgent.contains('Chrome')) {
       return BrowserName.chrome;


### PR DESCRIPTION
## Description

Fix this issue https://github.com/fluttercommunity/plus_plugins/issues/94

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/94

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
