### PR TITLE
[device_info_plus_linux] upgrade `file` dependency

### DIFF
--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-nullsafety.1
+
+- Update dependencies.
+
 ## 1.0.0-nullsafety.0
 
 - Migrated to null safety

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 1.0.0-nullsafety.0
+version: 1.0.0-nullsafety.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -25,11 +25,11 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus_platform_interface: ^1.0.0-nullsafety.0
-  device_info_plus_linux: ^1.0.0-nullsafety.0
-  device_info_plus_macos: ^1.0.0-nullsafety.0
-  device_info_plus_web: ^1.0.0-nullsafety.0
-  device_info_plus_windows: ^1.0.0-nullsafety.0
+  device_info_plus_platform_interface: ^1.0.0-nullsafety
+  device_info_plus_linux: ^1.0.0-nullsafety
+  device_info_plus_macos: ^1.0.0-nullsafety
+  device_info_plus_web: ^1.0.0-nullsafety
+  device_info_plus_windows: ^1.0.0-nullsafety
 
 dev_dependencies:
   test: ^1.3.0

--- a/packages/device_info_plus_linux/CHANGELOG.md
+++ b/packages/device_info_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0-nullsafety.1
+
+- Update dependencies.
+
 ## 1.0.0-nullsafety.0
 
 - Migrated to null safety

--- a/packages/device_info_plus_linux/pubspec.yaml
+++ b/packages/device_info_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_linux
 description: Linux implementation of the device_info_plus plugin
-version: 1.0.0-nullsafety.0
+version: 1.0.0-nullsafety.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   device_info_plus_platform_interface: ^1.0.0-nullsafety.0
-  file: '>=5.2.1 <=6.0.0'
+  file: ^6.0.0
   flutter:
     sdk: flutter
   meta: ^1.2.3


### PR DESCRIPTION
The latest `flutter_driver` in master depends on `file` 6.1.0.