### PR TITLE
fix(package_info_plus): restore backward compatibility

### DIFF
--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,4 +1,9 @@
+## 1.0.5
+
+- Remove the `required` keyword of `buildSignature` in `PackageInfo`'s constructor to restore backward compatibility
+
 ## 1.0.4
+
 - Add `buildSignature` to Android package info to retrieve the signing certifiate SHA1 at runtime.
 
 ## 1.0.3

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -24,7 +24,7 @@ class PackageInfo {
     required this.packageName,
     required this.version,
     required this.buildNumber,
-    required this.buildSignature,
+    this.buildSignature = '',
   });
 
   /// Disables the platform override in order to use a manually registered

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 1.0.4
+version: 1.0.5
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

This PR restores backward compatibility of `package_info_plus`.

`package_info_plus` violates semantic versioning spec in 1.0.4 where #340 added a required parameter to `PackageInfo`'s public constructor, this is a breaking change to [lines declaring `PackageInfo` as a non-nullable type with dummy values](https://github.com/bottlepay/plus_plugins/blob/a70e634f7094054fb7e13a1b917e49149e57411e/packages/package_info_plus/package_info_plus/example/lib/main.dart#L37-L43).

The change removes the `required` keyword and sets a default value(empty string) to allow the variable to be non-nullable.

## Related Issues

Closes #392 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
