### PR TITLE
issue-213: renamed FLTPackageInfoPlugin to FLTPackageInfoPlusPlugin

### DIFF
--- a/packages/package_info_plus_macos/macos/Classes/FLTPackageInfoPlusPlugin.h
+++ b/packages/package_info_plus_macos/macos/Classes/FLTPackageInfoPlusPlugin.h
@@ -4,5 +4,5 @@
 
 #import <FlutterMacOS/FlutterMacOS.h>
 
-@interface FLTPackageInfoPlugin : NSObject <FlutterPlugin>
+@interface FLTPackageInfoPlusPlugin : NSObject <FlutterPlugin>
 @end

--- a/packages/package_info_plus_macos/macos/Classes/FLTPackageInfoPlusPlugin.m
+++ b/packages/package_info_plus_macos/macos/Classes/FLTPackageInfoPlusPlugin.m
@@ -2,14 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import "FLTPackageInfoPlugin.h"
+#import "FLTPackageInfoPlusPlugin.h"
 
-@implementation FLTPackageInfoPlugin
+@implementation FLTPackageInfoPlusPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
   FlutterMethodChannel* channel =
       [FlutterMethodChannel methodChannelWithName:@"dev.fluttercommunity.plus/package_info"
                                   binaryMessenger:[registrar messenger]];
-  FLTPackageInfoPlugin* instance = [[FLTPackageInfoPlugin alloc] init];
+  FLTPackageInfoPlusPlugin* instance = [[FLTPackageInfoPlusPlugin alloc] init];
   [registrar addMethodCallDelegate:instance channel:channel];
 }
 

--- a/packages/package_info_plus_macos/pubspec.yaml
+++ b/packages/package_info_plus_macos/pubspec.yaml
@@ -8,7 +8,7 @@ flutter:
   plugin:
     platforms:
       macos:
-        pluginClass: FLTPackageInfoPlugin
+        pluginClass: FLTPackageInfoPlusPlugin
         fileName: package_info_plus_macos.dart
 
 environment:


### PR DESCRIPTION


## Description

* Renamed FLTPackageInfoPlugin to FLTPackageInfoPlusPlugin in order to avoid conflict with `package_info` plugin*

## Related Issues

fluttercommunity/plus_plugins#214

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
