### PR TITLE
[package_info_plus] docs: simplifies the usage

### DIFF
--- a/docs/package_info_plus/usage.mdx
+++ b/docs/package_info_plus/usage.mdx
@@ -20,17 +20,6 @@ String version = packageInfo.version;
 String buildNumber = packageInfo.buildNumber;
 ```
 
-Or in async mode:
-
-```dart
-PackageInfo.fromPlatform().then((PackageInfo packageInfo) {
-  String appName = packageInfo.appName;
-  String packageName = packageInfo.packageName;
-  String version = packageInfo.version;
-  String buildNumber = packageInfo.buildNumber;
-});
-```
-
 ## Known Issue
 
 As noted on [issue 20761](https://github.com/flutter/flutter/issues/20761#issuecomment-493434578), package_info on iOS

--- a/packages/package_info_plus/package_info_plus/README.md
+++ b/packages/package_info_plus/package_info_plus/README.md
@@ -32,17 +32,6 @@ String version = packageInfo.version;
 String buildNumber = packageInfo.buildNumber;
 ```
 
-Or in async mode:
-
-```dart
-PackageInfo.fromPlatform().then((PackageInfo packageInfo) {
-  String appName = packageInfo.appName;
-  String packageName = packageInfo.packageName;
-  String version = packageInfo.version;
-  String buildNumber = packageInfo.buildNumber;
-});
-```
-
 ## Known Issues
 
 ### iOS


### PR DESCRIPTION
## Description

This PR simplifies the **README** of [package_info_plus](pub.dev/packages/package_info_plus) by removing the usage section with `.then` notation.

## Related Issues

Closes #315.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.