### PR TITLE
Add cache buster to packageinfo version.json

### DIFF
--- a/packages/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Add cache buster to version.json
+
 ## 1.0.1
 
 - Improve documentation

--- a/packages/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 1.0.1
+version: 1.0.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -28,7 +28,7 @@ dependencies:
   package_info_plus_linux: ^1.0.0
   package_info_plus_macos: ^1.0.0
   package_info_plus_windows: ^1.0.0
-  package_info_plus_web: ^1.0.0
+  package_info_plus_web: ^1.0.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/package_info_plus_web/CHANGELOG.md
+++ b/packages/package_info_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+- Add cache buster to version.json
+
 ## 1.0.1
 
 - Improve documentation

--- a/packages/package_info_plus_web/lib/package_info_plus_web.dart
+++ b/packages/package_info_plus_web/lib/package_info_plus_web.dart
@@ -17,8 +17,9 @@ class PackageInfoPlugin extends PackageInfoPlatform {
 
   @override
   Future<PackageInfoData> getAll() async {
+    final cacheBuster = DateTime.now().millisecondsSinceEpoch;
     final url = Uri.parse(
-        '${Uri.parse(window.document.baseUri!).removeFragment()}version.json');
+        '${Uri.parse(window.document.baseUri!).removeFragment()}version.json?cachebuster=$cacheBuster');
 
     final response = await get(url);
     final versionMap = _getVersionMap(response);

--- a/packages/package_info_plus_web/pubspec.yaml
+++ b/packages/package_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_web
 description: Web platform implementation of package_info_plus
-version: 1.0.1
+version: 1.0.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

Version.json can get cached on different servers due to cache policies. adding a cache buster can help to prevent this and returning real data all the time. 

## Related Issues
https://github.com/fluttercommunity/plus_plugins/issues/225

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
