### PR TITLE
Preview release versions

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -85,7 +85,7 @@ scripts:
       rm -rf ./build ./android/.gradle ./ios/.symlinks ./ios/Pods ./android/.idea ./.idea ./.dart-tool/build
 
 dev_dependencies:
-  pedantic: 1.10.0-nullsafety
+  pedantic: 1.10.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/android_alarm_manager_plus/CHANGELOG.md
+++ b/packages/android_alarm_manager_plus/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.0-nullsafety.0
+## 1.0.0
 
 - Null safety support.
 

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager_plus
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 0.7.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety
+  pedantic: ^1.10.0
 
 flutter:
   plugin:

--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0-nullsafety.1
+## 1.0.0
 
 - Null safety support.
 

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -15,16 +15,16 @@ dependencies:
   flutter:
     sdk: flutter
 
-  platform: ^3.0.0-nullsafety
-  meta: ^1.3.0-nullsafety
+  platform: ^3.0.0
+  meta: ^1.3.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  test: ^1.16.0-nullsafety
-  mockito: ^5.0.0-nullsafety
-  pedantic: ^1.10.0-nullsafety
+  test: ^1.16.4
+  mockito: ^5.0.0
+  pedantic: ^1.10.0
 
 environment:
   sdk: ">=2.12.0-133.7.beta <3.0.0"

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 0.5.0-nullsafety.1
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrate to null safety
 

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -25,11 +25,11 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  battery_plus_platform_interface: ^0.4.0-nullsafety
-  battery_plus_linux: ^0.3.0-nullsafety.1
-  battery_plus_macos: ^0.3.0-nullsafety
-  battery_plus_web: ^0.4.0-nullsafety
-  battery_plus_windows: ^0.3.0-nullsafety
+  battery_plus_platform_interface: ^1.0.0
+  battery_plus_linux: ^1.0.0
+  battery_plus_macos: ^1.0.0
+  battery_plus_web: ^1.0.0
+  battery_plus_windows: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/pubspec.yaml
@@ -24,7 +24,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.0.5
+  meta: ^1.3.0
   battery_plus_platform_interface: ^1.0.0
   battery_plus_linux: ^1.0.0
   battery_plus_macos: ^1.0.0
@@ -35,10 +35,10 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  async: ^2.0.8
-  plugin_platform_interface: ^1.0.0
-  test: ^1.16.0-nullsafety
-  pedantic: ^1.10.0-nullsafety
+  async: ^2.5.0
+  plugin_platform_interface: ^2.0.0
+  test: ^1.16.4
+  pedantic: ^1.10.0
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'

--- a/packages/battery_plus_linux/CHANGELOG.md
+++ b/packages/battery_plus_linux/CHANGELOG.md
@@ -1,8 +1,4 @@
-## 0.3.0-nullsafety.1
-
-- Null safety fixes.
-
-## 0.3.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety.
 

--- a/packages/battery_plus_linux/pubspec.yaml
+++ b/packages/battery_plus_linux/pubspec.yaml
@@ -2,14 +2,14 @@ name: battery_plus_linux
 description: Linux implementation of the battery_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.3.0-nullsafety.1
+version: 1.0.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
-  battery_plus_platform_interface: ^0.4.0-nullsafety
+  battery_plus_platform_interface: ^1.0.0
   dbus: ^0.2.0
   flutter:
     sdk: flutter

--- a/packages/battery_plus_linux/pubspec.yaml
+++ b/packages/battery_plus_linux/pubspec.yaml
@@ -10,15 +10,15 @@ environment:
 
 dependencies:
   battery_plus_platform_interface: ^1.0.0
-  dbus: ^0.2.0
+  dbus: ^0.2.1
   flutter:
     sdk: flutter
-  meta: ^1.3.0-nullsafety
+  meta: ^1.3.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety
+  pedantic: ^1.10.0
 
 flutter:
   plugin:

--- a/packages/battery_plus_macos/CHANGELOG.md
+++ b/packages/battery_plus_macos/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-nullsafety.0
+## 1.0.0
 
 * Migrated to null safety.
 

--- a/packages/battery_plus_macos/pubspec.yaml
+++ b/packages/battery_plus_macos/pubspec.yaml
@@ -2,14 +2,14 @@ name: battery_plus_macos
 description: An implementation for the macos platform of the Flutter `battery_plus` plugin.
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.3.0-nullsafety.0
+version: 1.0.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
   flutter: '>=1.20.0'
 
 dependencies:
