### PR TITLE
Handle fall through in unknown battery state

### DIFF
--- a/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
+++ b/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
@@ -190,6 +190,7 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
         break;
       case BatteryManager.BATTERY_STATUS_UNKNOWN:
         events.success("unknown");
+        break;
       default:
         events.error("UNAVAILABLE", "Charging status unavailable", null);
         break;

--- a/packages/battery_plus/battery_plus/ios/Classes/FLTBatteryPlusPlugin.m
+++ b/packages/battery_plus/battery_plus/ios/Classes/FLTBatteryPlusPlugin.m
@@ -52,6 +52,7 @@
   switch (state) {
     case UIDeviceBatteryStateUnknown:
       _eventSink(@"unknown");
+      break;
     case UIDeviceBatteryStateFull:
       _eventSink(@"full");
     case UIDeviceBatteryStateCharging:

--- a/packages/battery_plus/battery_plus/test/battery_test.dart
+++ b/packages/battery_plus/battery_plus/test/battery_test.dart
@@ -63,6 +63,9 @@ void main() {
 
       controller.add(BatteryState.charging);
       expect(await queue.next, BatteryState.charging);
+      
+      controller.add(BatteryState.unknown);
+      expect(await queue.next, BatteryState.unknown);
     });
   });
 }

--- a/packages/battery_plus/battery_plus/test/battery_test.dart
+++ b/packages/battery_plus/battery_plus/test/battery_test.dart
@@ -63,7 +63,7 @@ void main() {
 
       controller.add(BatteryState.charging);
       expect(await queue.next, BatteryState.charging);
-      
+
       controller.add(BatteryState.unknown);
       expect(await queue.next, BatteryState.unknown);
     });


### PR DESCRIPTION
## Description

Add break statements for `unknown` battery state in Android and iOS implementations. The lack of these break statements will lead to erroneous errors being emitted when the `unknown` state is emitted. The other implementations seem to properly handle the `unknown` state.

## Related Issues

Potentially related issue: https://github.com/fluttercommunity/plus_plugins/issues/231

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
