### PR TITLE
[network_info_plus] Fix issue #431 network_info_plus: 'net/route.h' file not found when building for iOS emulator

### DIFF
--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- IOS: Fix issue failed to build on iOS emulator
+
 ## 1.1.0
 
 - Android, IOS: Adding IPv6 information

--- a/packages/network_info_plus/network_info_plus/ios/Classes/getgateway.c
+++ b/packages/network_info_plus/network_info_plus/ios/Classes/getgateway.c
@@ -13,14 +13,8 @@
 #include <sys/sysctl.h>
 #include "getgateway.h"
 
-#include "TargetConditionals.h"
-#if TARGET_IPHONE_SIMULATOR
-    #include <net/route.h>
-    #define TypeEN    "en1"
-#else
-    #include "route.h"
-    #define TypeEN    "en0"
-#endif
+#include "route.h"
+#define TypeEN    "en0"
 
 #include <net/if.h>
 #include <string.h>

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 1.2.0
+version: 1.2.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description
Fix issue #431 network_info_plus: 'net/route.h' file not found when building for iOS emulator

## Related Issues
#431 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