-  battery_plus_platform_interface: ^0.4.0-nullsafety
+  battery_plus_platform_interface: ^1.0.0
   flutter:
     sdk: flutter
 

--- a/packages/battery_plus_platform_interface/CHANGELOG.md
+++ b/packages/battery_plus_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
 

--- a/packages/battery_plus_platform_interface/pubspec.yaml
+++ b/packages/battery_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_platform_interface
 description: A common platform interface for the battery_plus plugin.
-version: 0.4.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/battery_plus_platform_interface/pubspec.yaml
+++ b/packages/battery_plus_platform_interface/pubspec.yaml
@@ -11,10 +11,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0-nullsafety
-  plugin_platform_interface: ^1.1.0-nullsafety
+  meta: ^1.3.0
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety
+  pedantic: ^1.10.0

--- a/packages/battery_plus_web/CHANGELOG.md
+++ b/packages/battery_plus_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.4.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
 

--- a/packages/battery_plus_web/pubspec.yaml
+++ b/packages/battery_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_web
 description: An implementation for the web platform of the Flutter `battery_plus` plugin.
-version: 0.4.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -12,7 +12,7 @@ flutter:
         fileName: battery_plus_web.dart
 
 dependencies:
-  battery_plus_platform_interface: ^0.4.0-nullsafety
+  battery_plus_platform_interface: ^1.0.0
   flutter_web_plugins:
     sdk: flutter
   flutter:

--- a/packages/battery_plus_windows/CHANGELOG.md
+++ b/packages/battery_plus_windows/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
 

--- a/packages/battery_plus_windows/pubspec.yaml
+++ b/packages/battery_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_windows
 description: Windows implementation of the battery_plus plugin
-version: 0.3.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  battery_plus_platform_interface: ^0.4.0-nullsafety
+  battery_plus_platform_interface: ^1.0.0
   flutter:
     sdk: flutter
 

--- a/packages/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
 

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 0.9.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -29,11 +29,11 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  connectivity_plus_platform_interface: ^0.5.0-nullsafety
-  connectivity_plus_linux: ^0.4.0-nullsafety
-  connectivity_plus_macos: ^0.5.0-nullsafety
-  connectivity_plus_web: ^0.7.0-nullsafety
-  connectivity_plus_windows: ^0.2.0-nullsafety
+  connectivity_plus_platform_interface: ^1.0.0
+  connectivity_plus_linux: ^1.0.0
+  connectivity_plus_macos: ^1.0.0
+  connectivity_plus_web: ^1.0.0
+  connectivity_plus_windows: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/pubspec.yaml
@@ -38,8 +38,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: any
-  mockito: ^5.0.0-nullsafety.7
+  test: ^1.16.4
+  mockito: ^5.0.0
   plugin_platform_interface: ^2.0.0
   pedantic: ^1.10.0
 

--- a/packages/connectivity_plus_linux/CHANGELOG.md
+++ b/packages/connectivity_plus_linux/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 0.4.0-nullsafety.1
-
-- Fixed a case with an unhandled exception
-
-## 0.4.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
+- Fixed a case with an unhandled exception
 
 ## 0.3.1
 

--- a/packages/connectivity_plus_linux/pubspec.yaml
+++ b/packages/connectivity_plus_linux/pubspec.yaml
@@ -12,13 +12,13 @@ dependencies:
   flutter:
     sdk: flutter
   connectivity_plus_platform_interface: ^1.0.0
-  dbus: ^0.2.0
+  dbus: ^0.2.1
   meta: ^1.3.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.7
+  mockito: ^5.0.0
   pedantic: ^1.10.0
   build_runner: ^1.11.5
 

--- a/packages/connectivity_plus_linux/pubspec.yaml
+++ b/packages/connectivity_plus_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_plus_linux
 description: Linux implementation of the connectivity_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.4.0-nullsafety.1
+version: 1.0.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  connectivity_plus_platform_interface: ^0.5.0-nullsafety.0
+  connectivity_plus_platform_interface: ^1.0.0
   dbus: ^0.2.0
   meta: ^1.3.0
 

