### PR TITLE
[package_info_plus_web] Fix double slash in version.json lookup

### DIFF
--- a/packages/package_info_plus_web/lib/package_info_plus_web.dart
+++ b/packages/package_info_plus_web/lib/package_info_plus_web.dart
@@ -18,7 +18,7 @@ class PackageInfoPlugin extends PackageInfoPlatform {
   @override
   Future<PackageInfoData> getAll() async {
     final url =
-        '${Uri.parse(window.document.baseUri).removeFragment()}/version.json';
+        '${Uri.parse(window.document.baseUri).removeFragment()}version.json';
 
     final response = await get(url);
     if (response.statusCode == 200) {


### PR DESCRIPTION
## Description

When accessing the version.json file the generated URL contains an extra forward-slash, that can prevent in some deployments access to the file

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/96

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
