### PR TITLE
[network_info_plus] ios: handle deprecation of `CNCopyCurrentNetworkInfo`

### DIFF
--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- IOS: Use `NEHotspotNetwork` on iOS 14+ to get SSID/BSSID.
+
 ## 1.1.0
 
 - Android, IOS: Adding IPv6 information

--- a/packages/network_info_plus/network_info_plus/ios/Classes/FLTCaptiveNetworkInfoProvider.h
+++ b/packages/network_info_plus/network_info_plus/ios/Classes/FLTCaptiveNetworkInfoProvider.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+#import "FLTNetworkInfoProvider.h"
+
+@interface FLTCaptiveNetworkInfoProvider : NSObject <FLTNetworkInfoProvider>
+@end

--- a/packages/network_info_plus/network_info_plus/ios/Classes/FLTCaptiveNetworkInfoProvider.m
+++ b/packages/network_info_plus/network_info_plus/ios/Classes/FLTCaptiveNetworkInfoProvider.m
@@ -1,0 +1,23 @@
+#import "FLTCaptiveNetworkInfoProvider.h"
+#import <SystemConfiguration/CaptiveNetwork.h>
+
+@implementation FLTCaptiveNetworkInfoProvider
+
+- (void)fetchNetworkInfoWithCompletionHandler:(void (^)(FLTNetworkInfo *network))completionHandler {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    NSArray *interfaceNames = (__bridge_transfer id)CNCopySupportedInterfaces();
+    for (NSString *interfaceName in interfaceNames) {
+      NSDictionary *networkInfo =
+          (__bridge_transfer id)CNCopyCurrentNetworkInfo((__bridge CFStringRef)interfaceName);
+      if (networkInfo) {
+        NSString *ssid = networkInfo[(NSString *)kCNNetworkInfoKeySSID];
+        NSString *bssid = networkInfo[(NSString *)kCNNetworkInfoKeyBSSID];
+        completionHandler([[FLTNetworkInfo alloc] initWithSSID:ssid BSSID:bssid]);
+        return;
+      }
+    }
+    completionHandler(nil);
+  });
+}
+
+@end

--- a/packages/network_info_plus/network_info_plus/ios/Classes/FLTHotspotNetworkInfoProvider.h
+++ b/packages/network_info_plus/network_info_plus/ios/Classes/FLTHotspotNetworkInfoProvider.h
@@ -1,0 +1,5 @@
+#import <Foundation/Foundation.h>
+#import "FLTNetworkInfoProvider.h"
+
+@interface FLTHotspotNetworkInfoProvider : NSObject <FLTNetworkInfoProvider>
+@end

--- a/packages/network_info_plus/network_info_plus/ios/Classes/FLTHotspotNetworkInfoProvider.m
+++ b/packages/network_info_plus/network_info_plus/ios/Classes/FLTHotspotNetworkInfoProvider.m
@@ -1,0 +1,19 @@
+#import "FLTHotspotNetworkInfoProvider.h"
+#import <NetworkExtension/NetworkExtension.h>
+
+@implementation FLTHotspotNetworkInfoProvider
+
+- (void)fetchNetworkInfoWithCompletionHandler:(void (^)(FLTNetworkInfo *network))completionHandler
+    API_AVAILABLE(ios(14)) {
+  [NEHotspotNetwork fetchCurrentWithCompletionHandler:^(NEHotspotNetwork *network) {
+    dispatch_async(dispatch_get_main_queue(), ^{
+      if (network) {
+        completionHandler([[FLTNetworkInfo alloc] initWithSSID:network.SSID BSSID:network.BSSID]);
+        return;
+      }
+      completionHandler(nil);
+    });
+  }];
+}
+
+@end

--- a/packages/network_info_plus/network_info_plus/ios/Classes/FLTNetworkInfo.h
+++ b/packages/network_info_plus/network_info_plus/ios/Classes/FLTNetworkInfo.h
@@ -1,0 +1,10 @@
+#import <Foundation/Foundation.h>
+
+@interface FLTNetworkInfo : NSObject
+
+@property(nonatomic, readonly) NSString *SSID;
+@property(nonatomic, readonly) NSString *BSSID;
+
+- (instancetype)initWithSSID:(NSString *)SSID BSSID:(NSString *)BSSID;
+
+@end

--- a/packages/network_info_plus/network_info_plus/ios/Classes/FLTNetworkInfo.m
+++ b/packages/network_info_plus/network_info_plus/ios/Classes/FLTNetworkInfo.m
@@ -1,0 +1,13 @@
+#import "FLTNetworkInfo.h"
+
+@implementation FLTNetworkInfo
+
+- (instancetype)initWithSSID:(NSString *)SSID BSSID:(NSString *)BSSID {
+  if ((self = [super init])) {
+    _SSID = [SSID copy];
+    _BSSID = [BSSID copy];
+  }
+  return self;
+}
+
+@end

--- a/packages/network_info_plus/network_info_plus/ios/Classes/FLTNetworkInfoProvider.h
+++ b/packages/network_info_plus/network_info_plus/ios/Classes/FLTNetworkInfoProvider.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+#import "FLTNetworkInfo.h"
+
+@protocol FLTNetworkInfoProvider <NSObject>
+
+- (void)fetchNetworkInfoWithCompletionHandler:
+    (void (^)(FLTNetworkInfo *networkInfo))completionHandler;
+
+@end

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 1.1.0
+version: 1.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

This PR migrates network info to modern `NEHotspotNetwork` APIs while keeping backward compatibility with older iOS versions. The code looks a little bit overkill for a couple of simple conditions though.

## Related Issues

#240

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
