### PR TITLE
Update (package_info_plus): Change Readme for more clarity

### DIFF
--- a/packages/package_info_plus/package_info_plus/README.md
+++ b/packages/package_info_plus/package_info_plus/README.md
@@ -24,6 +24,13 @@ application package. This works both on iOS and Android.
 ```dart
 import 'package:package_info_plus/package_info_plus.dart';
 
+... 
+
+// Be sure to add this line if `PackageInfo.fromPlatform()` is called before runApp()
+WidgetsFlutterBinding.ensureInitialized();
+
+...
+
 PackageInfo packageInfo = await PackageInfo.fromPlatform();
 
 String appName = packageInfo.appName;


### PR DESCRIPTION
## Description

This is a minor README update inspired by the same change in #517, but this time for another package. I believe that mentioning `WidgetsFlutterBinding.ensureInitialized()` below code sample as it was before change in this PR is something that some users might miss, while proposed change ensures people will see the note on what should be done in case `fromPlatform()` is called before `runApp()`.

## Related Issues

It is closed already, but still #309 is related here.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
