### PR TITLE
[share_plus] Use NSURL for web links

### DIFF
--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.5
+
+- Fixed: Use NSURL for web links (iOS)
+
 ## 2.1.4
 
 - Android: migrate to mavenCentral

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -210,7 +210,9 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
            subject:(NSString *)subject
     withController:(UIViewController *)controller
           atSource:(CGRect)origin {
-  NSObject *data = [shareText hasPrefix:@"https://"] ? [[NSURL alloc] initWithString:shareText] : [[SharePlusData alloc] initWithSubject:subject text:shareText];
+  NSObject *data = [shareText hasPrefix:@"https://"]
+                       ? [[NSURL alloc] initWithString:shareText]
+                       : [[SharePlusData alloc] initWithSubject:subject text:shareText];
   [self share:@[ data ] withController:controller atSource:origin];
 }
 

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -210,7 +210,7 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
            subject:(NSString *)subject
     withController:(UIViewController *)controller
           atSource:(CGRect)origin {
-  SharePlusData *data = [[SharePlusData alloc] initWithSubject:subject text:shareText];
+  NSObject *data = [shareText hasPrefix:@"https://"] ? [[NSURL alloc] initWithString:shareText] : [[SharePlusData alloc] initWithSubject:subject text:shareText];
   [self share:@[ data ] withController:controller atSource:origin];
 }
 

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 2.1.4
+version: 2.1.5
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

Uses a different share item on iOS so that more share providers (Instagram, etc) kick in

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/459

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
