### PR TITLE
[share_plus_linux] Fix sharing in Flatpak apps

### DIFF
--- a/packages/share_plus/share_plus_linux/CHANGELOG.md
+++ b/packages/share_plus/share_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+- Fixes: sharing in isolated sandboxes like Flatpak
+
 ## 2.0.3
 
 - Hotfix on 2.0.2, improved solution.

--- a/packages/share_plus/share_plus_linux/lib/share_plus_linux.dart
+++ b/packages/share_plus/share_plus_linux/lib/share_plus_linux.dart
@@ -3,12 +3,13 @@ library share_plus_linux;
 
 import 'dart:ui';
 
-import 'package:url_launcher/url_launcher.dart';
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 /// The Linux implementation of SharePlatform.
 class ShareLinux extends SharePlatform {
   /// Share text.
+  /// Throws a [PlatformException] on invalid URLs and schemes which cannot be handled.
   @override
   Future<void> share(
     String text, {
@@ -29,11 +30,7 @@ class ShareLinux extends SharePlatform {
           .join('&'),
     );
 
-    if (await canLaunch(uri.toString())) {
-      await launch(uri.toString());
-    } else {
-      throw Exception('Unable to share on linux');
-    }
+    await launch(uri.toString());
   }
 
   /// Share files.

--- a/packages/share_plus/share_plus_linux/lib/share_plus_linux.dart
+++ b/packages/share_plus/share_plus_linux/lib/share_plus_linux.dart
@@ -9,7 +9,7 @@ import 'package:url_launcher/url_launcher.dart';
 /// The Linux implementation of SharePlatform.
 class ShareLinux extends SharePlatform {
   /// Share text.
-  /// Throws a [PlatformException] on invalid URLs and schemes which cannot be handled.
+  /// Throws a [PlatformException] if `mailto:` scheme cannot be handled.
   @override
   Future<void> share(
     String text, {

--- a/packages/share_plus/share_plus_linux/pubspec.yaml
+++ b/packages/share_plus/share_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_linux
 description: Linux implementation of the share_plus plugin
-version: 2.0.3
+version: 2.0.4
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus_linux/test/share_plus_linux_test.dart
+++ b/packages/share_plus/share_plus_linux/test/share_plus_linux_test.dart
@@ -56,6 +56,9 @@ class MockUrlLauncherPlatform extends UrlLauncherPlatform {
     String? webOnlyWindowName,
   }) async {
     this.url = url;
+    if (!canLaunchMockValue) {
+      throw Exception();
+    }
     return true;
   }
 }


### PR DESCRIPTION
## Description

As stated here (https://github.com/flutter/flutter/issues/88463#issuecomment-901509331), `canLaunch` doesn't work with sandboxes such as Flatpak, which makes it impossible to share from these containers. 
According to the [documentation](https://pub.dev/documentation/url_launcher/latest/url_launcher/launch.html), `launch` method itself throws a `PlatformException` if the URL scheme is unknown or if there is no corresponding application, so the presence of `canLaunch` in the code is redundant and breaks Flatpak compatibility. 

## Related Issues

https://github.com/flutter/flutter/issues/88463

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
