### PR TITLE
feat(battery_plus): add save power mode getter

### DIFF
--- a/packages/battery_plus/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Android, iOS, Windows : add getter for power save mode state
+
 ## 1.0.2
 
 - Android: migrate to mavenCentral

--- a/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
+++ b/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
@@ -15,9 +15,6 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.PowerManager;
 import android.provider.Settings;
-
-import java.util.Locale;
-
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
@@ -28,10 +25,9 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
+import java.util.Locale;
 
-/**
- * BatteryPlusPlugin
- */
+/** BatteryPlusPlugin */
 public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, FlutterPlugin {
 
   private Context applicationContext;
@@ -43,9 +39,7 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
   private static final int POWER_SAVE_MODE_XIAOMI = 1;
   private static final int POWER_SAVE_MODE_HUAWEI = 4;
 
-  /**
-   * Plugin registration.
-   */
+  /** Plugin registration. */
   public static void registerWith(PluginRegistry.Registrar registrar) {
     final BatteryPlusPlugin instance = new BatteryPlusPlugin();
     instance.onAttachedToEngine(registrar.context(), registrar.messenger());
@@ -100,7 +94,7 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
   public void onListen(Object arguments, EventSink events) {
     chargingStateChangeReceiver = createChargingStateChangeReceiver(events);
     applicationContext.registerReceiver(
-      chargingStateChangeReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+        chargingStateChangeReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
 
     int status = getBatteryProperty(BatteryManager.BATTERY_PROPERTY_STATUS);
     publishBatteryStatus(events, status);
@@ -118,11 +112,11 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
       batteryLevel = getBatteryProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
     } else {
       Intent intent =
-        new ContextWrapper(applicationContext)
-          .registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+          new ContextWrapper(applicationContext)
+              .registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
       batteryLevel =
-        (intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) * 100)
-          / intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+          (intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) * 100)
+              / intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
     }
 
     return batteryLevel;
@@ -132,17 +126,21 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
     String manufacturer = Build.MANUFACTURER.toLowerCase(Locale.getDefault());
     if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
       switch (manufacturer) {
-        case "xiaomi": {
-          return getPowerSaveModeForXiaomi();
-        }
-        case "huawei": {
-          return getPowerSaveModeHuawei();
-        }
-        case "samsung": {
-          return getPowerSaveModeSamsung();
-        }
+        case "xiaomi":
+          {
+            return getPowerSaveModeForXiaomi();
+          }
+        case "huawei":
+          {
+            return getPowerSaveModeHuawei();
+          }
+        case "samsung":
+          {
+            return getPowerSaveModeSamsung();
+          }
         default:
-          PowerManager powerManager = (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
+          PowerManager powerManager =
+              (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
           return powerManager.isPowerSaveMode();
       }
     }
@@ -155,7 +153,8 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
   }
 
   private Boolean getPowerSaveModeHuawei() {
-    int mode = Settings.System.getInt(applicationContext.getContentResolver(), "SmartModeStatus", -1);
+    int mode =
+        Settings.System.getInt(applicationContext.getContentResolver(), "SmartModeStatus", -1);
     if (mode != -1) {
       return (mode == POWER_SAVE_MODE_HUAWEI);
     }
@@ -163,17 +162,17 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
   }
 
   private Boolean getPowerSaveModeForXiaomi() {
-    int mode = Settings.System.getInt(applicationContext.getContentResolver(), "POWER_SAVE_MODE_OPEN", -1);
+    int mode =
+        Settings.System.getInt(applicationContext.getContentResolver(), "POWER_SAVE_MODE_OPEN", -1);
     if (mode != -1) {
       return (mode == POWER_SAVE_MODE_XIAOMI);
     }
     return null;
   }
 
-
   private int getBatteryProperty(int property) {
     BatteryManager batteryManager =
-      (BatteryManager) applicationContext.getSystemService(applicationContext.BATTERY_SERVICE);
+        (BatteryManager) applicationContext.getSystemService(applicationContext.BATTERY_SERVICE);
     return batteryManager.getIntProperty(property);
   }
 

--- a/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
+++ b/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
@@ -10,8 +10,14 @@ import android.content.ContextWrapper;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.BatteryManager;
+import android.os.Build;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
+import android.os.PowerManager;
+import android.provider.Settings;
+
+import java.util.Locale;
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
@@ -23,7 +29,9 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 
-/** BatteryPlusPlugin */
+/**
+ * BatteryPlusPlugin
+ */
 public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, FlutterPlugin {
 
   private Context applicationContext;
@@ -31,7 +39,13 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
   private MethodChannel methodChannel;
   private EventChannel eventChannel;
 
-  /** Plugin registration. */
+  public static final String POWER_SAVE_MODE_SAMSUNG = "1";
+  private static final int POWER_SAVE_MODE_XIAOMI = 1;
+  private static final int POWER_SAVE_MODE_HUAWEI = 4;
+
+  /**
+   * Plugin registration.
+   */
   public static void registerWith(PluginRegistry.Registrar registrar) {
     final BatteryPlusPlugin instance = new BatteryPlusPlugin();
     instance.onAttachedToEngine(registrar.context(), registrar.messenger());
@@ -69,6 +83,14 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
       } else {
         result.error("UNAVAILABLE", "Battery level not available.", null);
       }
+    } else if (call.method.equals("isInBatterySaveMode")) {
+      Boolean isInPowerSaveMode = this.isInPowerSaveMode();
+
+      if (isInPowerSaveMode != null) {
+        result.success(isInPowerSaveMode);
+      } else {
+        result.error("UNAVAILABLE", "Battery save mode not available.", null);
+      }
     } else {
       result.notImplemented();
     }
@@ -78,7 +100,7 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
   public void onListen(Object arguments, EventSink events) {
     chargingStateChangeReceiver = createChargingStateChangeReceiver(events);
     applicationContext.registerReceiver(
-        chargingStateChangeReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+      chargingStateChangeReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
 
     int status = getBatteryProperty(BatteryManager.BATTERY_PROPERTY_STATUS);
     publishBatteryStatus(events, status);
@@ -96,19 +118,62 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
       batteryLevel = getBatteryProperty(BatteryManager.BATTERY_PROPERTY_CAPACITY);
     } else {
       Intent intent =
-          new ContextWrapper(applicationContext)
-              .registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
+        new ContextWrapper(applicationContext)
+          .registerReceiver(null, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
       batteryLevel =
-          (intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) * 100)
-              / intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+        (intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1) * 100)
+          / intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
     }
 
     return batteryLevel;
   }
 