--- a/packages/connectivity_plus_macos/CHANGELOG.md
+++ b/packages/connectivity_plus_macos/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
 

--- a/packages/connectivity_plus_macos/pubspec.yaml
+++ b/packages/connectivity_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_macos
 description: macOS implementation of the connectivity_plus plugin.
-version: 0.5.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -15,6 +15,6 @@ flutter:
         pluginClass: ConnectivityPlugin
 
 dependencies:
-  connectivity_plus_platform_interface: ^0.5.0-nullsafety.0
+  connectivity_plus_platform_interface: ^1.0.0
   flutter:
     sdk: flutter

--- a/packages/connectivity_plus_platform_interface/CHANGELOG.md
+++ b/packages/connectivity_plus_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.5.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
 

--- a/packages/connectivity_plus_platform_interface/pubspec.yaml
+++ b/packages/connectivity_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_platform_interface
 description: A common platform interface for the connectivity_plus plugin.
-version: 0.5.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/connectivity_plus_web/CHANGELOG.md
+++ b/packages/connectivity_plus_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.7.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
 

--- a/packages/connectivity_plus_web/example/pubspec.yaml
+++ b/packages/connectivity_plus_web/example/pubspec.yaml
@@ -20,4 +20,9 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.7
+  mockito: ^5.0.0
+
+dependency_overrides:
+  args: ^2.0.0
+  convert: ^3.0.0
+  crypto: ^3.0.0

--- a/packages/connectivity_plus_web/pubspec.yaml
+++ b/packages/connectivity_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_web
 description: An implementation for the web platform of the Flutter `connectivity_plus` plugin. This uses the NetworkInformation Web API, with a fallback to Navigator.onLine.
-version: 0.7.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -16,7 +16,7 @@ flutter:
         fileName: connectivity_plus_web.dart
 
 dependencies:
-  connectivity_plus_platform_interface: ^0.5.0-nullsafety.0
+  connectivity_plus_platform_interface: ^1.0.0
   flutter_web_plugins:
     sdk: flutter
   flutter:

--- a/packages/connectivity_plus_web/pubspec.yaml
+++ b/packages/connectivity_plus_web/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: any
+  test: ^1.16.4
   flutter_test:
     sdk: flutter
   pedantic: ^1.10.0

--- a/packages/connectivity_plus_windows/CHANGELOG.md
+++ b/packages/connectivity_plus_windows/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0-nullsafety.0
+## 1.0.0
 
 * Migrated to null safety
 

--- a/packages/connectivity_plus_windows/pubspec.yaml
+++ b/packages/connectivity_plus_windows/pubspec.yaml
@@ -2,14 +2,14 @@ name: connectivity_plus_windows
 description: Windows implementation of the connectivity_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.2.0-nullsafety.0
+version: 1.0.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
-  connectivity_plus_platform_interface: ^0.5.0-nullsafety.0
+  connectivity_plus_platform_interface: ^1.0.0
   flutter:
     sdk: flutter
 

--- a/packages/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 1.0.0-nullsafety.1
-
-- Update dependencies.
-
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
+- Update dependencies.
 
 ## 0.7.2
 

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 1.0.0-nullsafety.1
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -25,11 +25,11 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus_platform_interface: ^1.0.0-nullsafety
-  device_info_plus_linux: ^1.0.0-nullsafety
-  device_info_plus_macos: ^1.0.0-nullsafety
-  device_info_plus_web: ^1.0.0-nullsafety
-  device_info_plus_windows: ^1.0.0-nullsafety
+  device_info_plus_platform_interface: ^1.0.0
+  device_info_plus_linux: ^1.0.0
+  device_info_plus_macos: ^1.0.0
+  device_info_plus_web: ^1.0.0
+  device_info_plus_windows: ^1.0.0
 
 dev_dependencies:
   test: ^1.3.0

--- a/packages/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/pubspec.yaml
@@ -32,10 +32,10 @@ dependencies:
   device_info_plus_windows: ^1.0.0
 
 dev_dependencies:
-  test: ^1.3.0
+  test: ^1.16.4
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.2
+  pedantic: ^1.10.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/device_info_plus_linux/CHANGELOG.md
+++ b/packages/device_info_plus_linux/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 1.0.0-nullsafety.1
-
-- Update dependencies.
-
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
+- Update dependencies.
 
 ## 0.2.1
 

