### PR TITLE
fix(package_info_plus_linux): Use async functions in _getVersionJson()

### DIFF
--- a/packages/package_info_plus_linux/lib/src/package_info.dart
+++ b/packages/package_info_plus_linux/lib/src/package_info.dart
@@ -11,7 +11,7 @@ class PackageInfoLinux extends PackageInfoPlatform {
   /// appName, packageName, version, buildNumber
   @override
   Future<PackageInfoData> getAll() async {
-    final versionJson = _getVersionJson();
+    final versionJson = await _getVersionJson();
     return PackageInfoData(
       appName: versionJson['app_name'] ?? '',
       version: versionJson['version'] ?? '',
@@ -20,13 +20,13 @@ class PackageInfoLinux extends PackageInfoPlatform {
     );
   }
 
-  Map<String, dynamic> _getVersionJson() {
+  Future<Map<String, dynamic>> _getVersionJson() async {
     try {
-      final exePath = File('/proc/self/exe').resolveSymbolicLinksSync();
+      final exePath = await File('/proc/self/exe').resolveSymbolicLinks();
       final appPath = path.dirname(exePath);
       final assetPath = path.join(appPath, 'data', 'flutter_assets');
       final versionPath = path.join(assetPath, 'version.json');
-      return jsonDecode(File(versionPath).readAsStringSync());
+      return jsonDecode(await File(versionPath).readAsString());
     } catch (_) {
       return <String, dynamic>{};
     }


### PR DESCRIPTION
## Description

Currently, the `_getVersionJson()` function in package_info_plus_linux reads files synchronously. It's not reading much data, but on slow drives, it could cause issues (I've ran Linux on thumb drives that would take seconds to read a text file). I made the function asynchronous. This won't be a breaking change as `getAll()` (the only function that uses `_getVersionJson()`) was already asynchronous.

## Related Issues

None. Just noticed this myself and thought I'd fix it.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
