### PR TITLE
doc: Callback needs to be static

### DIFF
--- a/packages/android_alarm_manager_plus/README.md
+++ b/packages/android_alarm_manager_plus/README.md
@@ -48,7 +48,7 @@ Then in Dart code add:
 ```dart
 import 'package:android_alarm_manager_plus/android_alarm_manager_plus.dart';
 
-void printHello() {
+static void printHello() {
   final DateTime now = DateTime.now();
   final int isolateId = Isolate.current.hashCode;
   print("[$now] Hello, world! isolate=${isolateId} function='$printHello'");


### PR DESCRIPTION
I can't make the code from readme work, but the example app works.

By comparing the two, somehow `static` is missing in the example in readme and the alarm won't set without it.
