### PR TITLE
[battery_plus_android] send initial battery status

### DIFF
--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1
+
+- Send initial battery status for Android
+
 ## 0.9.0
 
 - Add Linux support (`battery_plus_linux`)

--- a/packages/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
+++ b/packages/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
@@ -79,6 +79,9 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
     chargingStateChangeReceiver = createChargingStateChangeReceiver(events);
     applicationContext.registerReceiver(
         chargingStateChangeReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+
+    int status = getBatteryProperty(BatteryManager.BATTERY_PROPERTY_STATUS);
+    publishBatteryStatus(events, status);
   }
 
   @Override
@@ -90,9 +93,7 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
   private int getBatteryLevel() {
     int batteryLevel = -1;
     if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
-      BatteryManager batteryManager =
-          (BatteryManager) applicationContext.getSystemService(applicationContext.BATTERY_SERVICE);
-      batteryLevel = batteryManager.getIntProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
+      batteryLevel = getBatteryProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
     } else {
       Intent intent =
           new ContextWrapper(applicationContext)
@@ -105,26 +106,35 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
     return batteryLevel;
   }
 
+  private int getBatteryProperty(int property) {
+    BatteryManager batteryManager =
+        (BatteryManager) applicationContext.getSystemService(applicationContext.BATTERY_SERVICE);
+    return batteryManager.getIntProperty(property);
+  }
+
+  private static void publishBatteryStatus(final EventSink events, int status) {
+    switch (status) {
+      case BatteryManager.BATTERY_STATUS_CHARGING:
+        events.success("charging");
+        break;
+      case BatteryManager.BATTERY_STATUS_FULL:
+        events.success("full");
+        break;
+      case BatteryManager.BATTERY_STATUS_DISCHARGING:
+        events.success("discharging");
+        break;
+      default:
+        events.error("UNAVAILABLE", "Charging status unavailable", null);
+        break;
+    }
+  }
+
   private BroadcastReceiver createChargingStateChangeReceiver(final EventSink events) {
     return new BroadcastReceiver() {
       @Override
       public void onReceive(Context context, Intent intent) {
         int status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
-
-        switch (status) {
-          case BatteryManager.BATTERY_STATUS_CHARGING:
-            events.success("charging");
-            break;
-          case BatteryManager.BATTERY_STATUS_FULL:
-            events.success("full");
-            break;
-          case BatteryManager.BATTERY_STATUS_DISCHARGING:
-            events.success("discharging");
-            break;
-          default:
-            events.error("UNAVAILABLE", "Charging status unavailable", null);
-            break;
-        }
+        publishBatteryStatus(events, status);
       }
     };
   }

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 0.9.0
+version: 0.9.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
Desktop & web already send the current battery status when the stream is opened. Given that there is no battery status getter in the API, this seems a reasonable approach to avoid "null" battery status on startup.