### PR TITLE
[device_info] fix platform_interface dependency for linux & windows

### DIFF
--- a/packages/device_info_plus_linux/pubspec.yaml
+++ b/packages/device_info_plus_linux/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^0.4.0
+  device_info_plus_platform_interface: ^1.0.0-nullsafety.0
   file: '>=5.2.1 <=6.0.0'
   flutter:
     sdk: flutter

--- a/packages/device_info_plus_windows/pubspec.yaml
+++ b/packages/device_info_plus_windows/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: '>=1.12.13+hotfix.4'
 
 dependencies:
-  device_info_plus_platform_interface: ^0.4.0
+  device_info_plus_platform_interface: ^1.0.0-nullsafety.0
   ffi: ^1.0.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
I forgot to publish the packages whilst bragging on Twitter. This came up while publishing `device_info_plus_linux` & `device_info_plus_windows`:
```
Package validation found the following potential issue:
* This package is opting into null-safety, but a dependency or file is not.
  
  package:device_info_plus_platform_interface is not opted into null safety in its pubspec.yaml:
  
  
  Note that by publishing with non-migrated dependencies your package may be
  broken at any time if one of your dependencies migrates without a breaking 
  change release. 
  
  We highly recommend that you wait until all of your dependencies have been 
  migrated before publishing.
  
  Run `pub outdated --mode=null-safety` for more information about the state of
  dependencies.
  
  See https://dart.dev/null-safety/migration-guide
  for more information about migrating.
```