### PR TITLE
fix(package_info): file version info - field must be external in struct

### DIFF
--- a/packages/package_info_plus/package_info_plus_windows/lib/src/file_version_info.dart
+++ b/packages/package_info_plus/package_info_plus_windows/lib/src/file_version_info.dart
@@ -10,10 +10,10 @@ part of package_info_plus_windows;
 
 class _LANGANDCODEPAGE extends Struct {
   @Uint16()
-  int? wLanguage;
+  external int? wLanguage;
 
   @Uint16()
-  int? wCodePage;
+  external int? wCodePage;
 }
 
 final _kernel32 = DynamicLibrary.open('kernel32.dll');


### PR DESCRIPTION
## Description

Fix the lint problem (error)
```
Fields of 'Struct' and 'Union' subclasses must be marked external.
Try adding the 'external' modifier.dart(field_must_be_external_in_struct)
```
<img width="1007" alt="Screenshot 2021-10-13 at 1 29 30 AM" src="https://user-images.githubusercontent.com/7347854/137021906-5c081f73-f0b5-407d-8f30-1ee50e9e9497.png">


## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