--- a/packages/device_info_plus_linux/pubspec.yaml
+++ b/packages/device_info_plus_linux/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
   file: ^6.0.0
   flutter:
     sdk: flutter
-  meta: ^1.2.3
+  meta: ^1.3.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.2
+  pedantic: ^1.10.0

--- a/packages/device_info_plus_linux/pubspec.yaml
+++ b/packages/device_info_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_linux
 description: Linux implementation of the device_info_plus plugin
-version: 1.0.0-nullsafety.1
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^1.0.0-nullsafety.0
+  device_info_plus_platform_interface: ^1.0.0
   file: ^6.0.0
   flutter:
     sdk: flutter

--- a/packages/device_info_plus_macos/CHANGELOG.md
+++ b/packages/device_info_plus_macos/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
 

--- a/packages/device_info_plus_macos/pubspec.yaml
+++ b/packages/device_info_plus_macos/pubspec.yaml
@@ -2,14 +2,14 @@ name: device_info_plus_macos
 description: Macos implementation of the device_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^1.0.0-nullsafety.0
+  device_info_plus_platform_interface: ^1.0.0
   flutter:
     sdk: flutter
 

--- a/packages/device_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_info_plus_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
 

--- a/packages/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus_platform_interface/pubspec.yaml
@@ -7,14 +7,14 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.1.8
-  plugin_platform_interface: ^1.1.0-nullsafety.2
+  meta: ^1.3.0
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^4.1.1
-  pedantic: ^1.9.2
+  mockito: ^5.0.0
+  pedantic: ^1.10.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_platform_interface
 description: A common platform interface for the device_info_plis plugin.
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/device_info_plus_web/CHANGELOG.md
+++ b/packages/device_info_plus_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null safety
 

--- a/packages/device_info_plus_web/pubspec.yaml
+++ b/packages/device_info_plus_web/pubspec.yaml
@@ -19,11 +19,11 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: any
+  test: ^1.16.4
   flutter_test:
     sdk: flutter
-  mockito: ^4.1.2
-  pedantic: ^1.9.2
+  mockito: ^5.0.0
+  pedantic: ^1.10.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/device_info_plus_web/pubspec.yaml
+++ b/packages/device_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_web
 description: An implementation for the web platform of the Flutter `device_info_plus` plugin.
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -12,7 +12,7 @@ flutter:
         fileName: device_info_plus_web.dart
 
 dependencies:
-  device_info_plus_platform_interface: ^1.0.0-nullsafety.0
+  device_info_plus_platform_interface: ^1.0.0
   flutter_web_plugins:
     sdk: flutter
   flutter:

--- a/packages/device_info_plus_windows/CHANGELOG.md
+++ b/packages/device_info_plus_windows/CHANGELOG.md
@@ -1,3 +1,3 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
-- Initial release.
+- Initial null-safe release.

--- a/packages/device_info_plus_windows/pubspec.yaml
+++ b/packages/device_info_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_windows
 description: Windows implementation of the device_info_plus plugin
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: '>=1.12.13+hotfix.4'
 
 dependencies:
-  device_info_plus_platform_interface: ^1.0.0-nullsafety.0
+  device_info_plus_platform_interface: ^1.0.0
   ffi: ^1.0.0
   flutter:
     sdk: flutter

--- a/packages/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrate to null-safety.
 

--- a/packages/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -25,11 +25,11 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  network_info_plus_platform_interface: ^1.0.0-nullsafety
-  network_info_plus_linux: ^1.0.0-nullsafety
-  network_info_plus_macos: ^1.0.0-nullsafety
-  network_info_plus_windows: ^1.0.0-nullsafety
-  network_info_plus_web: ^1.0.0-nullsafety
+  network_info_plus_platform_interface: ^1.0.0
+  network_info_plus_linux: ^1.0.0
+  network_info_plus_macos: ^1.0.0
+  network_info_plus_windows: ^1.0.0
+  network_info_plus_web: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/network_info_plus_linux/CHANGELOG.md
+++ b/packages/network_info_plus_linux/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrate to null-safety.
 

