### PR TITLE
[device_info_plus] sync repo sources with the v0.6.0 release

### DIFF
--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0
+
+- Rename method channel to avoid conflicts.
+
 ## 0.5.0
 
 - Transfer to plus-plugins monorepo

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 0.5.0
+version: 0.6.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -21,9 +21,9 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus_platform_interface: ^0.2.0
-  device_info_plus_linux: ^0.1.0
-  device_info_plus_web: ^0.2.0
+  device_info_plus_platform_interface: ^0.3.0
+  device_info_plus_linux: ^0.2.0
+  device_info_plus_web: ^0.3.0
 
 dev_dependencies:
   test: ^1.3.0


### PR DESCRIPTION
The device_info_plus v0.6.0 release commit went somehow missing. It was never pushed/merged to the repo. I've downloaded the sources from pub.dev and applied the minor changes.

Outdated platform plugin dependency versions in v0.5.0 (that the repo still had) were causing version conflicts:

```
   Because every version of device_info_plus from path depends on device_info_plus_platform_interface ^0.3.0 and device_info_plus_linux ^0.1.0 depends on device_info_plus_platform_interface ^0.2.0, device_info_plus from path is incompatible with device_info_plus_linux ^0.1.0.
   So, because device_info_example depends on device_info_plus from path which depends on device_info_plus_linux ^0.1.0, version solving failed.
```

These were sorted out in v0.6.0.