+  private Boolean isInPowerSaveMode() {
+    String manufacturer = Build.MANUFACTURER.toLowerCase(Locale.getDefault());
+    if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+      switch (manufacturer) {
+        case "xiaomi": {
+          return getPowerSaveModeForXiaomi();
+        }
+        case "huawei": {
+          return getPowerSaveModeHuawei();
+        }
+        case "samsung": {
+          return getPowerSaveModeSamsung();
+        }
+        default:
+          PowerManager powerManager = (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
+          return powerManager.isPowerSaveMode();
+      }
+    }
+    return null;
+  }
+
+  private boolean getPowerSaveModeSamsung() {
+    String mode = Settings.System.getString(applicationContext.getContentResolver(), "psm_switch");
+    return (mode.equals(POWER_SAVE_MODE_SAMSUNG));
+  }
+
+  private Boolean getPowerSaveModeHuawei() {
+    int mode = Settings.System.getInt(applicationContext.getContentResolver(), "SmartModeStatus", -1);
+    if (mode != -1) {
+      return (mode == POWER_SAVE_MODE_HUAWEI);
+    }
+    return null;
+  }
+
+  private Boolean getPowerSaveModeForXiaomi() {
+    int mode = Settings.System.getInt(applicationContext.getContentResolver(), "POWER_SAVE_MODE_OPEN", -1);
+    if (mode != -1) {
+      return (mode == POWER_SAVE_MODE_XIAOMI);
+    }
+    return null;
+  }
+
+
   private int getBatteryProperty(int property) {
     BatteryManager batteryManager =
-        (BatteryManager) applicationContext.getSystemService(applicationContext.BATTERY_SERVICE);
+      (BatteryManager) applicationContext.getSystemService(applicationContext.BATTERY_SERVICE);
     return batteryManager.getIntProperty(property);
   }
 

