### PR TITLE
[network_info_plus] Implemented get ip v6 macos

### DIFF
--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.1
+
+- Add IP v6 to MacOS
+
 ## 2.0.0
 
 - Remove deprecated method `registerWith` (of Android v1 embedding)

--- a/packages/network_info_plus/network_info_plus/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/network_info_plus/network_info_plus/example/macos/Runner.xcodeproj/project.pbxproj
@@ -296,12 +296,15 @@
 			buildActionMask = 2147483647;
 			files = (
 			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/Reachability/Reachability.framework",
+				"${BUILT_PRODUCTS_DIR}/network_info_plus_macos/network_info_plus_macos.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Reachability.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/network_info_plus_macos.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 2.0.0
+version: 2.0.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -27,7 +27,7 @@ dependencies:
   meta: ^1.3.0
   network_info_plus_platform_interface: ^1.0.0
   network_info_plus_linux: ^1.0.0
-  network_info_plus_macos: ^1.0.0
+  network_info_plus_macos: ^1.1.0
   network_info_plus_windows: ^1.0.0
   network_info_plus_web: ^1.0.0
 

--- a/packages/network_info_plus/network_info_plus_macos/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Add IP v6 support
+
 ## 1.0.1
 
 - Improve documentation

--- a/packages/network_info_plus/network_info_plus_macos/macos/Classes/IPHelper.h
+++ b/packages/network_info_plus/network_info_plus_macos/macos/Classes/IPHelper.h
@@ -19,33 +19,3 @@
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 
-NSString* getWifiIP() {
-  NSString* address = @"error";
-  struct ifaddrs* interfaces = NULL;
-  struct ifaddrs* temp_addr = NULL;
-  int success = 0;
-
-  // Retrieve the current interfaces - returns 0 on success.
-  success = getifaddrs(&interfaces);
-  if (success == 0) {
-    // Loop through linked list of interfaces.
-    temp_addr = interfaces;
-    while (temp_addr != NULL) {
-      if (temp_addr->ifa_addr->sa_family == AF_INET) {
-        // Check if interface is en0 which is the wifi connection on the iPhone.
-        if ([[NSString stringWithUTF8String:temp_addr->ifa_name] isEqualToString:@"en0"]) {
-          // Get NSString from C String
-          address = [NSString
-              stringWithUTF8String:inet_ntoa(((struct sockaddr_in*)temp_addr->ifa_addr)->sin_addr)];
-        }
-      }
-
-      temp_addr = temp_addr->ifa_next;
-    }
-  }
-
-  // Free memory
-  freeifaddrs(interfaces);
-
-  return address;
-}

--- a/packages/network_info_plus/network_info_plus_macos/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus_macos
 description: macOS implementation of the network_info_plus plugin.
-version: 1.0.1
+version: 1.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

- Adds a way to obtain IP v6 on MacOS.
- Adds other missing methods on network_info_plus for MacOS.

## Related Issues

- Fix #498 
