### PR TITLE
Fix connectivity_plus: Could not get unknown property 'javaToolchains' for task ':app:compileDebugAndroidTestJavaWithJavac'

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/android/build.gradle
@@ -18,21 +18,17 @@ rootProject.allprojects {
         google()
         mavenCentral()
     }
-    tasks.withType(JavaCompile).configureEach {
-    javaCompiler = javaToolchains.compilerFor {
-      languageVersion = JavaLanguageVersion.of(8)
-    }
-  }
-}
-
-project.getTasks().withType(JavaCompile){
-    options.compilerArgs.addAll(args)
 }
 
 apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 29
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
 
     defaultConfig {
         minSdkVersion 16

--- a/packages/connectivity_plus/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/android/build.gradle
@@ -18,6 +18,10 @@ rootProject.allprojects {
         google()
         mavenCentral()
     }
+
+    project.getTasks().withType(JavaCompile){
+        options.compilerArgs.addAll(args)
+    }
 }
 
 apply plugin: 'com.android.library'

--- a/packages/connectivity_plus/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/android/build.gradle
@@ -18,10 +18,6 @@ rootProject.allprojects {
         google()
         mavenCentral()
     }
-
-    project.getTasks().withType(JavaCompile){
-        options.compilerArgs.addAll(args)
-    }
 }
 
 apply plugin: 'com.android.library'


### PR DESCRIPTION
## Description

Hotfix of android java version used 
Error thrown:
`Could not get unknown property 'javaToolchains' for task ':app:compileDebugAndroidTestJavaWithJavac' of type com.android.build.gradle.tasks.AndroidJavaCompile.`

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/345
https://github.com/fluttercommunity/plus_plugins/issues/341

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
