### PR TITLE
fix(share_plus): Fixed crash at launch on iOS 12.x and below (#222)

### DIFF
--- a/packages/share_plus/CHANGELOG.md
+++ b/packages/share_plus/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.2
+- Fixed crash on launch when running iOS 12.x and below
+
 ## 2.0.1
 - Added preview title to iOS share sheet
 

--- a/packages/share_plus/ios/share_plus.podspec
+++ b/packages/share_plus/ios/share_plus.podspec
@@ -17,7 +17,7 @@ Downloaded by pub (not CocoaPods).
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.ios.framework = 'LinkPresentation'
+  s.ios.weak_framework = 'LinkPresentation'
 
   s.platform = :ios, '8.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/packages/share_plus/pubspec.yaml
+++ b/packages/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 2.0.1
+version: 2.0.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

### Issue
When running on iOS 12.x and below, apps depending on share_plus 2.0.1 crash at startup

I was able to reproduce the issue in a new flutter app with a dependency on either
`share_plus: 2.0.1`
or
```
share_plus:
    path: path_to_local_repo/plus_plugins/packages/share_plus
```

I was not able to reproduce the issue in the share_plus example included in this repository. I'm not sure why

### Root cause

In Xcode, build settings show an other linker flag of `-framework LinkPresentation`. This creates a requirement of having the LinkPresentation framework available at launch. Since LinkPresentation is not available until iOS 13 and later, this caused apps running iOS 12.x and lower to crash

### Fix

Updated iOS Podspec to use a weak_framework link to LinkPresentation framework. This updates the other linker flag in the Xcode project build settings to be `-weak_framework LinkPresentation`

Weak framework links mark the framework as optional, so the code will work in earlier iOS versions where LinkPresentation does not exist

Previously, I had added `API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0)` to the one method that uses LinkPresentation, so this code path will not be called in iOS versions where LinkPresentation does not exist

### Testing

Everything below uses a new flutter app linking to a local share_plus repo

iOS Simulator running iOS 12.0 (iPhone 5s) 
- [x] without these changes --> crashes
- [x] with these changes --> launches successfully
- [x] opens share sheet successfully

iPhone 5s running iOS 10.3.4
- [x] without these changes --> crashes
- [x] with these changes --> launches successfully
- [x] opens share sheet successfully

iOS Simulator running iOS 14.4 (iPhone 12 mini) 
- [x] without these changes --> launches successfully
- [x] with these changes --> launches successfully
- [x] opens share sheet successfully

iPhone Xs running iOS 14.4.2
- [x] without these changes --> launches successfully
- [x] with these changes --> launches successfully
- [x] opens share sheet successfully

## Related Issues

#222 [share_plus] iOS 12 and lower crashes at launch due to missing LinkPresentation.framework

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
