### PR TITLE
Replaced print in production with developer log

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,9 +11,6 @@ analyzer:
     # Ignore generated files
     - '**/*.g.dart'
     - 'lib/src/generated/*.dart'
-  
-  errors:
-    avoid_print: ignore
 
 linter:
   rules:

--- a/packages/android_alarm_manager_plus/example/lib/main.dart
+++ b/packages/android_alarm_manager_plus/example/lib/main.dart
@@ -11,6 +11,7 @@ import 'dart:ui';
 import 'package:android_alarm_manager_plus/android_alarm_manager_plus.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/material.dart';
+import 'dart:developer' as developer;
 
 /// The [SharedPreferences] key to access the alarm fire count.
 const String countKey = 'count';
@@ -78,7 +79,7 @@ class _AlarmHomePageState extends State<_AlarmHomePage> {
   }
 
   Future<void> _incrementCounter() async {
-    print('Increment counter!');
+    developer.log('Increment counter!');
 
     // Ensure we've loaded the updated count from the background isolate.
     await prefs.reload();
@@ -93,7 +94,7 @@ class _AlarmHomePageState extends State<_AlarmHomePage> {
 
   // The callback for our alarm
   static Future<void> callback() async {
-    print('Alarm fired!');
+    developer.log('Alarm fired!');
 
     // Get the previous cached count and increment it.
     final prefs = await SharedPreferences.getInstance();

--- a/packages/android_alarm_manager_plus/lib/android_alarm_manager_plus.dart
+++ b/packages/android_alarm_manager_plus/lib/android_alarm_manager_plus.dart
@@ -8,6 +8,7 @@ import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'dart:developer' as developer;
 
 const String _backgroundName =
     'dev.fluttercommunity.plus/android_alarm_manager_background';
@@ -33,7 +34,7 @@ void _alarmManagerCallbackDispatcher() {
     final closure = PluginUtilities.getCallbackFromHandle(handle);
 
     if (closure == null) {
-      print('Fatal: could not find callback');
+      developer.log('Fatal: could not find callback');
       exit(-1);
     }
 

--- a/packages/battery_plus/battery_plus/example/test_driver/battery_plus_e2e.dart
+++ b/packages/battery_plus/battery_plus/example/test_driver/battery_plus_e2e.dart
@@ -7,6 +7,7 @@
 import 'package:battery_plus/battery_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
+import 'dart:developer' as developer;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -21,7 +22,7 @@ void main() {
       (WidgetTester tester) async {
     final battery = Battery();
     final isInBatterySaveMode = await battery.isInBatterySaveMode;
-    print(isInBatterySaveMode);
+    developer.log(isInBatterySaveMode.toString());
     expect(isInBatterySaveMode, isNotNull);
   });
 }

--- a/packages/battery_plus/battery_plus_linux/lib/src/upower_device.dart
+++ b/packages/battery_plus/battery_plus_linux/lib/src/upower_device.dart
@@ -1,5 +1,6 @@
 // ignore: import_of_legacy_library_into_null_safe
 import 'package:dbus/dbus.dart';
+import 'dart:developer' as developer;
 
 const _kInterface = 'org.freedesktop.UPower';
 const _kDeviceAddress = 'org.freedesktop.UPower.Device';
@@ -42,14 +43,14 @@ class UPowerDevice extends DBusRemoteObject {
   Future<double> getPercentage() {
     return getProperty(_kDeviceAddress, 'Percentage').then(
       (value) => (value as DBusDouble).value,
-      onError: (error) => print(error),
+      onError: (error) => developer.log(error),
     );
   }
 
   Future<UPowerBatteryState> getState() {
     return getProperty(_kDeviceAddress, 'State').then(
       (value) => (value as DBusUint32).value.toBatteryState(),
-      onError: (error) => print(error),
+      onError: (error) => developer.log(error),
     );
   }
 

--- a/packages/connectivity_plus/connectivity_plus/example/lib/main.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'dart:developer' as developer;
 
 void main() {
   runApp(const MyApp());
@@ -67,7 +68,7 @@ class _MyHomePageState extends State<MyHomePage> {
     try {
       result = await _connectivity.checkConnectivity();
     } on PlatformException catch (e) {
-      print(e.toString());
+      developer.log(e.toString());
       return;
     }
 

--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -11,13 +11,14 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:device_info_plus/device_info_plus.dart';
+import 'dart:developer' as developer;
 
 void main() {
   runZonedGuarded(() {
     runApp(const MyApp());
   }, (dynamic error, dynamic stack) {
-    print(error);
-    print(stack);
+    developer.log(error);
+    developer.log(stack);
   });
 }
 

--- a/packages/network_info_plus/network_info_plus/example/lib/main.dart
+++ b/packages/network_info_plus/network_info_plus/example/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:network_info_plus/network_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'dart:developer' as developer;
 
 // Sets a platform override for desktop to avoid exceptions. See
 // https://flutter.dev/desktop#target-platform-override for more info.
@@ -95,7 +96,7 @@ class _MyHomePageState extends State<MyHomePage> {
         wifiName = await _networkInfo.getWifiName();
       }
     } on PlatformException catch (e) {
-      print(e.toString());
+      developer.log(e.toString());
       wifiName = 'Failed to get Wifi Name';
     }
 
@@ -115,49 +116,49 @@ class _MyHomePageState extends State<MyHomePage> {
         wifiBSSID = await _networkInfo.getWifiBSSID();
       }
     } on PlatformException catch (e) {
-      print(e.toString());
+      developer.log(e.toString());
       wifiBSSID = 'Failed to get Wifi BSSID';
     }
 
     try {
       wifiIPv4 = await _networkInfo.getWifiIP();
     } on PlatformException catch (e) {
-      print(e.toString());
+      developer.log(e.toString());
       wifiIPv4 = 'Failed to get Wifi IPv4';
     }
 
     try {
       wifiIPv6 = await _networkInfo.getWifiIPv6();
     } on PlatformException catch (e) {
-      print(e.toString());
+      developer.log(e.toString());
       wifiIPv6 = 'Failed to get Wifi IPv6';
     }
 
     try {
       wifiSubmask = await _networkInfo.getWifiSubmask();
     } on PlatformException catch (e) {
-      print(e.toString());
+      developer.log(e.toString());
       wifiSubmask = 'Failed to get Wifi submask address';
     }
 
     try {
       wifiBroadcast = await _networkInfo.getWifiBroadcast();
     } on PlatformException catch (e) {
-      print(e.toString());
+      developer.log(e.toString());
       wifiBroadcast = 'Failed to get Wifi broadcast';
     }
 
     try {
       wifiGatewayIP = await _networkInfo.getWifiGatewayIP();
     } on PlatformException catch (e) {
-      print(e.toString());
+      developer.log(e.toString());
       wifiGatewayIP = 'Failed to get Wifi gateway address';
     }
 
     try {
       wifiSubmask = await _networkInfo.getWifiSubmask();
     } on PlatformException catch (e) {
-      print(e.toString());
+      developer.log(e.toString());
       wifiSubmask = 'Failed to get Wifi submask';
     }
 

--- a/packages/sensors_plus/sensors_plus_web/lib/src/sensors.dart
+++ b/packages/sensors_plus/sensors_plus_web/lib/src/sensors.dart
@@ -5,6 +5,7 @@ import 'dart:js';
 import 'dart:js_util';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:sensors_plus_platform_interface/sensors_plus_platform_interface.dart';
+import 'dart:developer' as developer;
 
 /// The sensors plugin.
 class SensorsPlugin extends SensorsPlatform {
@@ -35,11 +36,11 @@ class SensorsPlugin extends SensorsPlatform {
       /// See Feature-Policy for implementation instructions in the browsers.
       if (error.toString().contains('SecurityError')) {
         /// See the note above about feature policy.
-        print('$apiName construction was blocked by a feature policy.');
+        developer.log('$apiName construction was blocked by a feature policy.');
 
         /// if this feature is not supported or Flag is not enabled yet!
       } else if (error.toString().contains('ReferenceError')) {
-        print('$apiName is not supported by the User Agent.');
+        developer.log('$apiName is not supported by the User Agent.');
 
         /// if this is unknown error, rethrow it
       } else {
@@ -78,7 +79,8 @@ class SensorsPlugin extends SensorsPlatform {
           _accelerometer.start();
 
           _accelerometer.onError.forEach(
-            (e) => print('The Api is supported but something is wrong! $e'),
+            (e) => developer
+                .log('The Api is supported but something is wrong! $e'),
           );
         },
         apiName: 'Accelerometer()',
@@ -124,7 +126,8 @@ class SensorsPlugin extends SensorsPlatform {
           _gyroscope.start();
 
           _gyroscope.onError.forEach(
-            (e) => print('The Api is supported but something is wrong! $e'),
+            (e) => developer
+                .log('The Api is supported but something is wrong! $e'),
           );
         },
         apiName: 'Gyroscope()',
@@ -171,7 +174,8 @@ class SensorsPlugin extends SensorsPlatform {
           _linearAccelerationSensor.start();
 
           _linearAccelerationSensor.onError.forEach(
-            (e) => print('The Api is supported but something is wrong! $e'),
+            (e) => developer
+                .log('The Api is supported but something is wrong! $e'),
           );
         },
         apiName: 'LinearAccelerationSensor()',
@@ -218,8 +222,8 @@ class SensorsPlugin extends SensorsPlatform {
           _magnetometerSensor.start();
 
           _magnetometerSensor.onError.forEach(
-            (e) =>
-                print('[SensorsPlugin] API supported but something is wrong: '
+            (e) => developer
+                .log('[SensorsPlugin] API supported but something is wrong: '
                     'Magnetometer $e'),
           );
         },

--- a/packages/sensors_plus/sensors_plus_web/lib/src/utils.dart
+++ b/packages/sensors_plus/sensors_plus_web/lib/src/utils.dart
@@ -1,4 +1,5 @@
 import 'dart:html' as html;
+import 'dart:developer' as developer;
 
 /// Receive permission status of the API.
 Future<void> checkPremission(
@@ -20,21 +21,21 @@ Future<void> checkPremission(
         initSensor();
       } else if (premissionStatus.state == 'prompt') {
         /// user needs to intract with this
-        print(
+        developer.log(
           'Premission [$premissionName] still has not been granted or denied.',
         );
       } else {
         // If permission is denied, do not do anything
-        print('Permission [$premissionName] to use sensor was denied.');
+        developer.log('Permission [$premissionName] to use sensor was denied.');
       }
     } catch (e) {
-      print(
+      developer.log(
         'Integration with Permissions API is not enabled, still try to start app.',
       );
       initSensor();
     }
   } else {
-    print('No Permissions API, still try to start app.');
+    developer.log('No Permissions API, still try to start app.');
     initSensor();
   }
 }


### PR DESCRIPTION
## Description

Removes `avoid_print: ignore` from analysis_options.yaml and replaces all `print()` in production with `developer.log()`

## Related Issues

> I would suggest switching from `print` to `dart:developer` as it is suggested here https://flutter.dev/docs/testing/code-debugging#logging
Or there is a specific reason to stick with `print`?

_Originally posted in https://github.com/fluttercommunity/plus_plugins/issues/519#issuecomment-935799373_

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