--- a/packages/battery_plus/battery_plus/example/lib/main.dart
+++ b/packages/battery_plus/battery_plus/example/lib/main.dart
@@ -59,28 +59,53 @@ class _MyHomePageState extends State<MyHomePage> {
         title: const Text('Plugin example app'),
       ),
       body: Center(
-        child: Text('$_batteryState'),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () async {
-          final batteryLevel = await _battery.batteryLevel;
-          // ignore: unawaited_futures
-          showDialog<void>(
-            context: context,
-            builder: (_) => AlertDialog(
-              content: Text('Battery: $batteryLevel%'),
-              actions: <Widget>[
-                TextButton(
-                  onPressed: () {
-                    Navigator.pop(context);
-                  },
-                  child: const Text('OK'),
-                )
-              ],
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text('$_batteryState'),
+            ElevatedButton(
+              onPressed: () async {
+                final batteryLevel = await _battery.batteryLevel;
+                // ignore: unawaited_futures
+                showDialog<void>(
+                  context: context,
+                  builder: (_) => AlertDialog(
+                    content: Text('Battery: $batteryLevel%'),
+                    actions: <Widget>[
+                      TextButton(
+                        onPressed: () {
+                          Navigator.pop(context);
+                        },
+                        child: const Text('OK'),
+                      )
+                    ],
+                  ),
+                );
+              },
+              child: const Icon(Icons.battery_unknown),
             ),
-          );
-        },
-        child: const Icon(Icons.battery_unknown),
+            ElevatedButton(
+                onPressed: () async {
+                  final isInPowerSaveMode = await _battery.isInBatterySaveMode;
+                  // ignore: unawaited_futures
+                  showDialog<void>(
+                    context: context,
+                    builder: (_) => AlertDialog(
+                      content: Text('isOnPowerSaveMode: $isInPowerSaveMode'),
+                      actions: <Widget>[
+                        TextButton(
+                          onPressed: () {
+                            Navigator.pop(context);
+                          },
+                          child: const Text('OK'),
+                        )
+                      ],
+                    ),
+                  );
+                },
+                child: const Icon(Icons.power_settings_new_rounded))
+          ],
+        ),
       ),
     );
   }

--- a/packages/battery_plus/battery_plus/example/lib/main.dart
+++ b/packages/battery_plus/battery_plus/example/lib/main.dart
@@ -82,7 +82,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   ),
                 );
               },
-              child: const Icon(Icons.battery_unknown),
+              child: const Text('Get battery level'),
             ),
             ElevatedButton(
                 onPressed: () async {
@@ -91,7 +91,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   showDialog<void>(
                     context: context,
                     builder: (_) => AlertDialog(
-                      content: Text('isOnPowerSaveMode: $isInPowerSaveMode'),
+                      content: Text('Is on low power mode: $isInPowerSaveMode'),
                       actions: <Widget>[
                         TextButton(
                           onPressed: () {
@@ -103,7 +103,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     ),
                   );
                 },
-                child: const Icon(Icons.power_settings_new_rounded))
+                child: const Text('Is on low power mode'))
           ],
         ),
       ),

--- a/packages/battery_plus/battery_plus/example/test_driver/battery_plus_e2e.dart
+++ b/packages/battery_plus/battery_plus/example/test_driver/battery_plus_e2e.dart
@@ -16,4 +16,12 @@ void main() {
     final batteryLevel = await battery.batteryLevel;
     expect(batteryLevel, isNotNull);
   });
+
+
+  testWidgets('Can get if device is in power mode', (WidgetTester tester) async {
+    final battery = Battery();
+    final isInBatterySaveMode = await battery.isInBatterySaveMode;
+    print(isInBatterySaveMode);
+    expect(isInBatterySaveMode, isNotNull);
+  });
 }

--- a/packages/battery_plus/battery_plus/example/test_driver/battery_plus_e2e.dart
+++ b/packages/battery_plus/battery_plus/example/test_driver/battery_plus_e2e.dart
@@ -17,8 +17,8 @@ void main() {
     expect(batteryLevel, isNotNull);
   });
 
