### PR TITLE
[package_info_plus] Make PackageInfo testable with mock data

### DIFF
--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.4
+
+- Add support for mock data during tests
+
 ## 0.6.3
 
 - Fix base URI resolving for Web

--- a/packages/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/lib/package_info_plus.dart
@@ -5,7 +5,8 @@
 import 'dart:async';
 import 'dart:io' show Platform;
 
-import 'package:flutter/foundation.dart' show kIsWeb, visibleForTesting;
+import 'package:flutter/foundation.dart'
+    show kIsWeb, required, visibleForTesting;
 import 'package:package_info_plus_linux/package_info_plus_linux.dart';
 import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
 import 'package:package_info_plus_windows/package_info_plus_windows.dart';
@@ -84,4 +85,21 @@ class PackageInfo {
 
   /// The build number. `CFBundleVersion` on iOS, `versionCode` on Android.
   final String buildNumber;
+
+  /// Initializes the application metadata with mock values for testing.
+  ///
+  /// If the singleton instance has been initialized already, it is overwritten.
+  @visibleForTesting
+  static void setMockInitialValues({
+    @required String appName,
+    @required String packageName,
+    @required String version,
+    @required String buildNumber,
+  }) {
+    _fromPlatform = PackageInfo(
+        appName: appName,
+        packageName: packageName,
+        version: version,
+        buildNumber: buildNumber);
+  }
 }

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 0.6.3
+version: 0.6.4
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/package_info_plus/test/package_info_test.dart
+++ b/packages/package_info_plus/test/package_info_test.dart
@@ -46,4 +46,18 @@ void main() {
       ],
     );
   });
+
+  test('Mock initial values', () async {
+    PackageInfo.setMockInitialValues(
+      appName: 'mock_package_info_example',
+      packageName: 'io.flutter.plugins.mockpackageinfoexample',
+      version: '1.1',
+      buildNumber: '2',
+    );
+    final info = await PackageInfo.fromPlatform();
+    expect(info.appName, 'mock_package_info_example');
+    expect(info.buildNumber, '2');
+    expect(info.packageName, 'io.flutter.plugins.mockpackageinfoexample');
+    expect(info.version, '1.1');
+  });
 }


### PR DESCRIPTION
## Description

Added a similar method as already given in the shared_preference plugin (https://github.com/flutter/plugins/blob/master/packages/shared_preferences/shared_preferences/lib/shared_preferences.dart#L196), to allow the easy usage of the package_info_plus plugin during tests. The method allows the setup of mock data and also enables the developer to change the data during tests.

## Related Issues

Fixes https://github.com/fluttercommunity/plus_plugins/issues/145

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