--- a/packages/network_info_plus_linux/pubspec.yaml
+++ b/packages/network_info_plus_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: network_info_plus_linux
 description: Linux implementation of the network_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 
 environment:
   sdk: '>=2.12.0-259.9.beta <3.0.0'
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus_platform_interface: ^1.0.0-nullsafety
+  network_info_plus_platform_interface: ^1.0.0
   dbus: ^0.2.1
   meta: ^1.3.0
 

--- a/packages/network_info_plus_macos/CHANGELOG.md
+++ b/packages/network_info_plus_macos/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrate to null-safety.
 

--- a/packages/network_info_plus_macos/pubspec.yaml
+++ b/packages/network_info_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus_macos
 description: macOS implementation of the network_info_plus plugin.
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -15,6 +15,6 @@ environment:
   flutter: '>=1.20.0'
 
 dependencies:
-  network_info_plus_platform_interface: ^1.0.0-nullsafety
+  network_info_plus_platform_interface: ^1.0.0
   flutter:
     sdk: flutter

--- a/packages/network_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/network_info_plus_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrate to null-safety.
 

--- a/packages/network_info_plus_platform_interface/pubspec.yaml
+++ b/packages/network_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus_platform_interface
 description: A common platform interface for the network_info_plus plugin.
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/network_info_plus_web/CHANGELOG.md
+++ b/packages/network_info_plus_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrate to null-safety.
 

--- a/packages/network_info_plus_web/pubspec.yaml
+++ b/packages/network_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus_web
 description: A stub implementation of the Network Info Plus plugin for Web.
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  network_info_plus_platform_interface: ^1.0.0-nullsafety
+  network_info_plus_platform_interface: ^1.0.0
 
 environment:
   sdk: '>=2.12.0-259.9.beta <3.0.0'

--- a/packages/network_info_plus_windows/CHANGELOG.md
+++ b/packages/network_info_plus_windows/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrate to null-safety.
 

--- a/packages/network_info_plus_windows/pubspec.yaml
+++ b/packages/network_info_plus_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: network_info_plus_windows
 description: Windows implementation of the network_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 
 environment:
   sdk: '>=2.12.0-259.9.beta <3.0.0'
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus_platform_interface: ^1.0.0-nullsafety
+  network_info_plus_platform_interface: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/network_info_plus_windows/pubspec.yaml
+++ b/packages/network_info_plus_windows/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   flutter:
     sdk: flutter
   network_info_plus_platform_interface: ^1.0.0
-
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,11 +1,8 @@
-## 1.0.0-nullsafety.1
-
-- Update dependencies
-- Fix dart SDK constraints
-
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrate to null-safety
+- Update dependencies
+- Fix dart SDK constraints
 
 ## 0.6.4
 

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 1.0.0-nullsafety.1
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -24,11 +24,11 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus_platform_interface: ^1.0.0-nullsafety
-  package_info_plus_linux: ^1.0.0-nullsafety
-  package_info_plus_macos: ^1.0.0-nullsafety
-  package_info_plus_windows: ^1.0.0-nullsafety
-  package_info_plus_web: ^1.0.0-nullsafety
+  package_info_plus_platform_interface: ^1.0.0
+  package_info_plus_linux: ^1.0.0
+  package_info_plus_macos: ^1.0.0
+  package_info_plus_windows: ^1.0.0
+  package_info_plus_web: ^1.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/package_info_plus_linux/CHANGELOG.md
+++ b/packages/package_info_plus_linux/CHANGELOG.md
@@ -1,11 +1,9 @@
-## 1.0.0-nullsafety.1
+## 1.0.0
 
+- Migrate to null-safety
 - Update dependencies
 - Fix dart SDK constraints
 
-## 1.0.0-nullsafety.0
-
-- Migrate to null-safety
 
 ## 0.1.1
 

--- a/packages/package_info_plus_linux/pubspec.yaml
+++ b/packages/package_info_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_linux
 description: Linux implementation of the package_info_plus plugin
-version: 1.0.0-nullsafety.1
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  package_info_plus_platform_interface: ^1.0.0-nullsafety
+  package_info_plus_platform_interface: ^1.0.0
   flutter:
     sdk: flutter
   path: ^1.8.0

--- a/packages/package_info_plus_macos/CHANGELOG.md
+++ b/packages/package_info_plus_macos/CHANGELOG.md
@@ -1,11 +1,9 @@
-## 1.0.0-nullsafety.1
+## 1.0.0
 
