### PR TITLE
Added toMap method 

### DIFF
--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
@@ -110,6 +110,33 @@ class AndroidDeviceInfo {
   /// https://developer.android.com/reference/android/content/pm/PackageManager
   final List<String?> systemFeatures;
 
+  /// Serializes [ AndroidDeviceInfo ] to map.
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'host': host,
+      'tags': tags,
+      'type': type,
+      'model': model,
+      'board': board,
+      'brand': brand,
+      'device': device,
+      'product': product,
+      'display': display,
+      'hardware': hardware,
+      'androidId': androidId,
+      'bootloader': bootloader,
+      'version': version.toMap(),
+      'fingerprint': fingerprint,
+      'manufacturer': manufacturer,
+      'supportedAbis': supportedAbis,
+      'systemFeatures': systemFeatures,
+      'isPhysicalDevice': isPhysicalDevice,
+      'supported32BitAbis': supported32BitAbis,
+      'supported64BitAbis': supported64BitAbis,
+    };
+  }
+
   /// Deserializes from the message received from [_kChannel].
   static AndroidDeviceInfo fromMap(Map<String, dynamic> map) {
     return AndroidDeviceInfo(
@@ -150,7 +177,7 @@ class AndroidDeviceInfo {
 ///
 /// See: https://developer.android.com/reference/android/os/Build.VERSION.html
 class AndroidBuildVersion {
-  AndroidBuildVersion._({
+  const AndroidBuildVersion._({
     this.baseOS,
     this.codename,
     this.incremental,
@@ -182,6 +209,19 @@ class AndroidBuildVersion {
 
   /// The user-visible security patch level.
   final String? securityPatch;
+
+  /// Serializes [ AndroidBuildVersion ] to map.
+  Map<String, dynamic> toMap() {
+    return {
+      'baseOS': baseOS,
+      'sdkInt': sdkInt,
+      'release': release,
+      'codename': codename,
+      'incremental': incremental,
+      'previewSdkInt': previewSdkInt,
+      'securityPatch': securityPatch,
+    };
+  }
 
   /// Deserializes from the map message received from [_kChannel].
   static AndroidBuildVersion _fromMap(Map<String, dynamic> map) {

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/ios_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/ios_device_info.dart
@@ -7,7 +7,7 @@
 /// See: https://developer.apple.com/documentation/uikit/uidevice
 class IosDeviceInfo {
   /// IOS device info class.
-  IosDeviceInfo({
+  const IosDeviceInfo({
     this.name,
     this.systemName,
     this.systemVersion,
@@ -56,12 +56,26 @@ class IosDeviceInfo {
           IosUtsname._fromMap(map['utsname']?.cast<String, dynamic>() ?? {}),
     );
   }
+
+  /// Serializes [ IosDeviceInfo ] to a map.
+  Map<String, dynamic> toMap() {
+    return {
+      'name': name,
+      'model': model,
+      'systemName': systemName,
+      'utsname': utsname._toMap(),
+      'systemVersion': systemVersion,
+      'localizedModel': localizedModel,
+      'identifierForVendor': identifierForVendor,
+      'isPhysicalDevice': isPhysicalDevice.toString(),
+    };
+  }
 }
 
 /// Information derived from `utsname`.
 /// See http://pubs.opengroup.org/onlinepubs/7908799/xsh/sysutsname.h.html for details.
 class IosUtsname {
-  IosUtsname._({
+  const IosUtsname._({
     this.sysname,
     this.nodename,
     this.release,
@@ -93,5 +107,16 @@ class IosUtsname {
       version: map['version'],
       machine: map['machine'],
     );
+  }
+
+  /// Serializes [ IosUtsname ] to map.
+  Map<String, dynamic> _toMap() {
+    return {
+      'release': release,
+      'version': version,
+      'machine': machine,
+      'sysname': sysname,
+      'nodename': nodename,
+    };
   }
 }

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/macos_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/macos_device_info.dart
@@ -5,7 +5,7 @@
 /// Object encapsulating MACOS device information.
 class MacOsDeviceInfo {
   /// Constructs a MacOsDeviceInfo.
-  MacOsDeviceInfo({
+  const MacOsDeviceInfo({
     required this.computerName,
     required this.hostName,
     required this.arch,
@@ -47,6 +47,21 @@ class MacOsDeviceInfo {
 
   /// Device CPU Frequency
   final int cpuFrequency;
+
+  /// Serializes [ MacOsDeviceInfo ] to map.
+  Map<String, dynamic> toMap() {
+    return {
+      'arch': arch,
+      'model': model,
+      'hostName': hostName,
+      'osRelease': osRelease,
+      'activeCPUs': activeCPUs,
+      'memorySize': memorySize,
+      'cpuFrequency': cpuFrequency,
+      'computerName': computerName,
+      'kernelVersion': kernelVersion,
+    };
+  }
 
   /// Constructs a [MacOsDeviceInfo] from a Map of dynamic.
   static MacOsDeviceInfo fromMap(Map<dynamic, dynamic> map) {

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
@@ -1,0 +1,85 @@
+import 'package:device_info_plus_platform_interface/model/android_device_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('$AndroidDeviceInfo', () {
+    group('fromMap | toMap', () {
+      const androidBuildVersionMap = <String, dynamic>{
+        'sdkInt': 16,
+        'baseOS': 'baseOS',
+        'previewSdkInt': 30,
+        'release': 'release',
+        'codename': 'codename',
+        'incremental': 'incremental',
+        'securityPatch': 'securityPatch',
+      };
+      const supportedAbis = <String>['arm64-v8a', 'x86', 'x86_64'];
+      const supported32BitAbis = <String?>['x86 (IA-32)', 'MMX'];
+      const supported64BitAbis = <String?>['x86-64', 'MMX', 'SSSE3'];
+      const systemFeatures = ['FEATURE_AUDIO_PRO', 'FEATURE_AUDIO_OUTPUT'];
+      final androidDeviceInfoMap = <String, dynamic>{
+        'id': 'id',
+        'host': 'host',
+        'tags': 'tags',
+        'type': 'type',
+        'model': 'model',
+        'board': 'board',
+        'brand': 'brand',
+        'device': 'device',
+        'product': 'product',
+        'display': 'display',
+        'hardware': 'hardware',
+        'androidId': 'androidId',
+        'isPhysicalDevice': true,
+        'bootloader': 'bootloader',
+        'fingerprint': 'fingerprint',
+        'manufacturer': 'manufacturer',
+        'supportedAbis': supportedAbis,
+        'systemFeatures': systemFeatures,
+        'version': androidBuildVersionMap,
+        'supported64BitAbis': supported64BitAbis,
+        'supported32BitAbis': supported32BitAbis,
+      };
+
+      test('fromMap should return $AndroidDeviceInfo with correct values', () {
+        final androidDeviceInfo =
+            AndroidDeviceInfo.fromMap(androidDeviceInfoMap);
+
+        expect(androidDeviceInfo.id, 'id');
+        expect(androidDeviceInfo.host, 'host');
+        expect(androidDeviceInfo.tags, 'tags');
+        expect(androidDeviceInfo.type, 'type');
+        expect(androidDeviceInfo.model, 'model');
+        expect(androidDeviceInfo.board, 'board');
+        expect(androidDeviceInfo.brand, 'brand');
+        expect(androidDeviceInfo.device, 'device');
+        expect(androidDeviceInfo.product, 'product');
+        expect(androidDeviceInfo.display, 'display');
+        expect(androidDeviceInfo.hardware, 'hardware');
+        expect(androidDeviceInfo.androidId, 'androidId');
+        expect(androidDeviceInfo.bootloader, 'bootloader');
+        expect(androidDeviceInfo.isPhysicalDevice, isTrue);
+        expect(androidDeviceInfo.fingerprint, 'fingerprint');
+        expect(androidDeviceInfo.manufacturer, 'manufacturer');
+        expect(androidDeviceInfo.supportedAbis, supportedAbis);
+        expect(androidDeviceInfo.systemFeatures, systemFeatures);
+        expect(androidDeviceInfo.supported32BitAbis, supported32BitAbis);
+        expect(androidDeviceInfo.supported64BitAbis, supported64BitAbis);
+        expect(androidDeviceInfo.version.sdkInt, 16);
+        expect(androidDeviceInfo.version.baseOS, 'baseOS');
+        expect(androidDeviceInfo.version.previewSdkInt, 30);
+        expect(androidDeviceInfo.version.release, 'release');
+        expect(androidDeviceInfo.version.codename, 'codename');
+        expect(androidDeviceInfo.version.incremental, 'incremental');
+        expect(androidDeviceInfo.version.securityPatch, 'securityPatch');
+      });
+
+      test('toMap should return map with correct key and map', () {
+        final androidDeviceInfo =
+            AndroidDeviceInfo.fromMap(androidDeviceInfoMap);
+
+        expect(androidDeviceInfo.toMap(), androidDeviceInfoMap);
+      });
+    });
+  });
+}

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/ios_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/ios_device_info_test.dart
@@ -1,0 +1,48 @@
+import 'package:device_info_plus_platform_interface/model/ios_device_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('$IosDeviceInfo', () {
+    group('fromMap | toMap', () {
+      const iosUtsnameMap = <String, dynamic>{
+        'release': 'release',
+        'version': 'version',
+        'machine': 'machine',
+        'sysname': 'sysname',
+        'nodename': 'nodename',
+      };
+      const iosDeviceInfoMap = <String, dynamic>{
+        'name': 'name',
+        'model': 'model',
+        'utsname': iosUtsnameMap,
+        'systemName': 'systemName',
+        'isPhysicalDevice': 'true',
+        'systemVersion': 'systemVersion',
+        'localizedModel': 'localizedModel',
+        'identifierForVendor': 'identifierForVendor',
+      };
+
+      test('fromMap should return $IosDeviceInfo with correct values', () {
+        final iosDeviceInfo = IosDeviceInfo.fromMap(iosDeviceInfoMap);
+
+        expect(iosDeviceInfo.name, 'name');
+        expect(iosDeviceInfo.model, 'model');
+        expect(iosDeviceInfo.isPhysicalDevice, isTrue);
+        expect(iosDeviceInfo.systemName, 'systemName');
+        expect(iosDeviceInfo.systemVersion, 'systemVersion');
+        expect(iosDeviceInfo.localizedModel, 'localizedModel');
+        expect(iosDeviceInfo.utsname.release, 'release');
+        expect(iosDeviceInfo.utsname.version, 'version');
+        expect(iosDeviceInfo.utsname.machine, 'machine');
+        expect(iosDeviceInfo.utsname.sysname, 'sysname');
+        expect(iosDeviceInfo.utsname.nodename, 'nodename');
+      });
+
+      test('toMap should return map with correct key and map', () {
+        final iosDeviceInfo = IosDeviceInfo.fromMap(iosDeviceInfoMap);
+
+        expect(iosDeviceInfo.toMap(), iosDeviceInfoMap);
+      });
+    });
+  });
+}

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/macos_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/macos_device_info_test.dart
@@ -1,0 +1,38 @@
+import 'package:device_info_plus_platform_interface/model/macos_device_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('$MacOsDeviceInfo', () {
+    group('fromMap | toMap', () {
+      const macosDeviceInfoMap = <String, dynamic>{
+        'arch': 'arch',
+        'model': 'model',
+        'activeCPUs': 4,
+        'memorySize': 16,
+        'cpuFrequency': 2,
+        'hostName': 'hostName',
+        'osRelease': 'osRelease',
+        'computerName': 'computerName',
+        'kernelVersion': 'kernelVersion',
+      };
+
+      test('fromMap should return $MacOsDeviceInfo with correct values', () {
+        final macosDeviceInfo = MacOsDeviceInfo.fromMap(macosDeviceInfoMap);
+
+        expect(macosDeviceInfo.arch, 'arch');
+        expect(macosDeviceInfo.model, 'model');
+        expect(macosDeviceInfo.activeCPUs, 4);
+        expect(macosDeviceInfo.memorySize, 16);
+        expect(macosDeviceInfo.cpuFrequency, 2);
+        expect(macosDeviceInfo.hostName, 'hostName');
+        expect(macosDeviceInfo.osRelease, 'osRelease');
+      });
+
+      test('toMap should return map with correct key and map', () {
+        final macosDeviceInfo = MacOsDeviceInfo.fromMap(macosDeviceInfoMap);
+
+        expect(macosDeviceInfo.toMap(), macosDeviceInfoMap);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

Added toMap method on android, ios, and macOS device info models.

## Related Issues

Closes #259

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
