### PR TITLE
fix(network_info_plus): Suppress Android build deprecation warnings

### DIFF
--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+- Suppress Android build deprecation warnings.
+
 ## 1.2.1
 
 - IOS: Fix issue failed to build on iOS emulator

--- a/packages/network_info_plus/network_info_plus/android/src/main/java/dev/fluttercommunity/plus/network_info/NetworkInfoPlusPlugin.java
+++ b/packages/network_info_plus/network_info_plus/android/src/main/java/dev/fluttercommunity/plus/network_info/NetworkInfoPlusPlugin.java
@@ -9,7 +9,6 @@ import android.net.wifi.WifiManager;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** NetworkInfoPlusPlugin */
 public class NetworkInfoPlusPlugin implements FlutterPlugin {
@@ -17,7 +16,8 @@ public class NetworkInfoPlusPlugin implements FlutterPlugin {
   private MethodChannel methodChannel;
 
   /** Plugin registration. */
-  public static void registerWith(Registrar registrar) {
+  @SuppressWarnings("deprecation")
+  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
 
     NetworkInfoPlusPlugin plugin = new NetworkInfoPlusPlugin();
     plugin.setupChannels(registrar.messenger(), registrar.context());

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 1.2.1
+version: 1.3.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

The plugin is updated to use Android v2 embedding, while keeping the registerWith() method for keeping backwards compatibility.
Since it's deprecated, there are warnings on every Android build.
This PR suppresses the warnings.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
