### PR TITLE
contrib: flutter_plugin_tools not needed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,6 @@ _See also: [Flutter's code of conduct](https://flutter.io/design-principles/#cod
 - [git](https://git-scm.com) (used for source version control).
 - An ssh client (used to authenticate with GitHub).
 - An IDE such as [Android Studio](https://developer.android.com/studio) or [Visual Studio Code](https://code.visualstudio.com/).
-- [`flutter_plugin_tools`](https://pub.dev/packages/flutter_plugin_tools) locally activated.
 - [`tuneup`](https://pub.dev/packages/tuneup) locally activated.
 
 ## 2. Forking & cloning the repository


### PR DESCRIPTION
## Description

"refactoring" the contributing guideline.
`flutter_plugin_tools` [was discontinued](https://pub.dev/packages/flutter_plugin_tools) and it's not needed to contribute to this repository.

Glad to amend this PR further if more items are outdated, so review appreciated.
