### PR TITLE
[website] minor tweaks to make it more mobile friendly

### DIFF
--- a/website/plugins.js
+++ b/website/plugins.js
@@ -99,7 +99,7 @@ module.exports = [
     },
   },
   {
-    name: 'Sensor ➕',
+    name: 'Sensors ➕',
     pub: 'sensors_plus',
     support: {
       web: true,

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -92,7 +92,7 @@ function Home() {
           <h2>{siteConfig.tagline}</h2>
           <div className={styles.actions}>
             {/* <Link to={`${siteConfig.baseUrl}docs/overview`}>Get Started &raquo;</Link> */}
-            <Link to="https://github.com/fluttercommunity">GitHub &raquo;</Link>
+            <Link to="https://github.com/fluttercommunity/plus_plugins">GitHub &raquo;</Link>
           </div>
         </div>
       </section>
@@ -104,7 +104,6 @@ function Home() {
                 <th align="left">Plugin</th>
                 <th>Pub</th>
                 <th>Docs</th>
-                <th>View Source</th>
                 <th>Android</th>
                 <th>iOS</th>
                 <th>Web</th>
@@ -130,13 +129,6 @@ function Home() {
                   <td>
                     <a href={`https://pub.dev/documentation/${plugin.pub}/latest/`}>
                       <Docs />
-                    </a>
-                  </td>
-                  <td>
-                    <a
-                      href={`https://github.com/fluttercommunity/plus_plugins/tree/main/packages/${plugin.pub}`}
-                    >
-                      <GithubIcon />
                     </a>
                   </td>
                   <td className="icon">

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -102,7 +102,6 @@ function Home() {
             <thead>
               <tr>
                 <th align="left">Plugin</th>
-                <th>Version</th>
                 <th>Pub</th>
                 <th>Docs</th>
                 <th>View Source</th>
@@ -121,14 +120,11 @@ function Home() {
                     <strong>{plugin.name}</strong>
                   </td>
                   <td style={{ minWidth: 150 }}>
-                    <img
-                      src={`https://img.shields.io/pub/v/${plugin.pub}.svg`}
-                      alt={`${plugin.name} Badge`}
-                    />
-                  </td>
-                  <td>
                     <a href={`https://pub.dev/packages/${plugin.pub}`}>
-                      <img width={25} src={useBaseUrl('img/dart-logo.png')} alt="Pub" />
+                      <img
+                        src={`https://img.shields.io/pub/v/${plugin.pub}.svg`}
+                        alt={`${plugin.name} Badge`}
+                      />
                     </a>
                   </td>
                   <td>


### PR DESCRIPTION
Make the table a bit narrower to make it fit mobile screens better. These tweaks make all columns almost fully visible in landscape mode on Pixel 5. In portrait mode, it's not possible to scroll all the way to the left to see the package name, but I have no idea how to fix that. :)