### PR TITLE
fix(device_info_plus): suppress Android build deprecation warnings

### DIFF
--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+- suppress Android build deprecation warnings
+
 ## 2.2.0
 
 - migrate integration_test to flutter sdk

--- a/packages/device_info_plus/device_info_plus/android/src/main/java/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.java
+++ b/packages/device_info_plus/device_info_plus/android/src/main/java/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.java
@@ -8,7 +8,6 @@ import android.content.Context;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** DeviceInfoPlusPlugin */
 public class DeviceInfoPlusPlugin implements FlutterPlugin {
@@ -16,7 +15,8 @@ public class DeviceInfoPlusPlugin implements FlutterPlugin {
   MethodChannel channel;
 
   /** Plugin registration. */
-  public static void registerWith(Registrar registrar) {
+  @SuppressWarnings("deprecation")
+  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
     DeviceInfoPlusPlugin plugin = new DeviceInfoPlusPlugin();
     plugin.setupMethodChannel(registrar.messenger(), registrar.context());
   }

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 2.2.0
+version: 2.3.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

The plugin is updated to use Android v2 embedding, while keeping the registerWith() method for keeping backwards compatibility.
Since it's deprecated, there are warnings on every Android build.
This PR suppresses the warnings.

## Related Issues

```
/opt/homebrew/Caskroom/flutter/2.5.0/flutter/.pub-cache/hosted/pub.dartlang.org/device_info_plus-2.1.0/android/src/main/java/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.java:11: warning: [deprecation] Registrar in PluginRegistry has been deprecated
import io.flutter.plugin.common.PluginRegistry.Registrar;
                                              ^
/opt/homebrew/Caskroom/flutter/2.5.0/flutter/.pub-cache/hosted/pub.dartlang.org/device_info_plus-2.1.0/android/src/main/java/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.java:19: warning: [deprecation] Registrar in PluginRegistry has been deprecated
  public static void registerWith(Registrar registrar) {
                                  ^
2 warnings

```

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
