### PR TITLE
[share_plus] Use NSURL when sharing non-image files to make correct actions appear in share sheet

### DIFF
--- a/packages/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -207,7 +207,8 @@ static NSString *const PLATFORM_CHANNEL = @"dev.fluttercommunity.plus/share";
       UIImage *image = [UIImage imageWithContentsOfFile:path];
       [items addObject:image];
     } else {
-      [items addObject:[[SharePlusData alloc] initWithFile:path mimeType:mimeType]];
+      NSURL *fileUrl = [NSURL fileURLWithPath:path];
+      [items addObject:fileUrl];
     }
   }
 


### PR DESCRIPTION
## Description

When sharing a non-image file with the iOS share sheet (via the share plugin), the correct actions based on the file type are not appearing in the share sheet. 

For example, when sharing a PDF file, the share sheet currently looks like the screenshot on the left. Notice that compared with the screenshot on the right, the current share sheet does not include the `Markup` or `Print` actions.

| Current Behavior  | Fixed - Using `NSURL`  |
| ------------- | ------------- |
| <img src="https://user-images.githubusercontent.com/1865904/100383907-b8a27380-3016-11eb-979c-8f1243de657f.jpeg" width="375" />  | <img src="https://user-images.githubusercontent.com/1865904/100384122-4ed69980-3017-11eb-9d3e-5608ff81170c.jpeg" width="375" />  |

The fix consists of using a `NSURL` based on the supplied file path when initializing the `UIActivityViewController`.

I've tested the fix with several file types including pdf, mp4, and docx; additional relevant share sheet actions are now being shown for each file type.

I'm sure there's some cleanup required if my fix is accepted, but as my Objective-C chops leave a lot to be desired, I'll be looking to the package maintainer(s) for guidance here.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.