### PR TITLE
Fix alarm_manager_plus for Android 12+

### DIFF
--- a/packages/android_alarm_manager_plus/CHANGELOG.md
+++ b/packages/android_alarm_manager_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.1
+
+- Fix `PendingIntent`s for Android 12+
+
 ## 1.3.0
 
 - migrate integration_test to flutter sdk

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmService.java
@@ -132,7 +132,9 @@ public class AlarmService extends JobIntentService {
     alarm.putExtra("id", requestCode);
     alarm.putExtra("callbackHandle", callbackHandle);
     PendingIntent pendingIntent =
-        PendingIntent.getBroadcast(context, requestCode, alarm, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent.getBroadcast(context, requestCode, alarm,
+		    (Build.VERSION >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0)
+			| PendingIntent.FLAG_UPDATE_CURRENT);
 
     // Use the appropriate clock.
     int clock = AlarmManager.RTC;
@@ -216,7 +218,9 @@ public class AlarmService extends JobIntentService {
     // Cancel the alarm with the system alarm service.
     Intent alarm = new Intent(context, AlarmBroadcastReceiver.class);
     PendingIntent existingIntent =
-        PendingIntent.getBroadcast(context, requestCode, alarm, PendingIntent.FLAG_NO_CREATE);
+        PendingIntent.getBroadcast(context, requestCode, alarm,
+		    (Build.VERSION >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0)
+			| PendingIntent.FLAG_NO_CREATE);
     if (existingIntent == null) {
       Log.i(TAG, "cancel: broadcast receiver not found");
       return;

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmService.java
@@ -132,9 +132,12 @@ public class AlarmService extends JobIntentService {
     alarm.putExtra("id", requestCode);
     alarm.putExtra("callbackHandle", callbackHandle);
     PendingIntent pendingIntent =
-        PendingIntent.getBroadcast(context, requestCode, alarm,
-		    (Build.VERSION >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0)
-			| PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent.getBroadcast(
+            context,
+            requestCode,
+            alarm,
+            (Build.VERSION >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0)
+                | PendingIntent.FLAG_UPDATE_CURRENT);
 
     // Use the appropriate clock.
     int clock = AlarmManager.RTC;
@@ -218,9 +221,12 @@ public class AlarmService extends JobIntentService {
     // Cancel the alarm with the system alarm service.
     Intent alarm = new Intent(context, AlarmBroadcastReceiver.class);
     PendingIntent existingIntent =
-        PendingIntent.getBroadcast(context, requestCode, alarm,
-		    (Build.VERSION >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0)
-			| PendingIntent.FLAG_NO_CREATE);
+        PendingIntent.getBroadcast(
+            context,
+            requestCode,
+            alarm,
+            (Build.VERSION >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0)
+                | PendingIntent.FLAG_NO_CREATE);
     if (existingIntent == null) {
       Log.i(TAG, "cancel: broadcast receiver not found");
       return;

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager_plus
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 1.3.0
+version: 1.3.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

This PR fixes `android_alarm_manager_plus` for Android 12+ by adding the `FLAG_IMMUTABLE` to the `PendingIntent`s.

## Related Issues

Fixes #477

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
