### PR TITLE
Connectivity_plus detect no-network on Android M and above

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.7
+
+- Android: Fix to detect no-network when Wi-Fi is disconnected on Android M and above
+
 ## 1.0.6
 
 - Android: Fix unregisterReceiver call for API < N

--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/Connectivity.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/Connectivity.java
@@ -11,6 +11,9 @@ import android.os.Build;
 
 /** Reports connectivity related information such as connectivity type and wifi information. */
 public class Connectivity {
+  static final String CONNECTIVITY_NONE = "none";
+  static final String CONNECTIVITY_WIFI = "wifi";
+  static final String CONNECTIVITY_MOBILE = "mobile";
   private ConnectivityManager connectivityManager;
 
   public Connectivity(ConnectivityManager connectivityManager) {
@@ -22,14 +25,14 @@ public class Connectivity {
       Network network = connectivityManager.getActiveNetwork();
       NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(network);
       if (capabilities == null) {
-        return "none";
+        return CONNECTIVITY_NONE;
       }
       if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
           || capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
-        return "wifi";
+        return CONNECTIVITY_WIFI;
       }
       if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-        return "mobile";
+        return CONNECTIVITY_MOBILE;
       }
     }
 

--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
@@ -50,7 +50,7 @@ public class ConnectivityBroadcastReceiver extends BroadcastReceiver
 
             @Override
             public void onLost(Network network) {
-              sendEvent();
+              sendEvent(Connectivity.CONNECTIVITY_NONE);
             }
           };
       connectivity.getConnectivityManager().registerDefaultNetworkCallback(networkCallback);
@@ -92,6 +92,17 @@ public class ConnectivityBroadcastReceiver extends BroadcastReceiver
           @Override
           public void run() {
             events.success(connectivity.getNetworkType());
+          }
+        };
+    mainHandler.post(runnable);
+  }
+
+  private void sendEvent(final String networkType) {
+    Runnable runnable =
+        new Runnable() {
+          @Override
+          public void run() {
+            events.success(networkType);
           }
         };
     mainHandler.post(runnable);

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 1.0.6
+version: 1.0.7
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

connectivity_plus plugin uses ConnectivityManager.NetworkCallback() when the Android OS version is VERSION_CODES.M or above.
Once the network is changed, it sends the latest network state to Flutter by using ConnectivityManager.getActiveNetwork()
(Ref: connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/Connectivity.java)
Sometimes getActiveNetwork() returns the network interface (not null) which is just disconnected for network disconnection.
This causes that the network state is shown as connected when it's disconnected.

* I just created a simple patch since the issue #290 is not fixed quickly. If you have a better fix already prepared, please ignore this PR.

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/290

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
