### PR TITLE
fix(network_info_plus_windows): Fix include order

### DIFF
--- a/packages/network_info_plus_windows/windows/include/network_info_plus_windows/network_info.h
+++ b/packages/network_info_plus_windows/windows/include/network_info_plus_windows/network_info.h
@@ -1,7 +1,9 @@
 #ifndef FLUTTER_PLUGIN_NETWORK_INFO_PLUS_NETWORK_INFO_H_
 #define FLUTTER_PLUGIN_NETWORK_INFO_PLUS_NETWORK_INFO_H_
 
+// clang-format off
 #include <winsock2.h>
+// clang-format on
 #include <windows.h>
 #include <winerror.h>
 #include <wlanapi.h>

--- a/packages/network_info_plus_windows/windows/include/network_info_plus_windows/network_info.h
+++ b/packages/network_info_plus_windows/windows/include/network_info_plus_windows/network_info.h
@@ -1,9 +1,9 @@
 #ifndef FLUTTER_PLUGIN_NETWORK_INFO_PLUS_NETWORK_INFO_H_
 #define FLUTTER_PLUGIN_NETWORK_INFO_PLUS_NETWORK_INFO_H_
 
+#include <winsock2.h>
 #include <windows.h>
 #include <winerror.h>
-#include <winsock2.h>
 #include <wlanapi.h>
 
 #include <functional>

--- a/packages/network_info_plus_windows/windows/network_info_plus_windows_plugin.cpp
+++ b/packages/network_info_plus_windows/windows/network_info_plus_windows_plugin.cpp
@@ -1,10 +1,10 @@
+#include "include/network_info_plus_windows/network_info.h"
 #include "include/network_info_plus_windows/network_info_plus_windows_plugin.h"
 
 #include <flutter/method_channel.h>
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
 
-#include "include/network_info_plus_windows/network_info.h"
 
 namespace {
 

--- a/packages/network_info_plus_windows/windows/network_info_plus_windows_plugin.cpp
+++ b/packages/network_info_plus_windows/windows/network_info_plus_windows_plugin.cpp
@@ -7,7 +7,6 @@
 #include <flutter/plugin_registrar_windows.h>
 #include <flutter/standard_method_codec.h>
 
-
 namespace {
 
 class NetworkInfoPlusWindowsPlugin : public flutter::Plugin {

--- a/packages/network_info_plus_windows/windows/network_info_plus_windows_plugin.cpp
+++ b/packages/network_info_plus_windows/windows/network_info_plus_windows_plugin.cpp
@@ -1,4 +1,6 @@
+// clang-format off
 #include "include/network_info_plus_windows/network_info.h"
+// clang-format on
 #include "include/network_info_plus_windows/network_info_plus_windows_plugin.h"
 
 #include <flutter/method_channel.h>


### PR DESCRIPTION
## Description

The current include order for network_info.h and network_info_plus_windows_plugin.cpp prevented the windows version to successfully run. See also the related issues. The wrong order seem to be caused by the melos format run as can be seen at d7f7f3f2ecceb0158fe879b7ac124a72d4d32637.

## Related Issues

#193 #202 #208 

## Checklist
Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

* [x]  I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
* [ ]  My PR includes unit or integration tests for _all_ changed/updated/fixed behaviors (See [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md)).
* [x]  All existing and new tests are passing.
* [x]  I updated/added relevant documentation (doc comments with `///`).
* [x]  The analyzer (`flutter analyze`) does not report any problems on my PR.
* [x]  I read and followed the [Flutter Style Guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo).
* [x]  I am willing to follow-up on review comments in a timely manner.

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?

* [ ]  Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
* [x] No, this is _not_ a breaking change.