### PR TITLE
[battery_plus] add "unknown" status (#61)

### DIFF
--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.0
+
+- Added "unknown" battery state for batteryless systems.
+
 ## 0.9.1
 
 - Send initial battery status for Android

--- a/packages/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
+++ b/packages/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
@@ -121,8 +121,11 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
         events.success("full");
         break;
       case BatteryManager.BATTERY_STATUS_DISCHARGING:
+      case BatteryManager.BATTERY_STATUS_NOT_CHARGING:
         events.success("discharging");
         break;
+      case BatteryManager.BATTERY_STATUS_UNKNOWN:
+        events.success("unknown");
       default:
         events.error("UNAVAILABLE", "Charging status unavailable", null);
         break;

--- a/packages/battery_plus/ios/Classes/FLTBatteryPlusPlugin.m
+++ b/packages/battery_plus/ios/Classes/FLTBatteryPlusPlugin.m
@@ -48,6 +48,8 @@
   if (!_eventSink) return;
   UIDeviceBatteryState state = [[UIDevice currentDevice] batteryState];
   switch (state) {
+    case UIDeviceBatteryStateUnknown:
+      _eventSink(@"unknown");
     case UIDeviceBatteryStateFull:
       _eventSink(@"full");
     case UIDeviceBatteryStateCharging:

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 0.9.1
+version: 0.10.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -25,11 +25,11 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  battery_plus_platform_interface: ^0.2.0
-  battery_plus_linux: ^0.1.0
-  battery_plus_macos: ^0.1.0
-  battery_plus_web: ^0.2.0
-  battery_plus_windows: ^0.1.0
+  battery_plus_platform_interface: ^0.3.0
+  battery_plus_linux: ^0.2.0
+  battery_plus_macos: ^0.2.0
+  battery_plus_web: ^0.3.0
+  battery_plus_windows: ^0.2.0
 
 dev_dependencies:
   async: ^2.0.8

--- a/packages/battery_plus_linux/CHANGELOG.md
+++ b/packages/battery_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Added "unknown" battery state for batteryless systems.
+
 ## 0.1.0
 
 - Initial Linux support.

--- a/packages/battery_plus_linux/lib/src/battery_plus_linux_real.dart
+++ b/packages/battery_plus_linux/lib/src/battery_plus_linux_real.dart
@@ -5,8 +5,6 @@ import 'package:meta/meta.dart';
 
 import 'upower_device.dart';
 
-// ### TODO: introduce an 'unknown' battery state for workstations?
-// https://github.com/fluttercommunity/plus_plugins/issues/61
 extension _ToBatteryState on UPowerBatteryState {
   BatteryState toBatteryState() {
     switch (this) {
@@ -14,8 +12,10 @@ extension _ToBatteryState on UPowerBatteryState {
         return BatteryState.charging;
       case UPowerBatteryState.discharging:
         return BatteryState.discharging;
-      default:
+      case UPowerBatteryState.fullyCharged:
         return BatteryState.full;
+      default:
+        return BatteryState.unknown;
     }
   }
 }

--- a/packages/battery_plus_linux/pubspec.yaml
+++ b/packages/battery_plus_linux/pubspec.yaml
@@ -2,14 +2,14 @@ name: battery_plus_linux
 description: Linux implementation of the battery_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.1.0
+version: 0.2.0
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
-  battery_plus_platform_interface: ^0.2.0
+  battery_plus_platform_interface: ^0.3.0
   dbus: ^0.1.0
   flutter:
     sdk: flutter

--- a/packages/battery_plus_macos/CHANGELOG.md
+++ b/packages/battery_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Added "unknown" battery state for batteryless systems.
+
 ## 0.1.0
 
 * Initial macOS release.

--- a/packages/battery_plus_macos/macos/Classes/BatteryPlusChargingHandler.swift
+++ b/packages/battery_plus_macos/macos/Classes/BatteryPlusChargingHandler.swift
@@ -74,10 +74,12 @@ class BatteryPlusChargingHandler: NSObject, FlutterStreamHandler {
         
         // Returns nil when battery is discharging
         if let isCharging = (description[kIOPSPowerSourceStateKey] as? String) {
-            if isCharging == kIOPSACPowerValue{
+            if isCharging == kIOPSACPowerValue {
                 return "charging"
-            }else {
+            } else if isCharging == kIOPSBatteryPowerValue {
                 return "discharging"
+            } else {
+                return "unknown"
             }
         }
         return "UNAVAILABLE"

--- a/packages/battery_plus_macos/pubspec.yaml
+++ b/packages/battery_plus_macos/pubspec.yaml
@@ -2,14 +2,14 @@ name: battery_plus_macos
 description: An implementation for the macos platform of the Flutter `battery_plus` plugin.
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.1.0
+version: 0.2.0
 
 environment:
   sdk: '>=2.6.0 <3.0.0'
   flutter: '>=1.20.0'
 
 dependencies:
-  battery_plus_platform_interface: ^0.2.0
+  battery_plus_platform_interface: ^0.3.0
   flutter:
     sdk: flutter
 

--- a/packages/battery_plus_platform_interface/CHANGELOG.md
+++ b/packages/battery_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.3.0
+
+- Added "unknown" battery state for batteryless systems.
+
+
 ## 0.2.0
 
 - Rename method channel to avoid conflicts

--- a/packages/battery_plus_platform_interface/lib/src/enums.dart
+++ b/packages/battery_plus_platform_interface/lib/src/enums.dart
@@ -7,5 +7,8 @@ enum BatteryState {
   charging,
 
   /// The battery is currently losing energy.
-  discharging
+  discharging,
+
+  /// The state of the battery is unknown.
+  unknown
 }

--- a/packages/battery_plus_platform_interface/lib/src/utils.dart
+++ b/packages/battery_plus_platform_interface/lib/src/utils.dart
@@ -9,6 +9,8 @@ BatteryState parseBatteryState(String state) {
       return BatteryState.charging;
     case 'discharging':
       return BatteryState.discharging;
+    case 'unknown':
+      return BatteryState.unknown;
     default:
       throw ArgumentError('$state is not a valid BatteryState.');
   }

--- a/packages/battery_plus_platform_interface/pubspec.yaml
+++ b/packages/battery_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_platform_interface
 description: A common platform interface for the battery_plus plugin.
-version: 0.2.0
+version: 0.3.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/battery_plus_web/CHANGELOG.md
+++ b/packages/battery_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0
+
+- Added "unknown" battery state for batteryless systems.
+
 ## 0.2.0
 
 - Rename method channel to avoid conflicts

--- a/packages/battery_plus_web/pubspec.yaml
+++ b/packages/battery_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_web
 description: An implementation for the web platform of the Flutter `battery_plus` plugin.
-version: 0.2.0
+version: 0.3.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -12,7 +12,7 @@ flutter:
         fileName: battery_plus_web.dart
 
 dependencies:
-  battery_plus_platform_interface: ^0.2.0
+  battery_plus_platform_interface: ^0.3.0
   flutter_web_plugins:
     sdk: flutter
   flutter:

--- a/packages/battery_plus_windows/CHANGELOG.md
+++ b/packages/battery_plus_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Added "unknown" battery state for batteryless systems.
+
 ## 0.1.0
 
 - Initial Windows support.

--- a/packages/battery_plus_windows/pubspec.yaml
+++ b/packages/battery_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_windows
 description: Windows implementation of the battery_plus plugin
-version: 0.1.0
+version: 0.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  battery_plus_platform_interface: ^0.2.0
+  battery_plus_platform_interface: ^0.3.0
   flutter:
     sdk: flutter
 

--- a/packages/battery_plus_windows/windows/system_battery.cpp
+++ b/packages/battery_plus_windows/windows/system_battery.cpp
@@ -74,9 +74,10 @@ std::string SystemBattery::GetStatusString() const {
     case BatteryStatus::Discharging:
       return "discharging";
     case BatteryStatus::Full:
+      return "full";
     case BatteryStatus::Unknown:
     default:
-      return "full"; // ### TODO: unknown
+      return "unknown";
   }
 }
 


### PR DESCRIPTION
Added "unknown" battery state for batteryless systems (e.g. workstations).

Closes: #61