### PR TITLE
Fixed links in docs/overview.mdx

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -15,18 +15,18 @@ PlusPlugins is a set of Flutter plugins that is developed based on existing Flut
 
 | Plugin                                                            | Version                                                                   |
 | ----------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| [Battery Plus](battery_plus/overview)                             | <img src="https://img.shields.io/pub/v/battery_plus.svg" />               |
-| [connectivity Plus](connectivity_plus/overview)                   | <img src="https://img.shields.io/pub/v/connectivity_plus.svg" />          |
-| [Device Info Plus](device_info_plus/overview)                     | <img src="https://img.shields.io/pub/v/device_info_plus.svg" />           |
-| [Network Info Plus](network_info_plus/overview)                   | <img src="https://img.shields.io/pub/v/network_info_plus.svg" />          |
-| [Package Info Plus](package_info_plus/overview)                   | <img src="https://img.shields.io/pub/v/package_info_plus.svg" />          |
-| [Sensors Plus](sensors_plus/overview)                             | <img src="https://img.shields.io/pub/v/sensors_plus.svg" />               |
-| [Share Plus](share_plus/overview)                                 | <img src="https://img.shields.io/pub/v/share_plus.svg" />                 |
-| [Android Alarm Manager Plus](android_alarm_manager_plus/overview) | <img src="https://img.shields.io/pub/v/android_alarm_manager_plus.svg" /> |
-| [Android Intent Plus](android_intent_plus/overview)               | <img src="https://img.shields.io/pub/v/android_intent_plus.svg" />        |
+| [Battery Plus](/docs/battery_plus/overview)                             | <img src="https://img.shields.io/pub/v/battery_plus.svg" />               |
+| [connectivity Plus](/docs/connectivity_plus/overview)                   | <img src="https://img.shields.io/pub/v/connectivity_plus.svg" />          |
+| [Device Info Plus](/docs/device_info_plus/overview)                     | <img src="https://img.shields.io/pub/v/device_info_plus.svg" />           |
+| [Network Info Plus](/docs/network_info_plus/overview)                   | <img src="https://img.shields.io/pub/v/network_info_plus.svg" />          |
+| [Package Info Plus](/docs/package_info_plus/overview)                   | <img src="https://img.shields.io/pub/v/package_info_plus.svg" />          |
+| [Sensors Plus](/docs/sensors_plus/overview)                             | <img src="https://img.shields.io/pub/v/sensors_plus.svg" />               |
+| [Share Plus](/docs/share_plus/overview)                                 | <img src="https://img.shields.io/pub/v/share_plus.svg" />                 |
+| [Android Alarm Manager Plus](/docs/android_alarm_manager_plus/overview) | <img src="https://img.shields.io/pub/v/android_alarm_manager_plus.svg" /> |
+| [Android Intent Plus](/docs/android_intent_plus/overview)               | <img src="https://img.shields.io/pub/v/android_intent_plus.svg" />        |
 
 :::note
-PlusPlugins are all null safety compatible. [check this out](null_safety)
+PlusPlugins are all null safety compatible. [check this out](/docs/null_safety)
 :::
 
 ```yaml title="pubspec.yaml"


### PR DESCRIPTION
## Description
The links in docs/overview don't work as of now if you go to the url https://plus.fluttercommunity.dev/docs/overview. This is because browser adds a '/' at the end of the url. To fix the issue we can use complete path to docs.

## Related Issues
Fixes #397 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
