### PR TITLE
Fix #184 - Support null values from Android

### DIFF
--- a/packages/device_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Fix https://github.com/fluttercommunity/plus_plugins/issues/184: Null values on Android
+
 ## 1.0.0
 
 - Migrated to null safety

--- a/packages/device_info_plus_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info_plus_platform_interface/lib/model/android_device_info.dart
@@ -21,18 +21,18 @@ class AndroidDeviceInfo {
     this.manufacturer,
     this.model,
     this.product,
-    required List<String> supported32BitAbis,
-    required List<String> supported64BitAbis,
-    required List<String> supportedAbis,
+    required List<String?> supported32BitAbis,
+    required List<String?> supported64BitAbis,
+    required List<String?> supportedAbis,
     this.tags,
     this.type,
     this.isPhysicalDevice,
     this.androidId,
-    required List<String> systemFeatures,
-  })   : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
-        supported64BitAbis = List<String>.unmodifiable(supported64BitAbis),
-        supportedAbis = List<String>.unmodifiable(supportedAbis),
-        systemFeatures = List<String>.unmodifiable(systemFeatures);
+    required List<String?> systemFeatures,
+  })   : supported32BitAbis = List<String?>.unmodifiable(supported32BitAbis),
+        supported64BitAbis = List<String?>.unmodifiable(supported64BitAbis),
+        supportedAbis = List<String?>.unmodifiable(supportedAbis),
+        systemFeatures = List<String?>.unmodifiable(systemFeatures);
 
   /// Android operating system version values derived from `android.os.Build.VERSION`.
   final AndroidBuildVersion version;
@@ -74,13 +74,13 @@ class AndroidDeviceInfo {
   final String? product;
 
   /// An ordered list of 32 bit ABIs supported by this device.
-  final List<String> supported32BitAbis;
+  final List<String?> supported32BitAbis;
 
   /// An ordered list of 64 bit ABIs supported by this device.
-  final List<String> supported64BitAbis;
+  final List<String?> supported64BitAbis;
 
   /// An ordered list of ABIs supported by this device.
-  final List<String> supportedAbis;
+  final List<String?> supportedAbis;
 
   /// Comma-separated tags describing the build, like "unsigned,debug".
   final String? tags;
@@ -108,7 +108,7 @@ class AndroidDeviceInfo {
   /// and many of the common feature strings to look for are available in
   /// PackageManager's public documentation:
   /// https://developer.android.com/reference/android/content/pm/PackageManager
-  final List<String> systemFeatures;
+  final List<String?> systemFeatures;
 
   /// Deserializes from the message received from [_kChannel].
   static AndroidDeviceInfo fromMap(Map<String, dynamic> map) {
@@ -139,9 +139,9 @@ class AndroidDeviceInfo {
   }
 
   /// Deserializes message as List<String>
-  static List<String> _fromList(dynamic message) {
+  static List<String?> _fromList(dynamic message) {
     final List<dynamic> list = message;
-    return List<String>.from(list);
+    return List<String?>.from(list);
   }
 }
 

--- a/packages/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_platform_interface
 description: A common platform interface for the device_info_plis plugin.
-version: 1.0.0
+version: 1.0.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
Fix issue reported in #184 by supporting nullable values coming from Android.

In theory we only need to update the platform interface and release it.

Will release once the PR is merged.

This has been tested with an emulator and using the example project.