-
-  testWidgets('Can get if device is in power mode', (WidgetTester tester) async {
+  testWidgets('Can get if device is in power mode',
+      (WidgetTester tester) async {
     final battery = Battery();
     final isInBatterySaveMode = await battery.isInBatterySaveMode;
     print(isInBatterySaveMode);

--- a/packages/battery_plus/battery_plus/ios/Classes/FLTBatteryPlusPlugin.m
+++ b/packages/battery_plus/battery_plus/ios/Classes/FLTBatteryPlusPlugin.m
@@ -36,9 +36,9 @@
       result(@(batteryLevel));
     }
   } else if ([@"isInBatterySaveMode" isEqualToString:call.method]) {
-      result(@([[NSProcessInfo processInfo] isLowPowerModeEnabled]));
+    result(@([[NSProcessInfo processInfo] isLowPowerModeEnabled]));
   } else {
-      result(FlutterMethodNotImplemented);
+    result(FlutterMethodNotImplemented);
   }
 }
 

--- a/packages/battery_plus/battery_plus/ios/Classes/FLTBatteryPlusPlugin.m
+++ b/packages/battery_plus/battery_plus/ios/Classes/FLTBatteryPlusPlugin.m
@@ -35,8 +35,10 @@
     } else {
       result(@(batteryLevel));
     }
+  } else if ([@"isInBatterySaveMode" isEqualToString:call.method]) {
+      result(@([[NSProcessInfo processInfo] isLowPowerModeEnabled]));
   } else {
-    result(FlutterMethodNotImplemented);
+      result(FlutterMethodNotImplemented);
   }
 }
 

--- a/packages/battery_plus/battery_plus/lib/battery_plus.dart
+++ b/packages/battery_plus/battery_plus/lib/battery_plus.dart
@@ -55,6 +55,11 @@ class Battery {
     return _platform.batteryLevel;
   }
 
