### PR TITLE
[battery_plus] address pub.dev score (#16) 

### DIFF
--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.10.1
+
+- Address pub score
+
 ## 0.10.0
 
 - Added "unknown" battery state for batteryless systems.

--- a/packages/battery_plus/lib/battery_plus.dart
+++ b/packages/battery_plus/lib/battery_plus.dart
@@ -7,7 +7,7 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:battery_plus_platform_interface/battery_plus_platform_interface.dart';
-import 'package:battery_plus_platform_interface/src/method_channel_battery_plus.dart';
+import 'package:battery_plus_platform_interface/method_channel_battery_plus.dart';
 import 'package:battery_plus_linux/battery_plus_linux.dart';
 
 // Export enums from the platform_interface so plugin users can use them directly.

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 0.10.0
+version: 0.10.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -25,11 +25,11 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  battery_plus_platform_interface: ^0.3.0
-  battery_plus_linux: ^0.2.0
-  battery_plus_macos: ^0.2.0
-  battery_plus_web: ^0.3.0
-  battery_plus_windows: ^0.2.0
+  battery_plus_platform_interface: ^0.3.1
+  battery_plus_linux: ^0.2.1
+  battery_plus_macos: ^0.2.1
+  battery_plus_web: ^0.3.1
+  battery_plus_windows: ^0.2.1
 
 dev_dependencies:
   async: ^2.0.8

--- a/packages/battery_plus_linux/CHANGELOG.md
+++ b/packages/battery_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- Address pub score
+
 ## 0.2.0
 
 - Added "unknown" battery state for batteryless systems.

--- a/packages/battery_plus_linux/pubspec.yaml
+++ b/packages/battery_plus_linux/pubspec.yaml
@@ -2,14 +2,14 @@ name: battery_plus_linux
 description: Linux implementation of the battery_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.2.0
+version: 0.2.1
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
-  battery_plus_platform_interface: ^0.3.0
+  battery_plus_platform_interface: ^0.3.1
   dbus: ^0.1.0
   flutter:
     sdk: flutter

--- a/packages/battery_plus_macos/CHANGELOG.md
+++ b/packages/battery_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- Address pub score
+
 ## 0.2.0
 
 - Added "unknown" battery state for batteryless systems.

--- a/packages/battery_plus_macos/pubspec.yaml
+++ b/packages/battery_plus_macos/pubspec.yaml
@@ -2,14 +2,14 @@ name: battery_plus_macos
 description: An implementation for the macos platform of the Flutter `battery_plus` plugin.
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.2.0
+version: 0.2.1
 
 environment:
   sdk: '>=2.6.0 <3.0.0'
   flutter: '>=1.20.0'
 
 dependencies:
-  battery_plus_platform_interface: ^0.3.0
+  battery_plus_platform_interface: ^0.3.1
   flutter:
     sdk: flutter
 

--- a/packages/battery_plus_platform_interface/CHANGELOG.md
+++ b/packages/battery_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Address pub score
+
 ## 0.3.0
 
 - Added "unknown" battery state for batteryless systems.

--- a/packages/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
+++ b/packages/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import 'method_channel_battery_plus.dart';
 import 'src/enums.dart';
-import 'src/method_channel_battery_plus.dart';
 export 'src/enums.dart';
 
 /// The interface that implementations of Battery must implement.

--- a/packages/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
+++ b/packages/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
@@ -7,9 +7,9 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 
-import '../battery_plus_platform_interface.dart';
-import 'enums.dart';
-import 'utils.dart';
+import 'battery_plus_platform_interface.dart';
+import 'src/enums.dart';
+import 'src/utils.dart';
 
 /// An implementation of [BatteryPlatform] that uses method channels.
 class MethodChannelBattery extends BatteryPlatform {

--- a/packages/battery_plus_platform_interface/pubspec.yaml
+++ b/packages/battery_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_platform_interface
 description: A common platform interface for the battery_plus plugin.
-version: 0.3.0
+version: 0.3.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/battery_plus_platform_interface/test/battery_plus_platform_interface_test.dart
+++ b/packages/battery_plus_platform_interface/test/battery_plus_platform_interface_test.dart
@@ -1,5 +1,5 @@
 import 'package:battery_plus_platform_interface/src/enums.dart';
-import 'package:battery_plus_platform_interface/src/method_channel_battery_plus.dart';
+import 'package:battery_plus_platform_interface/method_channel_battery_plus.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/battery_plus_web/CHANGELOG.md
+++ b/packages/battery_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Address pub score
+
 ## 0.3.0
 
 - Added "unknown" battery state for batteryless systems.

--- a/packages/battery_plus_web/pubspec.yaml
+++ b/packages/battery_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_web
 description: An implementation for the web platform of the Flutter `battery_plus` plugin.
-version: 0.3.0
+version: 0.3.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -12,7 +12,7 @@ flutter:
         fileName: battery_plus_web.dart
 
 dependencies:
-  battery_plus_platform_interface: ^0.3.0
+  battery_plus_platform_interface: ^0.3.1
   flutter_web_plugins:
     sdk: flutter
   flutter:

--- a/packages/battery_plus_windows/CHANGELOG.md
+++ b/packages/battery_plus_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1
+
+- Address pub score
+
 ## 0.2.0
 
 - Added "unknown" battery state for batteryless systems.

--- a/packages/battery_plus_windows/pubspec.yaml
+++ b/packages/battery_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_windows
 description: Windows implementation of the battery_plus plugin
-version: 0.2.0
+version: 0.2.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  battery_plus_platform_interface: ^0.3.0
+  battery_plus_platform_interface: ^0.3.1
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Importing `platform_interface/src/foo.dart` in the main package loses 10 pub score points:

    Pass static analysis

    20/30 points: code has no errors, warnings, lints, or formatting issues

    INFO: Don't import implementation files from another package.
