### PR TITLE
migrate integration_test to flutter sdk

### DIFF
--- a/packages/android_alarm_manager_plus/CHANGELOG.md
+++ b/packages/android_alarm_manager_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+- migrate integration_test to flutter sdk
+
 ## 1.2.0
 
 - Reverted feature to get scheduled alarms. See Issue #421 for more info.

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager_plus
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 1.2.0
+version: 1.3.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+- migrate integration_test to flutter sdk
+
 ## 2.0.0
 
 - increase flutter SDK version to 1.20.0

--- a/packages/android_intent_plus/example/pubspec.yaml
+++ b/packages/android_intent_plus/example/pubspec.yaml
@@ -11,8 +11,9 @@ dependencies:
     path: ../
 
 dev_dependencies:
-  integration_test: ^1.0.2+2
   flutter_driver:
+    sdk: flutter
+  integration_test:
     sdk: flutter
   pedantic: ^1.8.0
 

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 2.0.0
+version: 2.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/battery_plus/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- migrate integration_test to flutter sdk
+
 ## 1.1.1
 
 - Fix: Add break statements for unknown battery state in Android and iOS implementations

--- a/packages/battery_plus/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/example/pubspec.yaml
@@ -13,7 +13,8 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  integration_test: ^1.0.2
+  integration_test:
+    sdk: flutter
   pedantic: ^1.9.2
 
 dependency_overrides:

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 1.1.1
+version: 1.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- migrate integration_test to flutter sdk
+
 ## 1.1.0
 
 - Add ethernet as connectivity result. Supported on Android, Linux, macOS, and Web

--- a/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
@@ -13,8 +13,9 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   test: ^1.16.4
-  integration_test: ^1.0.2
   pedantic: ^1.10.0
 
 dependency_overrides:

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 1.1.0
+version: 1.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+- migrate integration_test to flutter sdk
+
 ## 2.1.0
 
 - add toMap to models

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  integration_test: ^1.0.2
+  integration_test:
+    sdk: flutter
   pedantic: ^1.10.0
 
 flutter:

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 2.1.0
+version: 2.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- migrate integration_test to flutter sdk
+
 ## 1.1.0
 
 - Android, IOS: Adding IPv6 information

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -13,8 +13,9 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   test: ^1.16.4
-  integration_test: ^1.0.2
   pedantic: ^1.10.0
 
 dependency_overrides:

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 1.1.0
+version: 1.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- migrate integration_test to flutter sdk
+
 ## 1.0.6
 
 - Web: Fixed url resolving for the version.json

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -11,11 +11,12 @@ dependencies:
     sdk: flutter
   package_info_plus:
     path: ../
-  integration_test: ^1.0.2
   universal_io: ^1.0.1
 
 dev_dependencies:
   flutter_driver:
+    sdk: flutter
+  integration_test:
     sdk: flutter
   test: any
   pedantic: ^1.10.0

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 1.0.6
+version: 1.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/sensors_plus/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- migrate integration_test to flutter sdk
+
 ## 1.1.0
 
 - Adds magnetometer support

--- a/packages/sensors_plus/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/example/pubspec.yaml
@@ -10,7 +10,8 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  integration_test: ^1.0.2
+  integration_test:
+    sdk: flutter
   pedantic: ^1.10.0
 
 flutter:

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: sensors_plus
 description: >
   Flutter plugin for accessing accelerometer, gyroscope, and magnetometer
   sensors.
-version: 1.1.0
+version: 1.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+- migrate integration_test to flutter sdk
+
 ## 2.1.5
 
 - Fixed: Use NSURL for web links (iOS)

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -11,7 +11,8 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  integration_test: ^1.0.2
+  integration_test:
+    sdk: flutter
   pedantic: ^1.10.0
 
 flutter:

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 2.1.5
+version: 2.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus_web/integration_test/pubspec.yaml
+++ b/packages/share_plus/share_plus_web/integration_test/pubspec.yaml
@@ -13,11 +13,12 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   share_plus_web:
     path: ../
   http: ^0.12.2
   mockito: ^5.0.0
-  integration_test: ^1.0.2
 
 dependency_overrides:
   args: ^2.0.0


### PR DESCRIPTION
## Description

Update `integration_test` to Flutter SDK.

## Related Issues

#465

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning