### PR TITLE
feat: get scheduled alarms functionality added.

### DIFF
--- a/packages/android_alarm_manager_plus/CHANGELOG.md
+++ b/packages/android_alarm_manager_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Added method to obtain the list of scheduled alarms (thanks @Chinmay-KB)
+
 ## 1.0.2
 
 - Android: migrate to mavenCentral

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmBroadcastReceiver.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmBroadcastReceiver.java
@@ -29,15 +29,14 @@ public class AlarmBroadcastReceiver extends BroadcastReceiver {
   @Override
   public void onReceive(Context context, Intent intent) {
     AlarmService.enqueueAlarmProcessing(context, intent);
-    int requestCode = intent.getIntExtra("id",0);
+    int requestCode = intent.getIntExtra("id", 0);
     Log.d("Scheduled alarms list", String.valueOf(requestCode));
     // If the alarm being fired is a oneshot alarm, it should be removed from the list of scheduled
     //alarms.
     try {
-      ScheduledAlarmsList.removeFromScheduledAlarmsList(requestCode,context, true);
+      ScheduledAlarmsList.removeFromScheduledAlarmsList(requestCode, context, true);
     } catch (JSONException e) {
       e.printStackTrace();
     }
-
   }
 }

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmBroadcastReceiver.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmBroadcastReceiver.java
@@ -7,6 +7,8 @@ package dev.fluttercommunity.plus.androidalarmmanager;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.util.Log;
+import org.json.JSONException;
 
 public class AlarmBroadcastReceiver extends BroadcastReceiver {
   /**
@@ -27,5 +29,15 @@ public class AlarmBroadcastReceiver extends BroadcastReceiver {
   @Override
   public void onReceive(Context context, Intent intent) {
     AlarmService.enqueueAlarmProcessing(context, intent);
+    int requestCode = intent.getIntExtra("id",0);
+    Log.d("Scheduled alarms list", String.valueOf(requestCode));
+    // If the alarm being fired is a oneshot alarm, it should be removed from the list of scheduled
+    //alarms.
+    try {
+      ScheduledAlarmsList.removeFromScheduledAlarmsList(requestCode,context, true);
+    } catch (JSONException e) {
+      e.printStackTrace();
+    }
+
   }
 }

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -125,20 +125,36 @@ public class AndroidAlarmManagerPlugin implements FlutterPlugin, MethodCallHandl
         // task.
         PeriodicRequest periodicRequest = PeriodicRequest.fromJson((JSONArray) arguments);
         AlarmService.setPeriodic(context, periodicRequest);
+        ScheduledAlarmsList.addToScheduledAlarmsList(
+          ScheduledAlarmsList.toJson(periodicRequest),
+          context
+        );
         result.success(true);
       } else if (method.equals("Alarm.oneShotAt")) {
         // This message indicates that the Flutter app would like to schedule a one-time
         // task.
         OneShotRequest oneShotRequest = OneShotRequest.fromJson((JSONArray) arguments);
         AlarmService.setOneShot(context, oneShotRequest);
+        ScheduledAlarmsList.addToScheduledAlarmsList(
+          ScheduledAlarmsList.toJson(oneShotRequest),
+          context
+        );
         result.success(true);
       } else if (method.equals("Alarm.cancel")) {
         // This message indicates that the Flutter app would like to cancel a previously
         // scheduled task.
         int requestCode = ((JSONArray) arguments).getInt(0);
         AlarmService.cancel(context, requestCode);
+        // A periodic alarm is not automatically removed when it triggers once, it needs to be
+        // cancelled manually. We need to remove that periodic alarm from list of scheduled alarms
+        // as well.
+        ScheduledAlarmsList.removeFromScheduledAlarmsList(requestCode,context, false);
         result.success(true);
-      } else {
+      } else if(method.equals("Alarm.scheduledAlarms")){
+        // Returns a json array of alarm info, converted to string.
+        result.success(ScheduledAlarmsList.getScheduledAlarms(context));
+      }
+      else {
         result.notImplemented();
       }
     } catch (JSONException e) {

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -126,9 +126,7 @@ public class AndroidAlarmManagerPlugin implements FlutterPlugin, MethodCallHandl
         PeriodicRequest periodicRequest = PeriodicRequest.fromJson((JSONArray) arguments);
         AlarmService.setPeriodic(context, periodicRequest);
         ScheduledAlarmsList.addToScheduledAlarmsList(
-          ScheduledAlarmsList.toJson(periodicRequest),
-          context
-        );
+            ScheduledAlarmsList.toJson(periodicRequest), context);
         result.success(true);
       } else if (method.equals("Alarm.oneShotAt")) {
         // This message indicates that the Flutter app would like to schedule a one-time
@@ -136,9 +134,7 @@ public class AndroidAlarmManagerPlugin implements FlutterPlugin, MethodCallHandl
         OneShotRequest oneShotRequest = OneShotRequest.fromJson((JSONArray) arguments);
         AlarmService.setOneShot(context, oneShotRequest);
         ScheduledAlarmsList.addToScheduledAlarmsList(
-          ScheduledAlarmsList.toJson(oneShotRequest),
-          context
-        );
+            ScheduledAlarmsList.toJson(oneShotRequest), context);
         result.success(true);
       } else if (method.equals("Alarm.cancel")) {
         // This message indicates that the Flutter app would like to cancel a previously
@@ -148,13 +144,12 @@ public class AndroidAlarmManagerPlugin implements FlutterPlugin, MethodCallHandl
         // A periodic alarm is not automatically removed when it triggers once, it needs to be
         // cancelled manually. We need to remove that periodic alarm from list of scheduled alarms
         // as well.
-        ScheduledAlarmsList.removeFromScheduledAlarmsList(requestCode,context, false);
+        ScheduledAlarmsList.removeFromScheduledAlarmsList(requestCode, context, false);
         result.success(true);
-      } else if(method.equals("Alarm.scheduledAlarms")){
+      } else if (method.equals("Alarm.scheduledAlarms")) {
         // Returns a json array of alarm info, converted to string.
         result.success(ScheduledAlarmsList.getScheduledAlarms(context));
-      }
-      else {
+      } else {
         result.notImplemented();
       }
     } catch (JSONException e) {

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/ScheduledAlarmsList.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/ScheduledAlarmsList.java
@@ -4,25 +4,21 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.util.Log;
-
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+import java.util.HashSet;
+import java.util.Set;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.util.HashSet;
-import java.util.Set;
-
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel;
-
 /**
- * This class does not affect the behaviour of the alarms, just lists all the scheduled alarms.
- * All the data is stored as a Set<String>, with each element of this set being a JSONObject which
- * is converted to a string. As data passed from flutter is assigned to PeriodicRequest or
+ * This class does not affect the behaviour of the alarms, just lists all the scheduled alarms. All
+ * the data is stored as a Set<String>, with each element of this set being a JSONObject which is
+ * converted to a string. As data passed from flutter is assigned to PeriodicRequest or
  * OneShotRequest, this class consists an overloaded function which serializes these objects into
  * JSONObjects. This helps while storing data in shared preferences and easy access to the key
  * values of the alarm.
  */
-
 public class ScheduledAlarmsList {
   private static final String TAG = "Scheduled alarms list";
   private static final String SCHEDULED_ALARMS_SP_KEY = "scheduled_alarms_sp_key";
@@ -35,7 +31,8 @@ public class ScheduledAlarmsList {
    * @return a json object representation of periodic alarm data.
    * @throws JSONException
    */
-  public static JSONObject toJson(AndroidAlarmManagerPlugin.PeriodicRequest periodicRequest) throws JSONException {
+  public static JSONObject toJson(AndroidAlarmManagerPlugin.PeriodicRequest periodicRequest)
+      throws JSONException {
     JSONObject jsonObject = new JSONObject();
     jsonObject.put("requestCode", periodicRequest.requestCode);
     jsonObject.put("exact", periodicRequest.exact);
@@ -55,7 +52,8 @@ public class ScheduledAlarmsList {
    * @return a json object representation of one shot alarm data.
    * @throws JSONException
    */
-  public static JSONObject toJson(AndroidAlarmManagerPlugin.OneShotRequest oneShotRequest) throws JSONException {
+  public static JSONObject toJson(AndroidAlarmManagerPlugin.OneShotRequest oneShotRequest)
+      throws JSONException {
     JSONObject jsonObject = new JSONObject();
     jsonObject.put("requestCode", oneShotRequest.requestCode);
     jsonObject.put("alarmClock", oneShotRequest.alarmClock);
@@ -75,24 +73,23 @@ public class ScheduledAlarmsList {
    * @param jsonObject Data about the type of alarm and its corresponding information.
    * @param context
    */
-
   public static void addToScheduledAlarmsList(JSONObject jsonObject, Context context) {
-    SharedPreferences prefs = context.getSharedPreferences(SCHEDULED_ALARMS_SP_KEY, Context.MODE_PRIVATE);
+    SharedPreferences prefs =
+        context.getSharedPreferences(SCHEDULED_ALARMS_SP_KEY, Context.MODE_PRIVATE);
     Set<String> listFromPrefs = prefs.getStringSet(SCHEDULED_ALARMS_LIST_KEY, null);
     Set<String> scheduledList = new HashSet<>();
-    if (listFromPrefs != null)
-      scheduledList.addAll(listFromPrefs);
+    if (listFromPrefs != null) scheduledList.addAll(listFromPrefs);
     /*
-      We find the following note in the Android API
+     We find the following note in the Android API
 
-      "Note that you must not modify the set instance returned by this call. The consistency of the
-      stored data is not guaranteed if you do, nor is your ability to modify the instance at all.".
+     "Note that you must not modify the set instance returned by this call. The consistency of the
+     stored data is not guaranteed if you do, nor is your ability to modify the instance at all.".
 
-      Hence the list is first fetched from Shared Preferences and then is made a copy of. All
-      mutations are done on that copy and is reassigned back to Shared preference in the same key.
-      Not doing so throws erroneous results.
+     Hence the list is first fetched from Shared Preferences and then is made a copy of. All
+     mutations are done on that copy and is reassigned back to Shared preference in the same key.
+     Not doing so throws erroneous results.
 
-     */
+    */
     scheduledList.add(jsonObject.toString());
     SharedPreferences.Editor editor = prefs.edit();
     editor.putStringSet(SCHEDULED_ALARMS_LIST_KEY, scheduledList);
@@ -103,37 +100,36 @@ public class ScheduledAlarmsList {
 
   /**
    * Removes alarm info for a given request code. This function has to handle two cases
+   *
    * <ol>
-   *   <li>
-   *     Oneshot alarms - These alarms will fire only once. Hence the plugin has to remove it from
-   *     the list of scheduled alarms as and when it is fired. {@link AlarmBroadcastReceiver}
-   *     overrides an {@link AlarmBroadcastReceiver#onReceive(Context, Intent)} which is fired
-   *     everytime an alarm is fired, regardless of it being a periodic alarm or oneshot. So in this
-   *     case the plugin first checks if alarm data with the same requestCode exists in the
-   *     shared preferences. If yes, then it checks whether the alarm data is for a periodic alarm
-   *     or an oneshot alarm. If it is oneshot then that data is removed from the set.
-   *   </li>
-   *   <li>
-   *     Periodic alarms- Peroidic alarms can only be removed manualy. This happens when the
-   *     {@link AlarmService#cancel(Context, int)} is called from
-   *     {@link AndroidAlarmManagerPlugin#onMethodCall(MethodCall, MethodChannel.Result)}. In this
-   *     case both oneshot and periodic alarms can be cancelled. Hence the plugin does not check for
-   *     the alarm type and removes the alarm data upon getting a match on the requestCode.
-   *   </li>
+   *   <li>Oneshot alarms - These alarms will fire only once. Hence the plugin has to remove it from
+   *       the list of scheduled alarms as and when it is fired. {@link AlarmBroadcastReceiver}
+   *       overrides an {@link AlarmBroadcastReceiver#onReceive(Context, Intent)} which is fired
+   *       everytime an alarm is fired, regardless of it being a periodic alarm or oneshot. So in
+   *       this case the plugin first checks if alarm data with the same requestCode exists in the
+   *       shared preferences. If yes, then it checks whether the alarm data is for a periodic alarm
+   *       or an oneshot alarm. If it is oneshot then that data is removed from the set.
+   *   <li>Periodic alarms- Peroidic alarms can only be removed manualy. This happens when the
+   *       {@link AlarmService#cancel(Context, int)} is called from {@link
+   *       AndroidAlarmManagerPlugin#onMethodCall(MethodCall, MethodChannel.Result)}. In this case
+   *       both oneshot and periodic alarms can be cancelled. Hence the plugin does not check for
+   *       the alarm type and removes the alarm data upon getting a match on the requestCode.
    * </ol>
+   *
    * @param requestCode Each alarm is assigned a unique request code as an identifier. This request
-   *                    code is required for cancelling an alarm.
+   *     code is required for cancelling an alarm.
    * @param context
    * @param checkForOneShot Depending on from where this method is being called, the plugin needs to
-   *                        check for whether an alarm being fired is an oneshot alarm or not.
+   *     check for whether an alarm being fired is an oneshot alarm or not.
    * @throws JSONException
    */
-  public static void removeFromScheduledAlarmsList(int requestCode, Context context, boolean checkForOneShot) throws JSONException {
-    SharedPreferences prefs = context.getSharedPreferences(SCHEDULED_ALARMS_SP_KEY, Context.MODE_PRIVATE);
+  public static void removeFromScheduledAlarmsList(
+      int requestCode, Context context, boolean checkForOneShot) throws JSONException {
+    SharedPreferences prefs =
+        context.getSharedPreferences(SCHEDULED_ALARMS_SP_KEY, Context.MODE_PRIVATE);
     Set<String> listFromPrefs = prefs.getStringSet(SCHEDULED_ALARMS_LIST_KEY, null);
     Set<String> scheduledList = new HashSet<>();
-    if (listFromPrefs != null)
-      scheduledList.addAll(listFromPrefs);
+    if (listFromPrefs != null) scheduledList.addAll(listFromPrefs);
 
     if (!scheduledList.isEmpty()) {
       JSONObject toRemove = null;
@@ -154,23 +150,20 @@ public class ScheduledAlarmsList {
           scheduledList.remove(toRemove.toString());
         }
 
-      } else
-        Log.e(TAG, "Alarm not found");
+      } else Log.e(TAG, "Alarm not found");
       SharedPreferences.Editor editor = prefs.edit();
       editor.putStringSet(SCHEDULED_ALARMS_LIST_KEY, scheduledList);
       editor.apply();
-    } else
-      Log.e(TAG, "No alarms scheduled");
+    } else Log.e(TAG, "No alarms scheduled");
     getScheduledAlarms(context);
   }
 
   public static String getScheduledAlarms(Context context) {
-    SharedPreferences prefs = context.getSharedPreferences(SCHEDULED_ALARMS_SP_KEY, Context.MODE_PRIVATE);
+    SharedPreferences prefs =
+        context.getSharedPreferences(SCHEDULED_ALARMS_SP_KEY, Context.MODE_PRIVATE);
     Set<String> scheduledList = prefs.getStringSet(SCHEDULED_ALARMS_LIST_KEY, null);
-    if (scheduledList == null)
-      scheduledList = new HashSet<>();
+    if (scheduledList == null) scheduledList = new HashSet<>();
     Log.d(TAG, scheduledList.toString());
     return scheduledList.toString();
   }
-
 }

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/ScheduledAlarmsList.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/ScheduledAlarmsList.java
@@ -1,0 +1,176 @@
+package dev.fluttercommunity.plus.androidalarmmanager;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.util.Log;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel;
+
+/**
+ * This class does not affect the behaviour of the alarms, just lists all the scheduled alarms.
+ * All the data is stored as a Set<String>, with each element of this set being a JSONObject which
+ * is converted to a string. As data passed from flutter is assigned to PeriodicRequest or
+ * OneShotRequest, this class consists an overloaded function which serializes these objects into
+ * JSONObjects. This helps while storing data in shared preferences and easy access to the key
+ * values of the alarm.
+ */
+
+public class ScheduledAlarmsList {
+  private static final String TAG = "Scheduled alarms list";
+  private static final String SCHEDULED_ALARMS_SP_KEY = "scheduled_alarms_sp_key";
+  private static final String SCHEDULED_ALARMS_LIST_KEY = "scheduled_alarms_list_key";
+
+  /**
+   * Serializes PeriodicRequest object into json object for easy handling.
+   *
+   * @param periodicRequest Alarm data passed from the flutter side.
+   * @return a json object representation of periodic alarm data.
+   * @throws JSONException
+   */
+  public static JSONObject toJson(AndroidAlarmManagerPlugin.PeriodicRequest periodicRequest) throws JSONException {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("requestCode", periodicRequest.requestCode);
+    jsonObject.put("exact", periodicRequest.exact);
+    jsonObject.put("wakeup", periodicRequest.wakeup);
+    jsonObject.put("startMillis", periodicRequest.startMillis);
+    jsonObject.put("intervalMillis", periodicRequest.intervalMillis);
+    jsonObject.put("rescheduleOnReboot", periodicRequest.rescheduleOnReboot);
+    jsonObject.put("callbackHandle", periodicRequest.callbackHandle);
+    jsonObject.put("alarmType", "periodic");
+    return jsonObject;
+  }
+
+  /**
+   * Serializes OneShotRequest object into json object for easy handling.
+   *
+   * @param oneShotRequest Alarm data passed from the flutter side.
+   * @return a json object representation of one shot alarm data.
+   * @throws JSONException
+   */
+  public static JSONObject toJson(AndroidAlarmManagerPlugin.OneShotRequest oneShotRequest) throws JSONException {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("requestCode", oneShotRequest.requestCode);
+    jsonObject.put("alarmClock", oneShotRequest.alarmClock);
+    jsonObject.put("allowWhileIdle", oneShotRequest.allowWhileIdle);
+    jsonObject.put("exact", oneShotRequest.exact);
+    jsonObject.put("wakeup", oneShotRequest.wakeup);
+    jsonObject.put("startMillis", oneShotRequest.startMillis);
+    jsonObject.put("rescheduleOnReboot", oneShotRequest.rescheduleOnReboot);
+    jsonObject.put("callbackHandle", oneShotRequest.callbackHandle);
+    jsonObject.put("alarmType", "oneshot");
+    return jsonObject;
+  }
+
+  /**
+   * Adds an alarm to the shared preferences whenever user creates a new alarm.
+   *
+   * @param jsonObject Data about the type of alarm and its corresponding information.
+   * @param context
+   */
+
+  public static void addToScheduledAlarmsList(JSONObject jsonObject, Context context) {
+    SharedPreferences prefs = context.getSharedPreferences(SCHEDULED_ALARMS_SP_KEY, Context.MODE_PRIVATE);
+    Set<String> listFromPrefs = prefs.getStringSet(SCHEDULED_ALARMS_LIST_KEY, null);
+    Set<String> scheduledList = new HashSet<>();
+    if (listFromPrefs != null)
+      scheduledList.addAll(listFromPrefs);
+    /*
+      We find the following note in the Android API
+
+      "Note that you must not modify the set instance returned by this call. The consistency of the
+      stored data is not guaranteed if you do, nor is your ability to modify the instance at all.".
+
+      Hence the list is first fetched from Shared Preferences and then is made a copy of. All
+      mutations are done on that copy and is reassigned back to Shared preference in the same key.
+      Not doing so throws erroneous results.
+
+     */
+    scheduledList.add(jsonObject.toString());
+    SharedPreferences.Editor editor = prefs.edit();
+    editor.putStringSet(SCHEDULED_ALARMS_LIST_KEY, scheduledList);
+    editor.apply();
+    Log.d(TAG, "Alarm added");
+    getScheduledAlarms(context);
+  }
+
+  /**
+   * Removes alarm info for a given request code. This function has to handle two cases
+   * <ol>
+   *   <li>
+   *     Oneshot alarms - These alarms will fire only once. Hence the plugin has to remove it from
+   *     the list of scheduled alarms as and when it is fired. {@link AlarmBroadcastReceiver}
+   *     overrides an {@link AlarmBroadcastReceiver#onReceive(Context, Intent)} which is fired
+   *     everytime an alarm is fired, regardless of it being a periodic alarm or oneshot. So in this
+   *     case the plugin first checks if alarm data with the same requestCode exists in the
+   *     shared preferences. If yes, then it checks whether the alarm data is for a periodic alarm
+   *     or an oneshot alarm. If it is oneshot then that data is removed from the set.
+   *   </li>
+   *   <li>
+   *     Periodic alarms- Peroidic alarms can only be removed manualy. This happens when the
+   *     {@link AlarmService#cancel(Context, int)} is called from
+   *     {@link AndroidAlarmManagerPlugin#onMethodCall(MethodCall, MethodChannel.Result)}. In this
+   *     case both oneshot and periodic alarms can be cancelled. Hence the plugin does not check for
+   *     the alarm type and removes the alarm data upon getting a match on the requestCode.
+   *   </li>
+   * </ol>
+   * @param requestCode Each alarm is assigned a unique request code as an identifier. This request
+   *                    code is required for cancelling an alarm.
+   * @param context
+   * @param checkForOneShot Depending on from where this method is being called, the plugin needs to
+   *                        check for whether an alarm being fired is an oneshot alarm or not.
+   * @throws JSONException
+   */
+  public static void removeFromScheduledAlarmsList(int requestCode, Context context, boolean checkForOneShot) throws JSONException {
+    SharedPreferences prefs = context.getSharedPreferences(SCHEDULED_ALARMS_SP_KEY, Context.MODE_PRIVATE);
+    Set<String> listFromPrefs = prefs.getStringSet(SCHEDULED_ALARMS_LIST_KEY, null);
+    Set<String> scheduledList = new HashSet<>();
+    if (listFromPrefs != null)
+      scheduledList.addAll(listFromPrefs);
+
+    if (!scheduledList.isEmpty()) {
+      JSONObject toRemove = null;
+      for (String alarm : scheduledList) {
+        JSONObject jsonObject = new JSONObject(alarm);
+        if (jsonObject.getInt("requestCode") == requestCode) {
+          toRemove = jsonObject;
+          break;
+        }
+      }
+      if (toRemove != null) {
+        if (checkForOneShot) {
+          if (toRemove.getString("alarmType").equalsIgnoreCase("oneshot")) {
+            scheduledList.remove(toRemove.toString());
+          } else Log.d(TAG, "Fired due to periodic alarm");
+        } else {
+          // The alarm is cancelled by the user
+          scheduledList.remove(toRemove.toString());
+        }
+
+      } else
+        Log.e(TAG, "Alarm not found");
+      SharedPreferences.Editor editor = prefs.edit();
+      editor.putStringSet(SCHEDULED_ALARMS_LIST_KEY, scheduledList);
+      editor.apply();
+    } else
+      Log.e(TAG, "No alarms scheduled");
+    getScheduledAlarms(context);
+  }
+
+  public static String getScheduledAlarms(Context context) {
+    SharedPreferences prefs = context.getSharedPreferences(SCHEDULED_ALARMS_SP_KEY, Context.MODE_PRIVATE);
+    Set<String> scheduledList = prefs.getStringSet(SCHEDULED_ALARMS_LIST_KEY, null);
+    if (scheduledList == null)
+      scheduledList = new HashSet<>();
+    Log.d(TAG, scheduledList.toString());
+    return scheduledList.toString();
+  }
+
+}

--- a/packages/android_alarm_manager_plus/example/lib/main.dart
+++ b/packages/android_alarm_manager_plus/example/lib/main.dart
@@ -135,7 +135,9 @@ class _AlarmHomePageState extends State<_AlarmHomePage> {
               key: ValueKey('RegisterOneShotAlarm'),
               onPressed: () async {
                 await AndroidAlarmManager.oneShot(
-                  const Duration(seconds: 5),
+                  // Setting a random duration just for testing purposes.
+                  // This way we can have different alarms for different durations.
+                  Duration(milliseconds: 1000 + Random().nextInt(pow(2, 10))),
                   // Ensure we have a unique alarm ID.
                   Random().nextInt(pow(2, 31)),
                   callback,
@@ -147,6 +149,26 @@ class _AlarmHomePageState extends State<_AlarmHomePage> {
                 'Schedule OneShot Alarm',
               ),
             ),
+            ElevatedButton(
+              onPressed: () async {
+                setState(() {});
+              },
+              child: Text(
+                'Fetch alarms list',
+              ),
+            ),
+            FutureBuilder(
+                future: AndroidAlarmManager.getScheduledAlarms(),
+                builder:
+                    (BuildContext context, AsyncSnapshot<String> snapshot) {
+                  if (snapshot.hasData) {
+                    return (snapshot.data == '[]')
+                        ? Text('No alarms scheduled')
+                        : Text(snapshot.data);
+                  } else {
+                    return Center(child: CircularProgressIndicator());
+                  }
+                })
           ],
         ),
       ),

--- a/packages/android_alarm_manager_plus/lib/android_alarm_manager_plus.dart
+++ b/packages/android_alarm_manager_plus/lib/android_alarm_manager_plus.dart
@@ -305,8 +305,8 @@ class AndroidAlarmManager {
   }
 
   /// Get a list of all the upcoming alarms
-  static Future<String> getScheduledAlarms() async{
+  static Future<String> getScheduledAlarms() async {
     final r = await _channel.invokeMethod('Alarm.scheduledAlarms', null);
-    return (r == null)? '[]' : r;
+    return (r == null) ? '[]' : r;
   }
 }

--- a/packages/android_alarm_manager_plus/lib/android_alarm_manager_plus.dart
+++ b/packages/android_alarm_manager_plus/lib/android_alarm_manager_plus.dart
@@ -304,7 +304,7 @@ class AndroidAlarmManager {
     return (r == null) ? false : r;
   }
 
-  /// Get a list of all the upcoming alarms
+  /// Get a list of all the upcoming alarms.
   static Future<String> getScheduledAlarms() async {
     final r = await _channel.invokeMethod('Alarm.scheduledAlarms', null);
     return (r == null) ? '[]' : r;

--- a/packages/android_alarm_manager_plus/lib/android_alarm_manager_plus.dart
+++ b/packages/android_alarm_manager_plus/lib/android_alarm_manager_plus.dart
@@ -303,4 +303,10 @@ class AndroidAlarmManager {
     final r = await _channel.invokeMethod<bool>('Alarm.cancel', <dynamic>[id]);
     return (r == null) ? false : r;
   }
+
+  /// Get a list of all the upcoming alarms
+  static Future<String> getScheduledAlarms() async{
+    final r = await _channel.invokeMethod('Alarm.scheduledAlarms', null);
+    return (r == null)? '[]' : r;
+  }
 }

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager_plus
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 1.0.2
+version: 1.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

The plugin now stores all the upcoming alarms, be it one shot or periodic and returns a json string containing info about all the
scheduled alarms.  Oneshot alarms are removed from this list when the alarm goes off. Peroidic alarms are removed only when it is explicitly cancelled.

## Related Issues

#342 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
