### PR TITLE
update connectivity docs

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
@@ -52,6 +52,10 @@ class Connectivity {
   }
 
   /// Fires whenever the connectivity state changes.
+  ///
+  /// On iOS, the connectivity status might not update when WiFi
+  /// status changes, this is a known issue that only affects simulators.
+  /// For details see https://github.com/fluttercommunity/plus_plugins/issues/479.
   Stream<ConnectivityResult> get onConnectivityChanged {
     return _platform.onConnectivityChanged;
   }


### PR DESCRIPTION
## Description

updated connectivity docs making the user aware of ambiguous action / bug when the WiFi state changes on iOS simulators 



## Related Issues

related to #479 


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
