### PR TITLE
catch handle  if the user cancels #201

### DIFF
--- a/packages/share_plus_web/lib/share_plus_web.dart
+++ b/packages/share_plus_web/lib/share_plus_web.dart
@@ -29,10 +29,12 @@ class SharePlusPlugin extends SharePlatform {
   }) async {
     try {
       await _navigator.share({'title': subject, 'text': text});
-    } catch (e) {
+    } on NoSuchMethodError catch (e) {
       //Navigator is not available or the webPage is not served on https
       final uri = Uri.encodeFull('mailto:?subject=$subject&body=$text');
       await launch(uri);
+    } catch (e) {
+      //Navigator share cancel
     }
   }
 


### PR DESCRIPTION
## Description

We should not open the email composer if the user cancels the sharing action.

## Related Issues

 [issue database](https://github.com/fluttercommunity/plus_plugins/issues/201)
