### PR TITLE
Migrate from deprecated pedantic to flutter_lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,18 +4,9 @@
 #
 # include: ../../analysis_options.yaml
 #
-include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  enable-experiment:
-    - non-nullable
-  exclude:
-    # Ignore generated files
-    - '**/*.g.dart'
-    - 'lib/src/generated/*.dart'
+include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    public_member_api_docs: true
-    prefer_final_in_for_each: true
-    prefer_final_locals: true
+    - prefer_final_in_for_each
+    - prefer_final_locals

--- a/melos.yaml
+++ b/melos.yaml
@@ -243,7 +243,7 @@ scripts:
     melos exec -c 6 -- "flutter clean"
 
 dev_dependencies:
-  pedantic: 1.10.0
+  flutter_lints: 1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/android_alarm_manager_plus/example/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/example/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  pedantic: ^1.9.2
+  flutter_lints: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 flutter:
   plugin:

--- a/packages/android_intent_plus/example/analysis_options.yaml
+++ b/packages/android_intent_plus/example/analysis_options.yaml
@@ -1,14 +1,7 @@
 # TODO: Remove this when migrated to null safety
-include: package:pedantic/analysis_options.yaml
-
-analyzer:
-  exclude:
-    # Ignore generated files
-    - '**/*.g.dart'
-    - 'lib/src/generated/*.dart'
+include: package:flutter_lints/flutter.yaml
 
 linter:
   rules:
-    public_member_api_docs: true
-    prefer_final_in_for_each: true
-    prefer_final_locals: true
+    - prefer_final_in_for_each
+    - prefer_final_locals

--- a/packages/android_intent_plus/example/pubspec.yaml
+++ b/packages/android_intent_plus/example/pubspec.yaml
@@ -15,7 +15,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  pedantic: ^1.8.0
+  flutter_lints: ^1.0.4
 
 # The following section is specific to Flutter.
 flutter:

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -26,4 +26,4 @@ dev_dependencies:
     sdk: flutter
   test: ^1.16.4
   mockito: ^5.0.0
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4

--- a/packages/battery_plus/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/example/pubspec.yaml
@@ -15,7 +15,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  pedantic: ^1.9.2
+  flutter_lints: ^1.0.4
 
 dependency_overrides:
   args: ^2.0.0

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -38,7 +38,7 @@ dev_dependencies:
   async: ^2.5.0
   plugin_platform_interface: ^2.0.0
   test: ^1.16.4
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/battery_plus/battery_plus_linux/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_linux/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 flutter:
   plugin:

--- a/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4

--- a/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
@@ -16,7 +16,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   test: ^1.16.4
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 dependency_overrides:
   args: ^2.0.0

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -41,4 +41,4 @@ dev_dependencies:
   test: ^1.16.4
   mockito: ^5.0.0
   plugin_platform_interface: ^2.0.0
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4

--- a/packages/connectivity_plus/connectivity_plus_linux/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_linux/pubspec.yaml
@@ -21,7 +21,7 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^1.11.5
   mockito: ^5.0.0
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 flutter:
   plugin:

--- a/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4

--- a/packages/connectivity_plus/connectivity_plus_web/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_web/pubspec.yaml
@@ -26,4 +26,4 @@ dev_dependencies:
   test: ^1.16.4
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -12,7 +12,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -35,7 +35,7 @@ dev_dependencies:
   test: ^1.16.4
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/device_info_plus/device_info_plus_web/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_web/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -16,7 +16,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   test: ^1.16.4
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 dependency_overrides:
   args: ^2.0.0

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -37,7 +37,7 @@ dev_dependencies:
   test: ^1.16.4
   mockito: ^5.0.0
   plugin_platform_interface: ^2.0.0
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/network_info_plus/network_info_plus_linux/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_linux/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 flutter:
   plugin:

--- a/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/network_info_plus/network_info_plus_windows/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_windows/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 flutter:
   plugin:

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   test: any
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -34,7 +34,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.16.4
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/package_info_plus/package_info_plus_linux/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_linux/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4

--- a/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/package_info_plus/package_info_plus_web/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_web/pubspec.yaml
@@ -25,7 +25,7 @@ dev_dependencies:
     sdk: flutter
   mockito: ^5.0.7
   build_runner: ^2.0.3
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/package_info_plus/package_info_plus_windows/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_windows/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4

--- a/packages/sensors_plus/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/example/pubspec.yaml
@@ -12,7 +12,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -27,7 +27,7 @@ dev_dependencies:
   test: ^1.16.4
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
   test: ^1.16.4
 
 environment:

--- a/packages/sensors_plus/sensors_plus_web/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus_web/pubspec.yaml
@@ -26,4 +26,4 @@ dev_dependencies:
   test: ^1.16.4
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -13,7 +13,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 flutter:
   uses-material-design: true

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/share_plus/share_plus_linux/pubspec.yaml
+++ b/packages/share_plus/share_plus_linux/pubspec.yaml
@@ -19,5 +19,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
   url_launcher_platform_interface: ^2.0.2

--- a/packages/share_plus/share_plus_macos/pubspec.yaml
+++ b/packages/share_plus/share_plus_macos/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 flutter:
   plugin:

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -15,7 +15,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
   test: ^1.16.4
 
 environment:

--- a/packages/share_plus/share_plus_web/pubspec.yaml
+++ b/packages/share_plus/share_plus_web/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/share_plus/share_plus_windows/pubspec.yaml
+++ b/packages/share_plus/share_plus_windows/pubspec.yaml
@@ -18,5 +18,5 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0
+  flutter_lints: ^1.0.4
   url_launcher_platform_interface: ^2.0.2


### PR DESCRIPTION
## Description

Migrated all packages from deprecated `pedantic` to `flutter_lints`. 
Added dev_dependency on package: `flutter_lints` to all project’s pubspec.yaml

Since the project already had a custom `analysis_options.yaml` file at its root, I added `include: package:flutter_lints/flutter.yaml` to it.


## Related Issues

#471

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
