### PR TITLE
[device_info] - Web not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Flutter plugin providing detailed information about the device
 
 | Android | iOS | MacOS | Web | Linux | Windows |
 |:-------:|:---:|:-----:|:---:|:-----:|:------:|
-|    ✔️    |  ✔️  |   ✔️   |  ✔️  |   ✔️   |   ✔️   |
+|    ✔️    |  ✔️  |   ✔️   |  ➖  |   ✔️   |   ✔️   |
 
 ----
 


### PR DESCRIPTION
## Description

The main repo `README` for device_info doesn't match the package `README`:

https://github.com/fluttercommunity/plus_plugins/tree/main/packages/network_info_plus#platform-support