+    /// check if device is on battery save mode
+  Future<bool> get isInBatterySaveMode {
+    return _platform.isInBatterySaveMode;
+  }
+
   /// Fires whenever the battery state changes.
   Stream<BatteryState> get onBatteryStateChanged {
     return _platform.onBatteryStateChanged;

--- a/packages/battery_plus/battery_plus/lib/battery_plus.dart
+++ b/packages/battery_plus/battery_plus/lib/battery_plus.dart
@@ -55,7 +55,7 @@ class Battery {
     return _platform.batteryLevel;
   }
 
-    /// check if device is on battery save mode
+  /// check if device is on battery save mode
   Future<bool> get isInBatterySaveMode {
     return _platform.isInBatterySaveMode;
   }

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 1.0.2
+version: 1.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/battery_plus/battery_plus/test/battery_test.dart
+++ b/packages/battery_plus/battery_plus/test/battery_test.dart
@@ -20,6 +20,9 @@ class MockBatteryPlatform
 
   @override
   Stream<BatteryState> get onBatteryStateChanged => controller.stream;
+
+  @override
+  Future<bool> get isInBatterySaveMode => Future.value(true);
 }
 
 void main() {
@@ -34,6 +37,10 @@ void main() {
 
   test('batteryLevel', () async {
     expect(await battery.batteryLevel, 42);
+  });
+
+  test('isInBatterySaveMode', () async {
+    expect(await battery.isInBatterySaveMode, true);
   });
 
   group('battery state', () {

--- a/packages/battery_plus/battery_plus_platform_interface/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.1.0
+
+- Add method channel for power save mode state
 ## 1.0.1
 
 - Improve documentation

--- a/packages/battery_plus/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
@@ -42,6 +42,11 @@ abstract class BatteryPlatform extends PlatformInterface {
     throw UnimplementedError('batteryLevel() has not been implemented.');
   }
 
+  /// Returns true if the device is on battery save mode
+  Future<bool> get isInBatterySaveMode {
+    throw UnimplementedError('isInBatterySaveMode() has not been implemented.');
+  }
+
   /// Returns a Stream of BatteryState changes.
   Stream<BatteryState> get onBatteryStateChanged {
     throw UnimplementedError(

--- a/packages/battery_plus/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
@@ -31,6 +31,12 @@ class MethodChannelBattery extends BatteryPlatform {
       .invokeMethod<int>('getBatteryLevel')
       .then<int>((dynamic result) => result);
 
+  /// Returns true if the device is on battery save mode
+  @override
+  Future<bool> get isInBatterySaveMode => methodChannel
+      .invokeMethod<bool>('isInBatterySaveMode')
+      .then<bool>((dynamic result) => result);
+
   /// Fires whenever the battery state changes.
   @override
   Stream<BatteryState> get onBatteryStateChanged {

--- a/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_platform_interface
 description: A common platform interface for the battery_plus plugin.
-version: 1.0.1
+version: 1.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/battery_plus/battery_plus_platform_interface/test/battery_plus_platform_interface_test.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/test/battery_plus_platform_interface_test.dart
@@ -19,6 +19,8 @@ void main() {
         switch (methodCall.method) {
           case 'getBatteryLevel':
             return 100;
+          case 'isInBatterySaveMode':
+            return true;
           default:
             return null;
         }
@@ -56,6 +58,20 @@ void main() {
         <Matcher>[
           isMethodCall(
             'getBatteryLevel',
+            arguments: null,
+          ),
+        ],
+      );
+    });
+
+    test('isInBatterySaveMode', () async {
+      final result = await methodChannelBattery.isInBatterySaveMode;
+      expect(result, true);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'isInBatterySaveMode',
             arguments: null,
           ),
         ],

--- a/packages/battery_plus/battery_plus_windows/windows/battery_plus_windows_plugin.cpp
+++ b/packages/battery_plus/battery_plus_windows/windows/battery_plus_windows_plugin.cpp
@@ -137,7 +137,17 @@ BatteryStatusStreamHandler::OnCancelInternal(
 
 void BatteryPlusWindowsPlugin::HandleMethodCall(
     const FlMethodCall &method_call, std::unique_ptr<FlMethodResult> result) {
-  if (method_call.method_name().compare("getBatteryLevel") == 0) {
+  if (method_call.method_name().compare("isInBatterySaveMode") == 0) {
+    SystemBattery battery;
+    int batteryStatus = battery.GetBatterySaveMode();
+    if (batteryStatus == 0 || batteryStatus == 1) {
+      bool isBatteryMode = batteryStatus == 1;
+      result->Success(flutter::EncodableValue(isBatteryMode));
+    } else {
+      result->Error(std::to_string(battery.GetError()),
+                    battery.GetErrorString());
+    }
+  } else if (method_call.method_name().compare("getBatteryLevel") == 0) {
     SystemBattery battery;
     int level = battery.GetLevel();
     if (level >= 0) {

--- a/packages/battery_plus/battery_plus_windows/windows/include/battery_plus_windows/system_battery.h
+++ b/packages/battery_plus/battery_plus_windows/windows/include/battery_plus_windows/system_battery.h
@@ -16,6 +16,7 @@ class SystemBattery {
   SystemBattery();
   ~SystemBattery();
 
+  int GetBatterySaveMode() const;
   int GetLevel() const;
 
   BatteryStatus GetStatus() const;

--- a/packages/battery_plus/battery_plus_windows/windows/system_battery.cpp
+++ b/packages/battery_plus/battery_plus_windows/windows/system_battery.cpp
@@ -36,6 +36,14 @@ SystemBattery::SystemBattery() {}
 
 SystemBattery::~SystemBattery() { StopListen(); }
 
+int SystemBattery::GetBatterySaveMode() const {
+  SYSTEM_POWER_STATUS status;
+  if (!GetBatteryStatus(&status)) {
+    return -1;
+  }
+  return status.SystemStatusFlag;
+}
+
 int SystemBattery::GetLevel() const {
   SYSTEM_POWER_STATUS status;
   if (!GetBatteryStatus(&status) || !IsValidBatteryStatus(&status)) {


### PR DESCRIPTION
## Description

Adding save power mode getter  in order to disable some functionalities if the device is in battery-save mode.
Only **Android**, **iOS** && **Windows** (thanks to @mzdm) are done for now, need some help for other platforms.


I try to run `melos run format` but without success even in a clean clone.

## Related Issues

#229 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
