### PR TITLE
connectivity_plus fix android memory leak (#326)

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5
+
+- Android: Fixed memory leak from registered receiver
+
 ## 1.0.4
 
 - Android: Add explicit compiler version to avoid warnings

--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityPlugin.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityPlugin.java
@@ -16,6 +16,7 @@ public class ConnectivityPlugin implements FlutterPlugin {
 
   private MethodChannel methodChannel;
   private EventChannel eventChannel;
+  private ConnectivityBroadcastReceiver receiver;
 
   /** Plugin registration. */
   @SuppressWarnings("deprecation")
@@ -45,8 +46,7 @@ public class ConnectivityPlugin implements FlutterPlugin {
 
     ConnectivityMethodChannelHandler methodChannelHandler =
         new ConnectivityMethodChannelHandler(connectivity);
-    ConnectivityBroadcastReceiver receiver =
-        new ConnectivityBroadcastReceiver(context, connectivity);
+    receiver = new ConnectivityBroadcastReceiver(context, connectivity);
 
     methodChannel.setMethodCallHandler(methodChannelHandler);
     eventChannel.setStreamHandler(receiver);
@@ -55,7 +55,9 @@ public class ConnectivityPlugin implements FlutterPlugin {
   private void teardownChannels() {
     methodChannel.setMethodCallHandler(null);
     eventChannel.setStreamHandler(null);
+    receiver.onCancel(null);
     methodChannel = null;
     eventChannel = null;
+    receiver = null;
   }
 }

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 1.0.4
+version: 1.0.5
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

connectivity_plus: Fix for an Android memory leak from a broadcast receiver which is not unregistered after the plugin is closed.
Android Broadcast receiver holds an instance of Android-Activity until it's unregistered.
This fix unregisters the receiver while tearing the plugin down.

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/326

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
