### PR TITLE
increase flutter sdk, that requires to remove ios folder

### DIFF
--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+
+- increase flutter SDK version to 1.20.0
+
 ## 1.0.3
 
 - clean up ios folder

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,8 +1,12 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 1.0.3
+version: 2.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.20.0"
 
 flutter:
   plugin:
@@ -23,7 +27,3 @@ dev_dependencies:
   test: ^1.16.4
   mockito: ^5.0.0
   pedantic: ^1.10.0
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"


### PR DESCRIPTION
## Description

increase SDK version to address failing publish due to not having ios folder. 


```
Uploading...
pubspec.yaml allows Flutter SDK version prior to 1.20.0, which does not support having no `ios/` folder.
Please consider increasing the Flutter SDK requirement to ^1.20.0 or higher (environment.sdk.flutter) or create an `ios/` folder.

See https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin
```
