### PR TITLE
[all] melos analyzer support null safety

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,9 +4,11 @@
 #
 # include: ../../analysis_options.yaml
 #
-include: package:pedantic/analysis_options.1.9.0.yaml
+include: package:pedantic/analysis_options.1.10.0-nullsafety.yaml
 
 analyzer:
+  enable-experiment:
+    - non-nullable
   exclude:
     # Ignore generated files
     - '**/*.g.dart'

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,7 +4,7 @@
 #
 # include: ../../analysis_options.yaml
 #
-include: package:pedantic/analysis_options.1.10.0-nullsafety.yaml
+include: package:pedantic/analysis_options.yaml
 
 analyzer:
   enable-experiment:

--- a/melos.yaml
+++ b/melos.yaml
@@ -85,8 +85,8 @@ scripts:
       rm -rf ./build ./android/.gradle ./ios/.symlinks ./ios/Pods ./android/.idea ./.idea ./.dart-tool/build
 
 dev_dependencies:
-  pedantic: 1.9.2
+  pedantic: 1.10.0-nullsafety
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/packages/android_intent_plus/example/analysis_options.yaml
+++ b/packages/android_intent_plus/example/analysis_options.yaml
@@ -1,0 +1,14 @@
+# TODO: Remove this when migrated to null safety
+include: package:pedantic/analysis_options.yaml
+
+analyzer:
+  exclude:
+    # Ignore generated files
+    - '**/*.g.dart'
+    - 'lib/src/generated/*.dart'
+
+linter:
+  rules:
+    public_member_api_docs: true
+    prefer_final_in_for_each: true
+    prefer_final_locals: true

--- a/packages/package_info_plus/example/analysis_options.yaml
+++ b/packages/package_info_plus/example/analysis_options.yaml
@@ -1,0 +1,14 @@
+# TODO: Remove this when migrated to null safety
+include: package:pedantic/analysis_options.yaml
+
+analyzer:
+  exclude:
+    # Ignore generated files
+    - '**/*.g.dart'
+    - 'lib/src/generated/*.dart'
+
+linter:
+  rules:
+    public_member_api_docs: true
+    prefer_final_in_for_each: true
+    prefer_final_locals: true


### PR DESCRIPTION
Small change to setup null safety in the analyzer used by melos.

Two exceptions need to be done for the example project in android_intent_plus and in package_info_plus