### PR TITLE
[connectivity_plus_windows] add ethernet support

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+- Add ethernet as connectivity result. Supported on Android, iOS, Windows, Linux, macOS, and Web
+
 ## 1.2.0
 
 - migrate integration_test to flutter sdk

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 1.2.0
+version: 1.3.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -33,7 +33,7 @@ dependencies:
   connectivity_plus_linux: ^1.1.0
   connectivity_plus_macos: ^1.1.0
   connectivity_plus_web: ^1.1.0
-  connectivity_plus_windows: ^1.1.0
+  connectivity_plus_windows: ^1.2.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/connectivity_plus/connectivity_plus_windows/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Add ethernet as connectivity result.
+
 ## 1.1.0
 
 - Update connectivity plus

--- a/packages/connectivity_plus/connectivity_plus_windows/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_windows/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_plus_windows
 description: Windows implementation of the connectivity_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 1.1.0
+version: 1.2.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/connectivity_plus/connectivity_plus_windows/windows/CMakeLists.txt
+++ b/packages/connectivity_plus/connectivity_plus_windows/windows/CMakeLists.txt
@@ -16,7 +16,11 @@ set_target_properties(${PLUGIN_NAME} PROPERTIES
 target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE
   "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+target_link_libraries(${PLUGIN_NAME} PRIVATE
+  flutter
+  flutter_wrapper_plugin
+  iphlpapi
+)
 
 # List of absolute paths to libraries that should be bundled with the plugin
 set(connectivity_plus_windows_bundled_libraries

--- a/packages/connectivity_plus/connectivity_plus_windows/windows/connectivity_plus_windows_plugin.cpp
+++ b/packages/connectivity_plus/connectivity_plus_windows/windows/connectivity_plus_windows_plugin.cpp
@@ -100,13 +100,13 @@ void ConnectivityPlusWindowsPlugin::RegisterWithRegistrar(
 
 static std::string ConnectivityToString(ConnectivityType connectivityType) {
   switch (connectivityType) {
-  case ConnectivityType::WiFi:
-    return "wifi";
-  case ConnectivityType::Ethernet:
-    return "ethernet";
-  case ConnectivityType::None:
-  default:
-    return "none";
+    case ConnectivityType::WiFi:
+      return "wifi";
+    case ConnectivityType::Ethernet:
+      return "ethernet";
+    case ConnectivityType::None:
+    default:
+      return "none";
   }
 }
 
@@ -114,7 +114,8 @@ void ConnectivityPlusWindowsPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue>& method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
   if (method_call.method_name().compare("check") == 0) {
-    std::string connectivity = ConnectivityToString(manager->GetConnectivityType());
+    std::string connectivity =
+        ConnectivityToString(manager->GetConnectivityType());
     result->Success(flutter::EncodableValue(connectivity));
   } else {
     result->NotImplemented();
@@ -128,7 +129,8 @@ ConnectivityStreamHandler::ConnectivityStreamHandler(
 ConnectivityStreamHandler::~ConnectivityStreamHandler() {}
 
 void ConnectivityStreamHandler::AddConnectivityEvent() {
-  std::string connectivity = ConnectivityToString(manager->GetConnectivityType());
+  std::string connectivity =
+      ConnectivityToString(manager->GetConnectivityType());
   sink->Success(flutter::EncodableValue(connectivity));
 }
 
@@ -138,8 +140,8 @@ ConnectivityStreamHandler::OnListenInternal(
     std::unique_ptr<FlEventSink>&& events) {
   sink = std::move(events);
 
-  auto callback = std::bind(&ConnectivityStreamHandler::AddConnectivityEvent,
-                            this);
+  auto callback =
+      std::bind(&ConnectivityStreamHandler::AddConnectivityEvent, this);
 
   if (!manager->StartListen(callback)) {
     return std::make_unique<FlStreamHandlerError>(

--- a/packages/connectivity_plus/connectivity_plus_windows/windows/include/connectivity_plus_windows/network_manager.h
+++ b/packages/connectivity_plus/connectivity_plus_windows/windows/include/connectivity_plus_windows/network_manager.h
@@ -1,10 +1,15 @@
 #ifndef NETWORK_MANAGER_H
 #define NETWORK_MANAGER_H
 
+// clang-format off
+#include <winsock2.h>
+// clang-format on
 #include <windows.h>
 
 #include <functional>
 #include <string>
+
+enum class ConnectivityType { None, Ethernet, WiFi };
 
 class NetworkListener;
 struct IConnectionPoint;
@@ -12,7 +17,7 @@ struct IConnectionPointContainer;
 struct INetworkListManager;
 struct IUnknown;
 
-typedef std::function<void(bool)> NetworkCallback;
+typedef std::function<void()> NetworkCallback;
 
 class NetworkManager {
  public:
@@ -22,7 +27,7 @@ class NetworkManager {
   bool Init();
   void Cleanup();
 
-  bool IsConnected();
+  ConnectivityType GetConnectivityType() const;
 
   bool StartListen(NetworkCallback pCallback);
   void StopListen();
@@ -31,6 +36,8 @@ class NetworkManager {
   int GetError() const;
 
  private:
+  std::vector<GUID> GetConnectedAdapterIds() const;
+
   DWORD dwCookie = 0;
   IUnknown *pUnknown = NULL;
   INetworkListManager *pNetworkListManager = NULL;

--- a/packages/connectivity_plus/connectivity_plus_windows/windows/network_manager.cpp
+++ b/packages/connectivity_plus/connectivity_plus_windows/windows/network_manager.cpp
@@ -46,10 +46,7 @@ class NetworkListener final : public INetworkEvents {
     return lAddend;
   }
 
-  HRESULT STDMETHODCALLTYPE
-  NetworkAdded(GUID networkId) {
-    return S_OK;
-  }
+  HRESULT STDMETHODCALLTYPE NetworkAdded(GUID networkId) { return S_OK; }
 
   HRESULT STDMETHODCALLTYPE
   NetworkConnectivityChanged(GUID networkId, NLM_CONNECTIVITY newConnectivity) {
@@ -57,10 +54,7 @@ class NetworkListener final : public INetworkEvents {
     return S_OK;
   }
 
-  HRESULT STDMETHODCALLTYPE
-  NetworkDeleted(GUID networkId) {
-    return S_OK;
-  }
+  HRESULT STDMETHODCALLTYPE NetworkDeleted(GUID networkId) { return S_OK; }
 
   HRESULT STDMETHODCALLTYPE
   NetworkPropertyChanged(GUID networkId, NLM_NETWORK_PROPERTY_CHANGE flags) {
@@ -181,17 +175,17 @@ ConnectivityType NetworkManager::GetConnectivityType() const {
       continue;
     }
 
-    if (std::find(adapterIds.begin(), adapterIds.end(), guid) != adapterIds.end()) {
+    if (std::find(adapterIds.begin(), adapterIds.end(), guid) !=
+        adapterIds.end()) {
       switch (addresses->IfType) {
-      case IF_TYPE_ETHERNET_CSMACD:
-        connectivities.insert(ConnectivityType::Ethernet);
-        break;
-      default:
-        connectivities.insert(ConnectivityType::WiFi);
-        break;
+        case IF_TYPE_ETHERNET_CSMACD:
+          connectivities.insert(ConnectivityType::Ethernet);
+          break;
+        default:
+          connectivities.insert(ConnectivityType::WiFi);
+          break;
       }
     }
-
   }
 
   if (connectivities.find(ConnectivityType::WiFi) != connectivities.end()) {
@@ -213,8 +207,7 @@ bool NetworkManager::StartListen(NetworkCallback pCallback) {
   HRESULT hr = pNetworkListManager->QueryInterface(
       IID_IConnectionPointContainer, (void **)&pCPContainer);
   if (SUCCEEDED(hr)) {
-    hr = pCPContainer->FindConnectionPoint(IID_INetworkEvents,
-                                           &pConnectPoint);
+    hr = pCPContainer->FindConnectionPoint(IID_INetworkEvents, &pConnectPoint);
     if (SUCCEEDED(hr)) {
       pListener = new NetworkListener(pCallback);
       hr = pConnectPoint->Advise((IUnknown *)pListener, &dwCookie);

--- a/packages/connectivity_plus/connectivity_plus_windows/windows/network_manager.cpp
+++ b/packages/connectivity_plus/connectivity_plus_windows/windows/network_manager.cpp
@@ -9,14 +9,16 @@
  * See full license text in LICENSE file at top of project tree
  */
 
-#include "network_manager.h"
+#include "include/connectivity_plus_windows/network_manager.h"
 
+#include <iphlpapi.h>
 #include <netlistmgr.h>
 #include <ocidl.h>
 
 #include <cassert>
+#include <set>
 
-class NetworkListener final : public INetworkListManagerEvents {
+class NetworkListener final : public INetworkEvents {
  public:
   NetworkListener(NetworkCallback pCb) : pCallback(pCb) {}
 
@@ -26,8 +28,8 @@ class NetworkListener final : public INetworkListManagerEvents {
     HRESULT hr = S_OK;
     if (IsEqualIID(riid, IID_IUnknown)) {
       *ppvObject = (IUnknown *)this;
-    } else if (IsEqualIID(riid, IID_INetworkListManagerEvents)) {
-      *ppvObject = (INetworkListManagerEvents *)this;
+    } else if (IsEqualIID(riid, IID_INetworkEvents)) {
+      *ppvObject = (INetworkEvents *)this;
     } else {
       hr = E_NOINTERFACE;
     }
@@ -45,15 +47,32 @@ class NetworkListener final : public INetworkListManagerEvents {
   }
 
   HRESULT STDMETHODCALLTYPE
-  ConnectivityChanged(NLM_CONNECTIVITY fConnectivity) {
-    Callback(fConnectivity &
-             (NLM_CONNECTIVITY_IPV4_INTERNET | NLM_CONNECTIVITY_IPV6_INTERNET));
+  NetworkAdded(GUID networkId) {
     return S_OK;
   }
 
-  void Callback(bool bConnected) {
+  HRESULT STDMETHODCALLTYPE
+  NetworkConnectivityChanged(GUID networkId, NLM_CONNECTIVITY newConnectivity) {
+    Callback();
+    return S_OK;
+  }
+
+  HRESULT STDMETHODCALLTYPE
+  NetworkDeleted(GUID networkId) {
+    return S_OK;
+  }
+
+  HRESULT STDMETHODCALLTYPE
+  NetworkPropertyChanged(GUID networkId, NLM_NETWORK_PROPERTY_CHANGE flags) {
+    if (flags & NLM_NETWORK_PROPERTY_CHANGE_CONNECTION) {
+      Callback();
+    }
+    return S_OK;
+  }
+
+  void Callback() {
     assert(pCallback);
-    pCallback(bConnected);
+    pCallback();
   }
 
  private:
@@ -94,13 +113,96 @@ void NetworkManager::Cleanup() {
   CoUninitialize();
 }
 
-bool NetworkManager::IsConnected() {
-  VARIANT_BOOL Connected = VARIANT_FALSE;
-  HRESULT hr = pNetworkListManager->get_IsConnectedToInternet(&Connected);
-  if (FAILED(hr)) {
-    return false;
+std::vector<GUID> NetworkManager::GetConnectedAdapterIds() const {
+  std::vector<GUID> adapterIds;
+
+  IEnumNetworkConnections *connections = NULL;
+  HRESULT hr = pNetworkListManager->GetNetworkConnections(&connections);
+  if (hr == S_OK) {
+    while (true) {
+      INetworkConnection *connection = NULL;
+      hr = connections->Next(1, &connection, NULL);
+      if (hr != S_OK) {
+        break;
+      }
+
+      VARIANT_BOOL isConnected = VARIANT_FALSE;
+      hr = connection->get_IsConnectedToInternet(&isConnected);
+      if (hr == S_OK && isConnected == VARIANT_TRUE) {
+        GUID guid;
+        hr = connection->GetAdapterId(&guid);
+        if (hr == S_OK) {
+          adapterIds.push_back(std::move(guid));
+        }
+      }
+      connection->Release();
+    }
+    connections->Release();
   }
-  return Connected == VARIANT_TRUE;
+
+  return adapterIds;
+}
+
+ConnectivityType NetworkManager::GetConnectivityType() const {
+  ULONG bufferSize = 15 * 1024;
+  ULONG flags = GAA_FLAG_SKIP_UNICAST | GAA_FLAG_SKIP_ANYCAST |
+                GAA_FLAG_SKIP_MULTICAST | GAA_FLAG_SKIP_DNS_SERVER |
+                GAA_FLAG_SKIP_FRIENDLY_NAME;
+  std::vector<unsigned char> buffer(bufferSize);
+  PIP_ADAPTER_ADDRESSES addresses =
+      reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buffer.front());
+  DWORD rc = GetAdaptersAddresses(AF_UNSPEC, flags, 0, addresses, &bufferSize);
+  if (rc == ERROR_BUFFER_OVERFLOW) {
+    buffer.resize(bufferSize);
+    addresses = reinterpret_cast<PIP_ADAPTER_ADDRESSES>(&buffer.front());
+    rc = GetAdaptersAddresses(AF_UNSPEC, flags, 0, addresses, &bufferSize);
+  }
+
+  if (rc != NO_ERROR) {
+    return ConnectivityType::None;
+  }
+
+  std::vector<GUID> adapterIds = GetConnectedAdapterIds();
+  if (adapterIds.empty()) {
+    return ConnectivityType::None;
+  }
+
+  std::set<ConnectivityType> connectivities;
+  for (; addresses != NULL; addresses = addresses->Next) {
+    NET_LUID luid;
+    rc = ConvertInterfaceIndexToLuid(addresses->IfIndex, &luid);
+    if (rc != NO_ERROR) {
+      continue;
+    }
+
+    GUID guid;
+    rc = ConvertInterfaceLuidToGuid(&luid, &guid);
+    if (rc != NO_ERROR) {
+      continue;
+    }
+
+    if (std::find(adapterIds.begin(), adapterIds.end(), guid) != adapterIds.end()) {
+      switch (addresses->IfType) {
+      case IF_TYPE_ETHERNET_CSMACD:
+        connectivities.insert(ConnectivityType::Ethernet);
+        break;
+      default:
+        connectivities.insert(ConnectivityType::WiFi);
+        break;
+      }
+    }
+
+  }
+
+  if (connectivities.find(ConnectivityType::WiFi) != connectivities.end()) {
+    return ConnectivityType::WiFi;
+  }
+
+  if (connectivities.find(ConnectivityType::Ethernet) != connectivities.end()) {
+    return ConnectivityType::Ethernet;
+  }
+
+  return ConnectivityType::None;
 }
 
 bool NetworkManager::StartListen(NetworkCallback pCallback) {
@@ -111,7 +213,7 @@ bool NetworkManager::StartListen(NetworkCallback pCallback) {
   HRESULT hr = pNetworkListManager->QueryInterface(
       IID_IConnectionPointContainer, (void **)&pCPContainer);
   if (SUCCEEDED(hr)) {
-    hr = pCPContainer->FindConnectionPoint(IID_INetworkListManagerEvents,
+    hr = pCPContainer->FindConnectionPoint(IID_INetworkEvents,
                                            &pConnectPoint);
     if (SUCCEEDED(hr)) {
       pListener = new NetworkListener(pCallback);


### PR DESCRIPTION
## Description

Add ethernet as connectivity result - #399 for Windows.

One maybe not so obvious change is that `NetworkListener` now implements `INetworkEvents`. It allows to watch for connectivity changes on individual networks and then compute system-wide connectivity type. If you're connected to both Ethernet and Wi-Fi and then disconnecting Wi-Fi, `INetworkListManagerEvents` won't fire callback because overall system connectivity did not change.

For backward compatibility any Internet-connected interface that's not Ethernet is considered Wi-Fi.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
