### PR TITLE
[network_info_plus] address pub score (#16)

### DIFF
--- a/packages/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+- Address pub score.
+
 ## 0.1.1+1
 
 - Provide longer package description to address pub score.

--- a/packages/network_info_plus/lib/network_info_plus.dart
+++ b/packages/network_info_plus/lib/network_info_plus.dart
@@ -8,7 +8,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/services.dart';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:network_info_plus_platform_interface/network_info_plus_platform_interface.dart';
-import 'package:network_info_plus_platform_interface/src/method_channel_network_info.dart';
+import 'package:network_info_plus_platform_interface/method_channel_network_info.dart';
 import 'package:network_info_plus_linux/network_info_plus_linux.dart';
 
 // Export enums from the platform_interface so plugin users can use them directly.

--- a/packages/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 0.1.1+1
+version: 0.1.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -25,11 +25,11 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  network_info_plus_platform_interface: ^0.1.0
-  network_info_plus_linux: ^0.1.0
-  network_info_plus_macos: ^0.1.0
-  network_info_plus_windows: ^0.1.0
-  network_info_plus_web: ^0.1.0
+  network_info_plus_platform_interface: ^0.1.1
+  network_info_plus_linux: ^0.1.1
+  network_info_plus_macos: ^0.1.1
+  network_info_plus_windows: ^0.1.1
+  network_info_plus_web: ^0.1.1
 
 dev_dependencies:
   flutter_test:

--- a/packages/network_info_plus_linux/CHANGELOG.md
+++ b/packages/network_info_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Address pub score.
+
 ## 0.1.0
 
 * Initial release for Linux.

--- a/packages/network_info_plus_linux/pubspec.yaml
+++ b/packages/network_info_plus_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: network_info_plus_linux
 description: Linux implementation of the network_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus_platform_interface: ^0.1.0
+  network_info_plus_platform_interface: ^0.1.1
   dbus: ^0.1.0
   meta: ^1.2.3
 

--- a/packages/network_info_plus_macos/CHANGELOG.md
+++ b/packages/network_info_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Address pub score.
+
 ## 0.1.0
 
 - Initial release.

--- a/packages/network_info_plus_macos/pubspec.yaml
+++ b/packages/network_info_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus_macos
 description: macOS implementation of the network_info_plus plugin.
-version: 0.1.0
+version: 0.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -15,6 +15,6 @@ environment:
   flutter: '>=1.20.0'
 
 dependencies:
-  network_info_plus_platform_interface: ^0.1.0
+  network_info_plus_platform_interface: ^0.1.1
   flutter:
     sdk: flutter

--- a/packages/network_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/network_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Address pub score.
+
 ## 0.1.0
 
 - Initial release.

--- a/packages/network_info_plus_platform_interface/lib/method_channel_network_info.dart
+++ b/packages/network_info_plus_platform_interface/lib/method_channel_network_info.dart
@@ -8,7 +8,7 @@ import 'package:network_info_plus_platform_interface/network_info_plus_platform_
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 
-import 'utils.dart';
+import 'src/utils.dart';
 
 /// An implementation of [NetworkInfoPlatform] that uses method channels.
 class MethodChannelNetworkInfo extends NetworkInfoPlatform {

--- a/packages/network_info_plus_platform_interface/lib/network_info_plus_platform_interface.dart
+++ b/packages/network_info_plus_platform_interface/lib/network_info_plus_platform_interface.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
+import 'method_channel_network_info.dart';
 import 'src/enums.dart';
-import 'src/method_channel_network_info.dart';
 
 export 'src/enums.dart';
 

--- a/packages/network_info_plus_platform_interface/pubspec.yaml
+++ b/packages/network_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus_platform_interface
 description: A common platform interface for the network_info_plus plugin.
-version: 0.1.0
+version: 0.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/network_info_plus_platform_interface/test/method_channel_network_info_test.dart
+++ b/packages/network_info_plus_platform_interface/test/method_channel_network_info_test.dart
@@ -5,7 +5,7 @@
 import 'package:network_info_plus_platform_interface/network_info_plus_platform_interface.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:network_info_plus_platform_interface/src/method_channel_network_info.dart';
+import 'package:network_info_plus_platform_interface/method_channel_network_info.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/network_info_plus_web/CHANGELOG.md
+++ b/packages/network_info_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Address pub score.
+
 ## 0.1.0
 
 - Added a stub implementation that throws unsupported exceptions.

--- a/packages/network_info_plus_web/pubspec.yaml
+++ b/packages/network_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus_web
 description: A stub implementation of the Network Info Plus plugin for Web.
-version: 0.1.0
+version: 0.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  network_info_plus_platform_interface: ^0.1.0
+  network_info_plus_platform_interface: ^0.1.1
 
 environment:
   sdk: ">=2.6.0 <3.0.0"

--- a/packages/network_info_plus_windows/CHANGELOG.md
+++ b/packages/network_info_plus_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Address pub score.
+
 ## 0.1.0
 
 * Initial release for Windows.

--- a/packages/network_info_plus_windows/pubspec.yaml
+++ b/packages/network_info_plus_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: network_info_plus_windows
 description: Windows implementation of the network_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.1.0
+version: 0.1.1
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus_platform_interface: ^0.1.0
+  network_info_plus_platform_interface: ^0.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Importing `platform_interface/src/foo.dart` in the main package loses 10 pub score points:

    Pass static analysis

    20/30 points: code has no errors, warnings, lints, or formatting issues

    INFO: Don't import implementation files from another package.
