### PR TITLE
[share_plus_macos] bump Flutter SDK version constraint

### DIFF
--- a/packages/share_plus_macos/pubspec.yaml
+++ b/packages/share_plus_macos/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   share_plus_platform_interface: ^2.0.0-nullsafety


### PR DESCRIPTION
To fix:

    Uploading...
    pubspec.yaml allows Flutter SDK version prior to 1.20.0, which does not support having no `ios/` folder.
    Please consider increasing the Flutter SDK requirement to ^1.20.0 or higher (environment.sdk.flutter) or create an `ios/` folder.
