### PR TITLE
fix(connectivity_plus): fixed the Java 15 compatibility

### DIFF
--- a/packages/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/android/build.gradle
@@ -36,4 +36,8 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 }


### PR DESCRIPTION
## Description

Fixes the Java 11-15 compatibility. 

When you're trying to compile project with Java 11-15 Gradle throws a warning about the byte code for Java 6/7. And because warnings are configured as errors (android/build.gradle:3) you're not able to compile project with `connectivity_plus` plugin and Java 11-15. This PR fixes this issue.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
