### PR TITLE
[package_info_plus] fix app name on iOS and macOS

### DIFF
--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.0
 
-- fix app name on macOS
+- fix app name on iOS and macOS
 
 ## 1.1.0
 

--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- fix app name on macOS
+
 ## 1.1.0
 
 - migrate integration_test to flutter sdk

--- a/packages/package_info_plus/package_info_plus/ios/Classes/FLTPackageInfoPlusPlugin.m
+++ b/packages/package_info_plus/package_info_plus/ios/Classes/FLTPackageInfoPlusPlugin.m
@@ -17,8 +17,7 @@
   if ([call.method isEqualToString:@"getAll"]) {
     result(@{
       @"appName" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]
-          ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"]
-          ?: [NSNull null],
+          ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"] ?: [NSNull null],
       @"packageName" : [[NSBundle mainBundle] bundleIdentifier] ?: [NSNull null],
       @"version" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"]
           ?: [NSNull null],

--- a/packages/package_info_plus/package_info_plus/ios/Classes/FLTPackageInfoPlusPlugin.m
+++ b/packages/package_info_plus/package_info_plus/ios/Classes/FLTPackageInfoPlusPlugin.m
@@ -17,6 +17,7 @@
   if ([call.method isEqualToString:@"getAll"]) {
     result(@{
       @"appName" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]
+          ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"]
           ?: [NSNull null],
       @"packageName" : [[NSBundle mainBundle] bundleIdentifier] ?: [NSNull null],
       @"version" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"]

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 1.1.0
+version: 1.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -26,7 +26,7 @@ dependencies:
     sdk: flutter
   package_info_plus_platform_interface: ^1.0.2
   package_info_plus_linux: ^1.0.3
-  package_info_plus_macos: ^1.1.1
+  package_info_plus_macos: ^1.2.0
   package_info_plus_windows: ^1.0.3
   package_info_plus_web: ^1.0.4
 

--- a/packages/package_info_plus/package_info_plus_macos/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- fix app name on iOS and macOS
+
 ## 1.1.1
 
 - Improve documentation

--- a/packages/package_info_plus/package_info_plus_macos/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus_macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.0
 
-- fix app name on iOS and macOS
+- fix app name on macOS
 
 ## 1.1.1
 

--- a/packages/package_info_plus/package_info_plus_macos/macos/Classes/FLTPackageInfoPlusPlugin.m
+++ b/packages/package_info_plus/package_info_plus_macos/macos/Classes/FLTPackageInfoPlusPlugin.m
@@ -17,8 +17,7 @@
   if ([call.method isEqualToString:@"getAll"]) {
     result(@{
       @"appName" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]
-          ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"]
-          ?: [NSNull null],
+          ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"] ?: [NSNull null],
       @"packageName" : [[NSBundle mainBundle] bundleIdentifier] ?: [NSNull null],
       @"version" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"]
           ?: [NSNull null],

--- a/packages/package_info_plus/package_info_plus_macos/macos/Classes/FLTPackageInfoPlusPlugin.m
+++ b/packages/package_info_plus/package_info_plus_macos/macos/Classes/FLTPackageInfoPlusPlugin.m
@@ -17,6 +17,7 @@
   if ([call.method isEqualToString:@"getAll"]) {
     result(@{
       @"appName" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"]
+          ?: [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleName"]
           ?: [NSNull null],
       @"packageName" : [[NSBundle mainBundle] bundleIdentifier] ?: [NSNull null],
       @"version" : [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleShortVersionString"]

--- a/packages/package_info_plus/package_info_plus_macos/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_macos
 description: macOS implementation of the package_info_plus plugin.
-version: 1.1.1
+version: 1.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

This PR adds fallback to `CFBundleName` if `CFBundleDisplayName` does not exist. This approach is suggested by Apple in [QA1544](https://developer.apple.com/library/archive/qa/qa1544).

## Related Issues

#432 

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