+- Migrate to null-safety
 - Update dependencies
 - Fix dart SDK constraints
 
-## 1.0.0-nullsafety.0
-
-- Migrate to null-safety
 
 ## 0.2.0
 

--- a/packages/package_info_plus_macos/pubspec.yaml
+++ b/packages/package_info_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_macos
 description: macOS implementation of the package_info_plus plugin.
-version: 1.0.0-nullsafety.1
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/package_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/package_info_plus_platform_interface/CHANGELOG.md
@@ -1,11 +1,9 @@
-## 1.0.0-nullsafety.1
+## 1.0.0
 
+- Migrate to null-safety
 - Update dependencies
 - Fix dart SDK constraints
 
-## 1.0.0-nullsafety.0
-
-- Migrate to null-safety
 
 ## 0.3.0
 

--- a/packages/package_info_plus_platform_interface/pubspec.yaml
+++ b/packages/package_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_platform_interface
 description: A common platform interface for the package_info_plus plugin.
-version: 1.0.0-nullsafety.1
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/package_info_plus_web/CHANGELOG.md
+++ b/packages/package_info_plus_web/CHANGELOG.md
@@ -1,11 +1,9 @@
-## 1.0.0-nullsafety.1
+## 1.0.0
 
+- Migrate to null-safety
 - Update dependencies
 - Fix dart SDK constraints
 
-## 1.0.0-nullsafety.0
-
-- Migrate to null-safety
 
 ## 0.2.1
 

--- a/packages/package_info_plus_web/pubspec.yaml
+++ b/packages/package_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_web
 description: Web platform implementation of package_info_plus
-version: 1.0.0-nullsafety.1
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -13,7 +13,7 @@ flutter:
 
 dependencies:
   http: ^0.13.0
-  package_info_plus_platform_interface: ^1.0.0-nullsafety
+  package_info_plus_platform_interface: ^1.0.0
   flutter:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/package_info_plus_windows/CHANGELOG.md
+++ b/packages/package_info_plus_windows/CHANGELOG.md
@@ -1,11 +1,9 @@
-## 1.0.0-nullsafety.1
+## 1.0.0
 
+- Migrate to null-safety
 - Update dependencies
 - Fix dart SDK constraints
 
-## 1.0.0-nullsafety.0
-
-- Migrate to null-safety
 
 ## [0.2.0]
 

--- a/packages/package_info_plus_windows/pubspec.yaml
+++ b/packages/package_info_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_windows
 description: Windows implementation of the package_info_plus plugin
-version: 1.0.0-nullsafety.1
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  package_info_plus_platform_interface: ^1.0.0-nullsafety
+  package_info_plus_platform_interface: ^1.0.0
   ffi: ^1.0.0
   flutter:
     sdk: flutter

--- a/packages/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null-safety
 

--- a/packages/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sensors_plus
 description: Flutter plugin for accessing accelerometer and gyroscope sensors.
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -18,8 +18,8 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  sensors_plus_web: ^1.0.0-nullsafety
-  sensors_plus_platform_interface: ^1.0.0-nullsafety
+  sensors_plus_web: ^1.0.0
+  sensors_plus_platform_interface: ^1.0.0
 
 dev_dependencies:
   test: ^1.16.2

--- a/packages/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   sensors_plus_platform_interface: ^1.0.0
 
 dev_dependencies:
-  test: ^1.16.2
+  test: ^1.16.4
   flutter_test:
     sdk: flutter
   pedantic: ^1.10.0

--- a/packages/sensors_plus_platform_interface/CHANGELOG.md
+++ b/packages/sensors_plus_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null-safety
 

--- a/packages/sensors_plus_platform_interface/pubspec.yaml
+++ b/packages/sensors_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sensors_plus_platform_interface
 description: A common platform interface for the sensors_plus plugin.
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/sensors_plus_platform_interface/pubspec.yaml
+++ b/packages/sensors_plus_platform_interface/pubspec.yaml
@@ -8,13 +8,13 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  plugin_platform_interface: ^1.1.0-nullsafety
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   pedantic: ^1.10.0
-  test: ^1.16.2
+  test: ^1.16.4
 
 environment:
   sdk: '>=2.12.0-259.12.beta <3.0.0'

