### PR TITLE
Disable integration_test job until fixed

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -34,7 +34,7 @@ jobs:
 
   format:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - name: 'Git Checkout'
         uses: actions/checkout@v2

--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -106,6 +106,7 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
 
   integration_tests:
+    if: false # currently broken, see issue 220
     runs-on: ${{matrix.os}}
     strategy:
       matrix:


### PR DESCRIPTION
Job is currently broken, would be good to fix it but I don't have the knowledge to do it. I have created a ticket #220 to fix it, meanwhile let's disable it.