### PR TITLE
[package_info_plus] Update preview dependencies #50

### DIFF
--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-nullsafety.1
+
+- Update dependencies
+- Fix dart SDK constraints
+
 ## 1.0.0-nullsafety.0
 
 - Migrate to null-safety

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 1.0.0-nullsafety.0
+version: 1.0.0-nullsafety.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -33,9 +33,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: ^1.16.2
+  test: ^1.16.4
   pedantic: ^1.10.0
 
 environment:
-  sdk: '>=2.12.0-259.12.beta <3.0.0'
+  sdk: '>=2.12.0-259.9.beta <3.0.0'
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/package_info_plus_linux/CHANGELOG.md
+++ b/packages/package_info_plus_linux/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-nullsafety.1
+
+- Update dependencies
+- Fix dart SDK constraints
+
 ## 1.0.0-nullsafety.0
 
 - Migrate to null-safety

--- a/packages/package_info_plus_linux/pubspec.yaml
+++ b/packages/package_info_plus_linux/pubspec.yaml
@@ -1,11 +1,11 @@
 name: package_info_plus_linux
 description: Linux implementation of the package_info_plus plugin
-version: 1.0.0-nullsafety.0
+version: 1.0.0-nullsafety.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
-  sdk: '>=2.12.0-259.12.beta <3.0.0'
+  sdk: '>=2.12.0-259.9.beta <3.0.0'
   flutter: ">=1.17.0"
 
 dependencies:

--- a/packages/package_info_plus_macos/CHANGELOG.md
+++ b/packages/package_info_plus_macos/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-nullsafety.1
+
+- Update dependencies
+- Fix dart SDK constraints
+
 ## 1.0.0-nullsafety.0
 
 - Migrate to null-safety

--- a/packages/package_info_plus_macos/pubspec.yaml
+++ b/packages/package_info_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_macos
 description: macOS implementation of the package_info_plus plugin.
-version: 1.0.0-nullsafety.0
+version: 1.0.0-nullsafety.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -12,7 +12,7 @@ flutter:
         fileName: package_info_plus_macos.dart
 
 environment:
-  sdk: '>=2.12.0-259.12.beta <3.0.0'
+  sdk: '>=2.12.0-259.9.beta <3.0.0'
   flutter: '>=1.20.0'
 
 dependencies:

--- a/packages/package_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/package_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-nullsafety.1
+
+- Update dependencies
+- Fix dart SDK constraints
+
 ## 1.0.0-nullsafety.0
 
 - Migrate to null-safety

--- a/packages/package_info_plus_platform_interface/pubspec.yaml
+++ b/packages/package_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_platform_interface
 description: A common platform interface for the package_info_plus plugin.
-version: 1.0.0-nullsafety.0
+version: 1.0.0-nullsafety.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -8,14 +8,14 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ^1.1.0-nullsafety
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety
+  mockito: ^5.0.0
   pedantic: ^1.10.0
 
 environment:
-  sdk: '>=2.12.0-259.12.beta <3.0.0'
+  sdk: '>=2.12.0-259.9.beta <3.0.0'
   flutter: ">=1.9.1+hotfix.4"

--- a/packages/package_info_plus_web/CHANGELOG.md
+++ b/packages/package_info_plus_web/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-nullsafety.1
+
+- Update dependencies
+- Fix dart SDK constraints
+
 ## 1.0.0-nullsafety.0
 
 - Migrate to null-safety

--- a/packages/package_info_plus_web/pubspec.yaml
+++ b/packages/package_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_web
 description: Web platform implementation of package_info_plus
-version: 1.0.0-nullsafety.0
+version: 1.0.0-nullsafety.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -26,5 +26,5 @@ dev_dependencies:
   pedantic: ^1.10.0
 
 environment:
-  sdk: '>=2.12.0-259.12.beta <3.0.0'
+  sdk: '>=2.12.0-259.9.beta <3.0.0'
   flutter: ">=1.20.0"

--- a/packages/package_info_plus_windows/CHANGELOG.md
+++ b/packages/package_info_plus_windows/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0-nullsafety.1
+
+- Update dependencies
+- Fix dart SDK constraints
+
 ## 1.0.0-nullsafety.0
 
 - Migrate to null-safety

--- a/packages/package_info_plus_windows/pubspec.yaml
+++ b/packages/package_info_plus_windows/pubspec.yaml
@@ -1,11 +1,11 @@
 name: package_info_plus_windows
 description: Windows implementation of the package_info_plus plugin
-version: 1.0.0-nullsafety.0
+version: 1.0.0-nullsafety.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
-  sdk: '>=2.12.0-259.12.beta <3.0.0'
+  sdk: '>=2.12.0-259.9.beta <3.0.0'
   flutter: ">=1.17.0"
 
 dependencies:


### PR DESCRIPTION
## Description

I just discovered some problems with the [pub.dev score](https://pub.dev/packages/package_info_plus/versions/1.0.0-nullsafety.0/score) for the new null safety version (btw. thanks for the migration 👍 ). I lowered the version constraints to the [recommended one](https://dart.dev/null-safety/migration-guide#package-version):
```
Before you publish a stable null safety version of a package, we strongly recommend following these pubspec rules:

Set the Dart lower SDK constraint to 2.12.0-259.9.beta.
Use stable versions of all direct dependencies.
```

I also updated some dependencies.

## Related Issues

#50 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

## Info

I ran `flutter analyze` and the tests in **package_info_plus**, but I wasn't able to run the whole check suite via Melos, as the bootstrapping failed due to version conflicts in the android_alarm_manager_plus package.

Potential reviewer: @jpnurmi 