### PR TITLE
[package_info_plus] Added supported platforms to README.md

### DIFF
--- a/packages/package_info_plus/README.md
+++ b/packages/package_info_plus/README.md
@@ -34,6 +34,11 @@ PackageInfo.fromPlatform().then((PackageInfo packageInfo) {
 });
 ```
 
+## Supported platforms
+| Android | iOS | MacOS | Web | Linux | Window |
+|:-------:|:---:|:-----:|:---:|:-----:|:------:|
+|    ✔️    |  ✔️  |   ✔️   |  ✔️  |   ✔️   |   ✔️    |
+
 ## Known Issue
 
 As noted on [issue 20761](https://github.com/flutter/flutter/issues/20761#issuecomment-493434578), package_info on iOS 


### PR DESCRIPTION
## Description

When I read the `README.md` of `package_info_plus` it wasn't for me clear, which platforms are supported. You can see it maybe with the dependencies like `package_info_plus_linux`. However, it is very hidden. And in the description of the `pubspec.yaml`, which will be displayed at the right side, mentioning only Android & iOS which is confusing (My thoughts: Why not also mention Linux, Web, macOS and Windows? Or is there no support for this platforms)? 

## Demo
![image](https://user-images.githubusercontent.com/24459435/106867114-82940680-66cd-11eb-90cf-68a8dcc6e1e1.png)

## Related Issues
Part of #111

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.