### PR TITLE
[connectivity_plus] address pub score (#16)

### DIFF
--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.8.1
+
+- Address pub score
+
 ## 0.8.0
 
 - Add Windows support (`connectivity_plus_windows`).

--- a/packages/connectivity_plus/lib/connectivity_plus.dart
+++ b/packages/connectivity_plus/lib/connectivity_plus.dart
@@ -7,7 +7,7 @@ import 'dart:io' show Platform;
 
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
-import 'package:connectivity_plus_platform_interface/src/method_channel_connectivity.dart';
+import 'package:connectivity_plus_platform_interface/method_channel_connectivity.dart';
 import 'package:connectivity_plus_linux/connectivity_plus_linux.dart';
 
 // Export enums from the platform_interface so plugin users can use them directly.

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 0.8.0
+version: 0.8.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -25,11 +25,11 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  connectivity_plus_platform_interface: ^0.4.0
-  connectivity_plus_linux: ^0.3.0
-  connectivity_plus_macos: ^0.4.0
-  connectivity_plus_web: ^0.6.0
-  connectivity_plus_windows: ^0.1.0
+  connectivity_plus_platform_interface: ^0.4.1
+  connectivity_plus_linux: ^0.3.1
+  connectivity_plus_macos: ^0.4.1
+  connectivity_plus_web: ^0.6.1
+  connectivity_plus_windows: ^0.1.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/connectivity_plus_linux/CHANGELOG.md
+++ b/packages/connectivity_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+- Address pub score
+
 ## 0.3.0
 
 - Removed members that were moved to network_info_plus

--- a/packages/connectivity_plus_linux/pubspec.yaml
+++ b/packages/connectivity_plus_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_plus_linux
 description: Linux implementation of the connectivity_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.3.0
+version: 0.3.1
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  connectivity_plus_platform_interface: ^0.4.0
+  connectivity_plus_platform_interface: ^0.4.1
   dbus: ^0.1.0
   meta: ^1.2.3
 

--- a/packages/connectivity_plus_macos/CHANGELOG.md
+++ b/packages/connectivity_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+- Address pub score
+
 ## 0.4.0
 
 - Removed members that were moved to network_info_plus

--- a/packages/connectivity_plus_macos/pubspec.yaml
+++ b/packages/connectivity_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_macos
 description: macOS implementation of the connectivity_plus plugin.
-version: 0.4.0
+version: 0.4.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -15,6 +15,6 @@ environment:
   flutter: '>=1.20.0'
 
 dependencies:
-  connectivity_plus_platform_interface: ^0.4.0
+  connectivity_plus_platform_interface: ^0.4.1
   flutter:
     sdk: flutter

--- a/packages/connectivity_plus_platform_interface/CHANGELOG.md
+++ b/packages/connectivity_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+- Address pub score
+
 ## 0.4.0
 
 - Removed members that were moved to network_info_plus

--- a/packages/connectivity_plus_platform_interface/lib/connectivity_plus_platform_interface.dart
+++ b/packages/connectivity_plus_platform_interface/lib/connectivity_plus_platform_interface.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import 'method_channel_connectivity.dart';
 import 'src/enums.dart';
-import 'src/method_channel_connectivity.dart';
 
 export 'src/enums.dart';
 

--- a/packages/connectivity_plus_platform_interface/lib/method_channel_connectivity.dart
+++ b/packages/connectivity_plus_platform_interface/lib/method_channel_connectivity.dart
@@ -8,7 +8,7 @@ import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 
-import 'utils.dart';
+import 'src/utils.dart';
 
 /// An implementation of [ConnectivityPlatform] that uses method channels.
 class MethodChannelConnectivity extends ConnectivityPlatform {

--- a/packages/connectivity_plus_platform_interface/pubspec.yaml
+++ b/packages/connectivity_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_platform_interface
 description: A common platform interface for the connectivity_plus plugin.
-version: 0.4.0
+version: 0.4.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/connectivity_plus_platform_interface/test/method_channel_connectivity_test.dart
+++ b/packages/connectivity_plus_platform_interface/test/method_channel_connectivity_test.dart
@@ -5,7 +5,7 @@
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:connectivity_plus_platform_interface/src/method_channel_connectivity.dart';
+import 'package:connectivity_plus_platform_interface/method_channel_connectivity.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/connectivity_plus_web/CHANGELOG.md
+++ b/packages/connectivity_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.1
+
+- Address pub score
+
 ## 0.6.0
 
 - Removed members that were moved to network_info_plus

--- a/packages/connectivity_plus_web/pubspec.yaml
+++ b/packages/connectivity_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_web
 description: An implementation for the web platform of the Flutter `connectivity_plus` plugin. This uses the NetworkInformation Web API, with a fallback to Navigator.onLine.
-version: 0.6.0
+version: 0.6.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -12,7 +12,7 @@ flutter:
         fileName: connectivity_plus_web.dart
 
 dependencies:
-  connectivity_plus_platform_interface: ^0.4.0
+  connectivity_plus_platform_interface: ^0.4.1
   flutter_web_plugins:
     sdk: flutter
   flutter:

--- a/packages/connectivity_plus_windows/CHANGELOG.md
+++ b/packages/connectivity_plus_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Address pub score
+
 ## 0.1.0
 
 * Initial release for Windows.

--- a/packages/connectivity_plus_windows/pubspec.yaml
+++ b/packages/connectivity_plus_windows/pubspec.yaml
@@ -2,14 +2,14 @@ name: connectivity_plus_windows
 description: Windows implementation of the connectivity_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
-  connectivity_plus_platform_interface: ^0.4.0
+  connectivity_plus_platform_interface: ^0.4.1
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
Importing `platform_interface/src/foo.dart` in the main package loses 10 pub score points:

    Pass static analysis

    20/30 points: code has no errors, warnings, lints, or formatting issues

    INFO: Don't import implementation files from another package.
