### PR TITLE
fix(android_alarm_manager_plus): Remove deprecated method registerWith

### DIFF
--- a/packages/android_alarm_manager_plus/CHANGELOG.md
+++ b/packages/android_alarm_manager_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0
+
+- Remove deprecated method `registerWith` (of Android v1 embedding)
+
 ## 1.3.2
 
 - Fix build issue introduced in 1.3.1.

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -13,7 +13,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.view.FlutterNativeView;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -41,25 +40,10 @@ import org.json.JSONException;
  * </ol>
  */
 public class AndroidAlarmManagerPlugin implements FlutterPlugin, MethodCallHandler {
-  private static AndroidAlarmManagerPlugin instance;
-  private final String TAG = "AndroidAlarmManagerPlugin";
+  private static final String TAG = "AndroidAlarmManagerPlugin";
   private Context context;
   private Object initializationLock = new Object();
   private MethodChannel alarmManagerPluginChannel;
-
-  /**
-   * Registers this plugin with an associated Flutter execution context, represented by the given
-   * {@link Registrar}.
-   *
-   * <p>Once this method is executed, an instance of {@code AndroidAlarmManagerPlugin} will be
-   * connected to, and running against, the associated Flutter execution context.
-   */
-  public static void registerWith(Registrar registrar) {
-    if (instance == null) {
-      instance = new AndroidAlarmManagerPlugin();
-    }
-    instance.onAttachedToEngine(registrar.context(), registrar.messenger());
-  }
 
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager_plus
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 1.3.2
+version: 2.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

The recently merged PR https://github.com/fluttercommunity/plus_plugins/pull/495 didn't include the removal for this package, because the tests were failing (and to not have too much overhead, I reverted the changes).

This PR does the same as https://github.com/fluttercommunity/plus_plugins/pull/495, but for `android_alarm_manger_plus`, and the checks are successful this time (couldn't check the reason locally because the tests use `melos`, maybe just had to add `static` in line 43/44).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
