### PR TITLE
Migrate CMake files

### DIFF
--- a/packages/battery_plus/example/linux/flutter/CMakeLists.txt
+++ b/packages/battery_plus/example/linux/flutter/CMakeLists.txt
@@ -80,7 +80,8 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
-      linux-x64 ${CMAKE_BUILD_TYPE}
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/packages/battery_plus/example/windows/flutter/CMakeLists.txt
+++ b/packages/battery_plus/example/windows/flutter/CMakeLists.txt
@@ -91,6 +91,7 @@ add_custom_command(
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
       windows-x64 $<CONFIG>
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/packages/connectivity_plus/example/linux/flutter/CMakeLists.txt
+++ b/packages/connectivity_plus/example/linux/flutter/CMakeLists.txt
@@ -80,7 +80,8 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
-      linux-x64 ${CMAKE_BUILD_TYPE}
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/packages/device_info_plus/example/linux/flutter/CMakeLists.txt
+++ b/packages/device_info_plus/example/linux/flutter/CMakeLists.txt
@@ -80,7 +80,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
-      linux-x64 ${CMAKE_BUILD_TYPE}
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS

--- a/packages/network_info_plus/example/linux/flutter/CMakeLists.txt
+++ b/packages/network_info_plus/example/linux/flutter/CMakeLists.txt
@@ -80,7 +80,8 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
-      linux-x64 ${CMAKE_BUILD_TYPE}
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/packages/network_info_plus/example/windows/flutter/CMakeLists.txt
+++ b/packages/network_info_plus/example/windows/flutter/CMakeLists.txt
@@ -91,6 +91,7 @@ add_custom_command(
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
       windows-x64 $<CONFIG>
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/packages/package_info_plus/example/linux/flutter/CMakeLists.txt
+++ b/packages/package_info_plus/example/linux/flutter/CMakeLists.txt
@@ -80,7 +80,8 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
-      linux-x64 ${CMAKE_BUILD_TYPE}
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/packages/package_info_plus/example/windows/flutter/CMakeLists.txt
+++ b/packages/package_info_plus/example/windows/flutter/CMakeLists.txt
@@ -91,6 +91,7 @@ add_custom_command(
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
       windows-x64 $<CONFIG>
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/packages/share_plus/example/linux/flutter/CMakeLists.txt
+++ b/packages/share_plus/example/linux/flutter/CMakeLists.txt
@@ -80,7 +80,8 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.sh"
-      linux-x64 ${CMAKE_BUILD_TYPE}
+      ${FLUTTER_TARGET_PLATFORM} ${CMAKE_BUILD_TYPE}
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"

--- a/packages/share_plus/example/windows/flutter/CMakeLists.txt
+++ b/packages/share_plus/example/windows/flutter/CMakeLists.txt
@@ -91,6 +91,7 @@ add_custom_command(
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
       windows-x64 $<CONFIG>
+  VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS
   "${FLUTTER_LIBRARY}"


### PR DESCRIPTION
Both VERBATIM (Windows & Linux) and FLUTTER_TARGET_PLATFORM (Linux only) CMake migration changes have reached dev, so we can commit them to avoid applying them every time `pub get` is run:

    Running "flutter pub get" in xxx...
    add_custom_command() missing VERBATIM or FLUTTER_TARGET_PLATFORM, updating.
    Building Linux application...
