### PR TITLE
fix(share_plus): image_picker pickImage not defined

### DIFF
--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -67,7 +67,7 @@ class DemoAppState extends State<DemoApp> {
                     title: const Text('Add image'),
                     onTap: () async {
                       final imagePicker = ImagePicker();
-                      final pickedFile = await imagePicker.pickImage(
+                      final pickedFile = await imagePicker.getImage(
                         source: ImageSource.gallery,
                       );
                       if (pickedFile != null) {


### PR DESCRIPTION
## Description

```
The method 'pickImage' isn't defined for the type 'ImagePicker'.
Try correcting the name to the name of an existing method, or defining a method named 'pickImage'.
```
<img width="1440" alt="Screenshot 2021-10-13 at 2 12 29 AM" src="https://user-images.githubusercontent.com/7347854/137026540-82868ef2-4d39-4efc-af99-c9c970822a71.png">


## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
