### PR TITLE
Transition of platform channel test interfaces to flutter_test package [WIP]

### DIFF
--- a/packages/sensors_plus/sensors_plus/test/sensors_test.dart
+++ b/packages/sensors_plus/sensors_plus/test/sensors_test.dart
@@ -5,7 +5,8 @@
 import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
+import 'package:flutter_test/flutter_test.dart'
+    show TestDefaultBinaryMessengerBinding, TestWidgetsFlutterBinding;
 import 'package:sensors_plus/sensors_plus.dart';
 import 'package:test/test.dart';
 
@@ -72,7 +73,7 @@ void _initializeFakeSensorChannel(String channelName, List<double> sensorData) {
     );
   }
 
-  ServicesBinding.instance!.defaultBinaryMessenger
+  TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
       .setMockMessageHandler(channelName, (ByteData? message) async {
     final methodCall = standardMethod.decodeMethodCall(message);
     if (methodCall.method == 'listen') {

--- a/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
@@ -5,7 +5,8 @@
 import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
-import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
+import 'package:flutter_test/flutter_test.dart'
+    show TestDefaultBinaryMessengerBinding, TestWidgetsFlutterBinding;
 import 'package:sensors_plus_platform_interface/sensors_plus_platform_interface.dart';
 import 'package:sensors_plus_platform_interface/src/method_channel_sensors.dart';
 import 'package:test/test.dart';
@@ -95,7 +96,7 @@ void _initializeFakeSensorChannel(String channelName, List<double> sensorData) {
     );
   }
 
-  ServicesBinding.instance!.defaultBinaryMessenger
+  TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
       .setMockMessageHandler(channelName, (ByteData? message) async {
     final methodCall = standardMethod.decodeMethodCall(message);
     if (methodCall.method == 'listen') {

--- a/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
+++ b/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
@@ -5,7 +5,8 @@
 import 'dart:io';
 import 'dart:ui';
 
-import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
+import 'package:flutter_test/flutter_test.dart'
+    show TestDefaultBinaryMessengerBinding, TestWidgetsFlutterBinding;
 import 'package:mockito/mockito.dart';
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
 import 'package:share_plus_platform_interface/method_channel/method_channel_share.dart';
@@ -21,8 +22,9 @@ void main() {
   setUp(() {
     mockChannel = MockMethodChannel();
     // Re-pipe to mockito for easier verifies.
-    MethodChannelShare.channel
-        .setMockMethodCallHandler((MethodCall call) async {
+    TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
+        .setMockMethodCallHandler(MethodChannelShare.channel,
+            (MethodCall call) async {
       // The explicit type can be void as the only method call has a return type of void.
       await mockChannel.invokeMethod<void>(call.method, call.arguments);
     });


### PR DESCRIPTION
## Description
Following https://flutter.dev/docs/release/breaking-changes/mock-platform-channels

This depends on updating CI/CD to support flutter > 2.5.0. 

## Related Issues

closes #488 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
