### PR TITLE
[device_info_plus] fix macos support

### DIFF
--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.1
+
+- Fix macOS support.
+
 ## 0.7.0
 
 - Add macOS support via `device_info_plus_macos`.

--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.7.2
+
+- Update dependencies.
+
 ## 0.7.1
 
 - Fix macOS support.

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 0.7.1
+version: 0.7.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -24,9 +24,9 @@ dependencies:
   flutter:
     sdk: flutter
   device_info_plus_platform_interface: ^0.4.0
-  device_info_plus_linux: ^0.2.0
-  device_info_plus_macos: ^0.1.0
-  device_info_plus_web: ^0.3.0
+  device_info_plus_linux: ^0.2.1
+  device_info_plus_macos: ^0.1.1
+  device_info_plus_web: ^0.3.1
 
 dev_dependencies:
   test: ^1.3.0

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 0.7.0
+version: 0.7.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -23,7 +23,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus_platform_interface: ^0.3.0
+  device_info_plus_platform_interface: ^0.4.0
   device_info_plus_linux: ^0.2.0
   device_info_plus_macos: ^0.1.0
   device_info_plus_web: ^0.3.0

--- a/packages/device_info_plus_linux/CHANGELOG.md
+++ b/packages/device_info_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- Update dependencies.
+
 ## 0.2.0
 
 - Rename method channel to avoid conflicts.

--- a/packages/device_info_plus_linux/pubspec.yaml
+++ b/packages/device_info_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_linux
 description: Linux implementation of the device_info_plus plugin
-version: 0.2.0
+version: 0.2.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^0.3.0
+  device_info_plus_platform_interface: ^0.4.0
   file: '>=5.2.1 <=6.0.0'
   flutter:
     sdk: flutter

--- a/packages/device_info_plus_macos/CHANGELOG.md
+++ b/packages/device_info_plus_macos/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+- Update dependencies.
+
+
 ## 0.1.0
 
 - Initial release.

--- a/packages/device_info_plus_macos/pubspec.yaml
+++ b/packages/device_info_plus_macos/pubspec.yaml
@@ -2,14 +2,14 @@ name: device_info_plus_macos
 description: Macos implementation of the device_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: '>=2.6.0 <3.0.0'
   flutter: ">=1.20.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^0.3.0
+  device_info_plus_platform_interface: ^0.4.0
   flutter:
     sdk: flutter
 

--- a/packages/device_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+- Add macOS support.
+
 ## 0.3.0
 
 - Rename method channel to avoid conflicts.

--- a/packages/device_info_plus_platform_interface/lib/device_info_plus_platform_interface.dart
+++ b/packages/device_info_plus_platform_interface/lib/device_info_plus_platform_interface.dart
@@ -12,11 +12,13 @@ import 'method_channel/method_channel_device_info.dart';
 import 'model/android_device_info.dart';
 import 'model/ios_device_info.dart';
 import 'model/linux_device_info.dart';
+import 'model/macos_device_info.dart';
 import 'model/web_browser_info.dart';
 
 export 'model/android_device_info.dart';
 export 'model/ios_device_info.dart';
 export 'model/linux_device_info.dart';
+export 'model/macos_device_info.dart';
 export 'model/web_browser_info.dart';
 export 'model/macos_device_info.dart';
 

--- a/packages/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_platform_interface
 description: A common platform interface for the device_info_plis plugin.
-version: 0.3.0
+version: 0.4.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/device_info_plus_web/CHANGELOG.md
+++ b/packages/device_info_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Update dependencies.
+
 ## 0.3.0
 
 - Rename method channel to avoid conflicts.

--- a/packages/device_info_plus_web/pubspec.yaml
+++ b/packages/device_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_web
 description: An implementation for the web platform of the Flutter `device_info_plus` plugin.
-version: 0.3.0
+version: 0.3.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -12,7 +12,7 @@ flutter:
         fileName: device_info_plus_web.dart
 
 dependencies:
-  device_info_plus_platform_interface: ^0.3.0
+  device_info_plus_platform_interface: ^0.4.0
   flutter_web_plugins:
     sdk: flutter
   flutter:


### PR DESCRIPTION
MacOsDeviceInfo export was missing in the platform interface.