### PR TITLE
fix(sensors_plus): Suppress Android build deprecation warnings

### DIFF
--- a/packages/sensors_plus/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+- Suppress Android build deprecation warnings.
+
 ## 1.2.0
 
 - migrate integration_test to flutter sdk

--- a/packages/sensors_plus/sensors_plus/android/src/main/java/dev/fluttercommunity/plus/sensors/SensorsPlugin.java
+++ b/packages/sensors_plus/sensors_plus/android/src/main/java/dev/fluttercommunity/plus/sensors/SensorsPlugin.java
@@ -10,7 +10,6 @@ import android.hardware.SensorManager;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** SensorsPlugin */
 public class SensorsPlugin implements FlutterPlugin {
@@ -29,7 +28,8 @@ public class SensorsPlugin implements FlutterPlugin {
   private EventChannel magnetometerChannel;
 
   /** Plugin registration. */
-  public static void registerWith(Registrar registrar) {
+  @SuppressWarnings("deprecation")
+  public static void registerWith(io.flutter.plugin.common.PluginRegistry.Registrar registrar) {
     SensorsPlugin plugin = new SensorsPlugin();
     plugin.setupEventChannels(registrar.context(), registrar.messenger());
   }

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: sensors_plus
 description: >
   Flutter plugin for accessing accelerometer, gyroscope, and magnetometer
   sensors.
-version: 1.2.0
+version: 1.3.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

The plugin is updated to use Android v2 embedding, while keeping the registerWith() method for keeping backwards compatibility.
Since it's deprecated, there are warnings on every Android build.
This PR suppresses the warnings.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