--- a/packages/sensors_plus_web/CHANGELOG.md
+++ b/packages/sensors_plus_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-nullsafety.0
+## 1.0.0
 
 - Migrated to null-safety
 

--- a/packages/sensors_plus_web/pubspec.yaml
+++ b/packages/sensors_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sensors_plus_web
 description: The web implementation of sensors_plus
-version: 1.0.0-nullsafety.0
+version: 1.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  sensors_plus_platform_interface: ^1.0.0-nullsafety.0
+  sensors_plus_platform_interface: ^1.0.0
   flutter_web_plugins:
     sdk: flutter
 

--- a/packages/sensors_plus_web/pubspec.yaml
+++ b/packages/sensors_plus_web/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  test: ^1.16.2
+  test: ^1.16.4
   flutter_test:
     sdk: flutter
   pedantic: ^1.10.0

--- a/packages/share_plus/CHANGELOG.md
+++ b/packages/share_plus/CHANGELOG.md
@@ -1,10 +1,7 @@
-## 2.1.0-nullsafety.0
-
-- Add macOS support (`share_plus_macos`)
-
-## 2.0.0-nullsafety.0
+## 2.0.0
 
 - Migrated to null safety
+- Add macOS support (`share_plus_macos`)
 
 ## 1.2.0
 

--- a/packages/share_plus/pubspec.yaml
+++ b/packages/share_plus/pubspec.yaml
@@ -22,8 +22,8 @@ flutter:
         default_package: share_plus_windows
 
 dependencies:
-  meta: ^1.0.5
-  mime: ^1.0.0-nullsafety
+  meta: ^1.3.0
+  mime: ^1.0.0
   flutter:
     sdk: flutter
   share_plus_platform_interface: ^2.0.0
@@ -35,7 +35,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.2
+  pedantic: ^1.10.0
 
 environment:
   sdk: '>=2.12.0-259.9.beta <3.0.0'

--- a/packages/share_plus/pubspec.yaml
+++ b/packages/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 2.1.0-nullsafety.0
+version: 2.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -26,11 +26,11 @@ dependencies:
   mime: ^1.0.0-nullsafety
   flutter:
     sdk: flutter
-  share_plus_platform_interface: ^2.0.0-nullsafety
-  share_plus_linux: ^2.0.0-nullsafety
-  share_plus_macos: ^0.1.0-nullsafety
-  share_plus_windows: ^0.2.0-nullsafety
-  share_plus_web: ^0.2.0-nullsafety
+  share_plus_platform_interface: ^2.0.0
+  share_plus_linux: ^2.0.0
+  share_plus_macos: ^2.0.0
+  share_plus_windows: ^2.0.0
+  share_plus_web: ^2.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/share_plus_linux/CHANGELOG.md
+++ b/packages/share_plus_linux/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-nullsafety.0
+## 2.0.0
 
 - Migrated to null safety
 

--- a/packages/share_plus_linux/pubspec.yaml
+++ b/packages/share_plus_linux/pubspec.yaml
@@ -10,13 +10,13 @@ environment:
 
 dependencies:
   share_plus_platform_interface: ^2.0.0
-  file: ^6.0.0-nullsafety
+  file: ^6.0.0
   flutter:
     sdk: flutter
-  meta: ^1.2.3
-  url_launcher: ^6.0.0-nullsafety
+  meta: ^1.3.0
+  url_launcher: ^6.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.2
+  pedantic: ^1.10.0

--- a/packages/share_plus_linux/pubspec.yaml
+++ b/packages/share_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_linux
 description: Linux implementation of the share_plus plugin
-version: 2.0.0-nullsafety.0
+version: 2.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  share_plus_platform_interface: ^2.0.0-nullsafety
+  share_plus_platform_interface: ^2.0.0
   file: ^6.0.0-nullsafety
   flutter:
     sdk: flutter

--- a/packages/share_plus_macos/CHANGELOG.md
+++ b/packages/share_plus_macos/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.0-nullsafety.0
+## 2.0.0
 
-* Initial macOS support
+* Initial null-safe macOS support
 

--- a/packages/share_plus_macos/pubspec.yaml
+++ b/packages/share_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_macos
 description: MacOS implementation of the share_plus plugin
-version: 0.1.0-nullsafety.0
+version: 2.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  share_plus_platform_interface: ^2.0.0-nullsafety
+  share_plus_platform_interface: ^2.0.0
   flutter:
     sdk: flutter
 

