### PR TITLE
feat(share_plus): Show preview title in iOS share sheet (#190)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -3,3 +3,4 @@ Simon Lightfoot <simon@devangels.london>
 J-P Nurmi <jpnurmi@gmail.com>
 Miguel Beltran <miquelbeltran@gmail.com>
 Neevash Ramdial <mail@neevash.dev>
+Andrew Teich <andrewteich@me.com>

--- a/packages/share_plus/CHANGELOG.md
+++ b/packages/share_plus/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.1
+- Added preview title to iOS share sheet
+
 ## 2.0.0
 
 - Migrated to null safety

--- a/packages/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #import "FLTSharePlusPlugin.h"
+#import "LinkPresentation/LPLinkMetadata.h"
 
 static NSString *const PLATFORM_CHANNEL = @"dev.fluttercommunity.plus/share";
 
@@ -87,6 +88,14 @@ static NSString *const PLATFORM_CHANNEL = @"dev.fluttercommunity.plus/share";
   UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
   UIGraphicsEndImageContext();
   return newImage;
+}
+
+- (LPLinkMetadata *)activityViewControllerLinkMetadata:
+    (UIActivityViewController *)activityViewController
+    API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0)) {
+  LPLinkMetadata *metadata = [[LPLinkMetadata alloc] init];
+  metadata.title = _text;
+  return metadata;
 }
 
 @end

--- a/packages/share_plus/ios/share_plus.podspec
+++ b/packages/share_plus/ios/share_plus.podspec
@@ -17,7 +17,8 @@ Downloaded by pub (not CocoaPods).
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  
+  s.ios.framework = 'LinkPresentation'
+
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end

--- a/packages/share_plus/pubspec.yaml
+++ b/packages/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 2.0.0
+version: 2.0.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

Fixes one of the issues reported in #190 where the iOS share sheet would show a blank preview instead of the given text.

Verified working on iOS 14.4, 12.0 simulators

## Related Issues

 #190 [share_plus] Text not showing in share modal and web opens a new tab to about:blank

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
