### PR TITLE
fix README.md pub links

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ PlusPlugins is a set of [Flutter plugins](https://flutter.io/platform-plugins/) 
 
 ### `battery_plus`
 
-> ![battery_plus][battery_plus_badge_pub] [![pub points][battery_plus_badge_pub_points]][battery_plus_pub_points]
+> [![battery_plus][battery_plus_badge_pub]][battery_plus] [![pub points][battery_plus_badge_pub_points]][battery_plus_pub_points]
 
 Flutter plugin for accessing information about the battery state(full, charging, discharging) on Android and iOS.
 
@@ -57,7 +57,7 @@ Flutter plugin for accessing information about the battery state(full, charging,
 
 ### `connectivity_plus`
 
-> ![connectivity_plus][connectivity_plus_badge_pub] [![pub points][connectivity_plus_badge_pub_points]][connectivity_plus_pub_points]
+> [![connectivity_plus][connectivity_plus_badge_pub]][connectivity_plus] [![pub points][connectivity_plus_badge_pub_points]][connectivity_plus_pub_points]
 
 Flutter plugin for discovering the state of the network (WiFi &
 mobile/cellular) connectivity on Android and iOS.
@@ -74,7 +74,7 @@ mobile/cellular) connectivity on Android and iOS.
 
 ### `device_info_plus`
 
-> ![device_info_plus][device_info_plus_badge_pub] [![pub points][device_info_plus_badge_pub_points]][device_info_plus_pub_points]
+> [![device_info_plus][device_info_plus_badge_pub]][device_info_plus] [![pub points][device_info_plus_badge_pub_points]][device_info_plus_pub_points]
 
 Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
@@ -91,7 +91,7 @@ Flutter plugin providing detailed information about the device
 
 ### `network_info_plus`
 
-> ![network_info_plus][network_info_plus_badge_pub] [![pub points][network_info_plus_badge_pub_points]][network_info_plus_pub_points]
+> [![network_info_plus][network_info_plus_badge_pub]][network_info_plus] [![pub points][network_info_plus_badge_pub_points]][network_info_plus_pub_points]
 
 Flutter plugin for discovering network info.
 
@@ -107,7 +107,7 @@ Flutter plugin for discovering network info.
 
 ### `package_info_plus`
 
-> ![package_info_plus][package_info_plus_badge_pub] [![pub points][package_info_plus_badge_pub_points]][package_info_plus_pub_points]
+> [![package_info_plus][package_info_plus_badge_pub]][package_info_plus] [![pub points][package_info_plus_badge_pub_points]][package_info_plus_pub_points]
 
 Flutter plugin for querying information about the application
   package, such as CFBundleVersion on iOS or versionCode on Android.
@@ -124,7 +124,7 @@ Flutter plugin for querying information about the application
 
 ### `sensors_plus`
 
-> ![sensors_plus][sensors_plus_badge_pub] [![pub points][sensors_plus_badge_pub_points]][sensors_plus_pub_points]
+> [![sensors_plus][sensors_plus_badge_pub]][sensors_plus] [![pub points][sensors_plus_badge_pub_points]][sensors_plus_pub_points]
 
 Flutter plugin for accessing accelerometer and gyroscope sensors.
 
@@ -140,7 +140,7 @@ Flutter plugin for accessing accelerometer and gyroscope sensors.
 
 ### `share_plus`
 
-> ![share_plus][share_plus_badge_pub] [![pub points][share_plus_badge_pub_points]][share_plus_pub_points]
+> [![share_plus][share_plus_badge_pub]][share_plus] [![pub points][share_plus_badge_pub_points]][share_plus_pub_points]
 
 Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 
@@ -156,7 +156,7 @@ Flutter plugin for sharing content via the platform share UI, using the ACTION_S
 
 ### `android_alarm_manager_plus`
 
-> ![android_alarm_manager_plus][android_alarm_manager_plus_badge_pub] [![pub points][android_alarm_manager_plus_badge_pub_points]][android_alarm_manager_plus_pub_points]
+> [![android_alarm_manager_plus][android_alarm_manager_plus_badge_pub]][android_alarm_manager_plus] [![pub points][android_alarm_manager_plus_badge_pub_points]][android_alarm_manager_plus_pub_points]
 
 Flutter plugin for accessing the Android AlarmManager service, and running Dart code in the background when alarms fire.
 
@@ -164,15 +164,15 @@ Flutter plugin for accessing the Android AlarmManager service, and running Dart 
 
 #### Platform Support
 
-| Android | 
+| Android |
 |:-------:|
-|    ✔️    | 
+|    ✔️    |
 
 ----
 
 ### `android_intent_plus`
 
-> ![android_intent_plus][android_intent_plus_badge_pub] [![pub points][android_intent_plus_badge_pub_points]][android_intent_plus_pub_points]
+> [![android_intent_plus][android_intent_plus_badge_pub]][android_intent_plus] [![pub points][android_intent_plus_badge_pub_points]][android_intent_plus_pub_points]
 
 Flutter plugin for launching Android Intents. Not supported on iOS.
 


### PR DESCRIPTION
## Description

If that is not intended then this PR fixes pub.dev version badges links. 

![image](https://user-images.githubusercontent.com/67197047/108201620-6017d980-7120-11eb-9f44-42f79935dfed.png)

When you click on them it displays the image in the new tab but [usually on other packages](https://github.com/flutter/packages) it opens pub.dev link.




## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
