### PR TITLE
feat(share_plus): Updated iOS share sheet preview title to use subject when text is not set

### DIFF
--- a/packages/share_plus/CHANGELOG.md
+++ b/packages/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Updated iOS share sheet preview title to use subject when text is not set
+
 ## 2.1.0
 
 - Fixes #241 resolves issues with deprecations as of android API version 29 and replaces the requirement for external storage locations with an easy application cache usage.

--- a/packages/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -94,7 +94,11 @@ static NSString *const PLATFORM_CHANNEL = @"dev.fluttercommunity.plus/share";
     (UIActivityViewController *)activityViewController
     API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0)) {
   LPLinkMetadata *metadata = [[LPLinkMetadata alloc] init];
-  metadata.title = _text;
+  if ([_text length] > 0) {
+    metadata.title = _text;
+  } else if ([_subject length] > 0) {
+    metadata.title = _subject;
+  }
   return metadata;
 }
 

--- a/packages/share_plus/pubspec.yaml
+++ b/packages/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 2.1.0
+version: 2.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
 Updated iOS share sheet preview title to use subject when text is not set

## Description

Currently, the iOS share sheet preview tittle will show the value of the text parameter. If the text parameter is not set, then the share sheet preview title will be blank.

This change makes it so that the share sheet preview title will show the value of the subject parameter if it is set and the text parameter is not. If both text and subject are set, it will show the value of the text parameter.

This change was motivated by a comment by @TheJulianJES in https://github.com/fluttercommunity/plus_plugins/pull/207#issuecomment-845512546

Specifically, if he saves an image with text set to a value it will show the share sheet title preview correctly, but it will also save two files instead of the expected one: 
- the image
- an empty file named after the value of the text parameter

If he instead saves an image with text set to null and subject set to a value, it saves the image as expected (with no additional files saved), but the share sheet preview is blank.

This change makes it so that the second scenario above will show the subject in the share sheet preview title.

## Related Issues

https://github.com/fluttercommunity/plus_plugins/pull/207#issuecomment-845512546

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
