### PR TITLE
Do not remove the tearDownChannel onDetachedFromActivity.

### DIFF
--- a/packages/share_plus/CHANGELOG.md
+++ b/packages/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Do not tear down method channel onDetachedFromActivity.
+
 ## 2.1.0
 
 - Fixes #241 resolves issues with deprecations as of android API version 29 and replaces the requirement for external storage locations with an easy application cache usage.

--- a/packages/share_plus/android/src/main/java/dev/fluttercommunity/plus/share/SharePlusPlugin.java
+++ b/packages/share_plus/android/src/main/java/dev/fluttercommunity/plus/share/SharePlusPlugin.java
@@ -45,7 +45,7 @@ public class SharePlusPlugin implements FlutterPlugin, ActivityAware {
 
   @Override
   public void onDetachedFromActivity() {
-    tearDownChannel();
+    share.setActivity(null);
   }
 
   @Override
@@ -63,10 +63,5 @@ public class SharePlusPlugin implements FlutterPlugin, ActivityAware {
     share = new Share(context, activity);
     handler = new MethodCallHandler(share);
     methodChannel.setMethodCallHandler(handler);
-  }
-
-  private void tearDownChannel() {
-    share.setActivity(null);
-    methodChannel.setMethodCallHandler(null);
   }
 }

--- a/packages/share_plus/pubspec.yaml
+++ b/packages/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 2.1.0
+version: 2.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

We should not tear down the method channel onDetachedFromActivity. That will cause MissingPluginException for the following method calls.

## Related Issues

flutter/flutter#12264

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