--- a/packages/share_plus_macos/pubspec.yaml
+++ b/packages/share_plus_macos/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.2
+  pedantic: ^1.10.0
 
 flutter:
   plugin:

--- a/packages/share_plus_platform_interface/CHANGELOG.md
+++ b/packages/share_plus_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-nullsafety.0
+## 2.0.0
 
 - Migrated to null safety
 

--- a/packages/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_platform_interface
 description: A common platform interface for the share_plus plugin.
-version: 2.0.0-nullsafety.0
+version: 2.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus_platform_interface/pubspec.yaml
@@ -7,16 +7,16 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.1.8
-  mime: ^1.0.0-nullsafety
-  plugin_platform_interface: ^1.1.0-nullsafety
+  meta: ^1.3.0
+  mime: ^1.0.0
+  plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety
-  pedantic: ^1.9.2
-  test: ^1.3.0
+  mockito: ^5.0.0
+  pedantic: ^1.10.0
+  test: ^1.16.4
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/share_plus_web/CHANGELOG.md
+++ b/packages/share_plus_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0-nullsafety.0
+## 2.0.0
 
 - Migrated to null safety
 

--- a/packages/share_plus_web/integration_test/pubspec.yaml
+++ b/packages/share_plus_web/integration_test/pubspec.yaml
@@ -17,5 +17,10 @@ dev_dependencies:
   share_plus_web:
     path: ../
   http: ^0.12.2
-  mockito: ^4.1.1
+  mockito: ^5.0.0
   integration_test: ^1.0.2
+
+dependency_overrides:
+  args: ^2.0.0
+  convert: ^3.0.0
+  crypto: ^3.0.0

--- a/packages/share_plus_web/pubspec.yaml
+++ b/packages/share_plus_web/pubspec.yaml
@@ -2,7 +2,7 @@ name: share_plus_web
 description: Web platform implementation of share_plus
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 0.2.0-nullsafety.0
+version: 2.0.0
 
 flutter:
   plugin:
@@ -12,7 +12,7 @@ flutter:
         fileName: share_plus_web.dart
 
 dependencies:
-  share_plus_platform_interface: ^2.0.0-nullsafety
+  share_plus_platform_interface: ^2.0.0
   url_launcher: ^6.0.0-nullsafety
   flutter:
     sdk: flutter

--- a/packages/share_plus_web/pubspec.yaml
+++ b/packages/share_plus_web/pubspec.yaml
@@ -13,17 +13,17 @@ flutter:
 
 dependencies:
   share_plus_platform_interface: ^2.0.0
-  url_launcher: ^6.0.0-nullsafety
+  url_launcher: ^6.0.1
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.1.7
+  meta: ^1.3.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.2
+  pedantic: ^1.10.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"

--- a/packages/share_plus_windows/CHANGELOG.md
+++ b/packages/share_plus_windows/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0-nullsafety.0
+## 2.0.0
 
 - Migrated to null safety
 

--- a/packages/share_plus_windows/pubspec.yaml
+++ b/packages/share_plus_windows/pubspec.yaml
@@ -12,10 +12,10 @@ dependencies:
   share_plus_platform_interface: ^2.0.0
   flutter:
     sdk: flutter
-  meta: ^1.2.3
-  url_launcher: ^6.0.0-nullsafety
+  meta: ^1.3.0
+  url_launcher: ^6.0.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.2
+  pedantic: ^1.10.0

--- a/packages/share_plus_windows/pubspec.yaml
+++ b/packages/share_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_windows
 description: Windows implementation of the share_plus plugin
-version: 0.2.0-nullsafety.0
+version: 2.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  share_plus_platform_interface: ^2.0.0-nullsafety
+  share_plus_platform_interface: ^2.0.0
   flutter:
     sdk: flutter
   meta: ^1.2.3


### PR DESCRIPTION
As mentioned in https://medium.com/dartlang/preparing-the-dart-and-flutter-ecosystem-for-null-safety-e550ce72c010

> We’ve also added a new feature to pub.dev that tags package versions as preview releases when their dependent Dart SDK hasn’t yet been released to stable. Preview releases will automatically be promoted to regular stable versions once a new stable Dart SDK is released.