### PR TITLE
[device_info_plus_macos] bump up Flutter version constraint

### DIFF
--- a/packages/device_info_plus_macos/pubspec.yaml
+++ b/packages/device_info_plus_macos/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.1.0
 
 environment:
   sdk: '>=2.6.0 <3.0.0'
-  flutter: '>=1.12.13+hotfix.4'
+  flutter: ">=1.20.0"
 
 dependencies:
   device_info_plus_platform_interface: ^0.3.0


### PR DESCRIPTION
Required because of the missing `ios/` directory.