### PR TITLE
fix(connectivity-plus): fix unregisterReceiver call

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.6
+
+- Android: Fix unregisterReceiver call for API < N
+
 ## 1.0.5
 
 - Android: Fix memory leak from registered receiver

--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
@@ -67,7 +67,11 @@ public class ConnectivityBroadcastReceiver extends BroadcastReceiver
         networkCallback = null;
       }
     } else {
-      context.unregisterReceiver(this);
+      try {
+        context.unregisterReceiver(this);
+      } catch (Exception e) {
+        //listen never called, ignore the error
+      }
     }
   }
 

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 1.0.5
+version: 1.0.6
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
We are calling `unregisterReceiver` even if a call to `onListen` (which calls `registerReceiver` for API < N) has never been requested by consumer.
This happen if the package is used to one-shot check connectivity and not using the connectivity change stream events.

An alternative to this fix would be to track the onListen call with a boolean flag and call `unregisterReceiver` only if the flag has been set to true in `onListen`, let me know if you like this approach more.
 
Closes #358, #367
