### PR TITLE
fix(share_plus): lint problem - method isn't defined - setMockMethodCallHandler

### DIFF
--- a/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
+++ b/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
@@ -5,13 +5,13 @@
 import 'dart:io';
 import 'dart:ui';
 
-import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
-import 'package:mockito/mockito.dart';
-import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
-import 'package:share_plus_platform_interface/method_channel/method_channel_share.dart';
-import 'package:test/test.dart';
-
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
+import 'package:flutter_test/src/deprecated.dart';
+import 'package:mockito/mockito.dart';
+import 'package:share_plus_platform_interface/method_channel/method_channel_share.dart';
+import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
+import 'package:test/test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
## Description

```
The method 'setMockMethodCallHandler' isn't defined for the type 'MethodChannel'.
Try correcting the name to the name of an existing method, or defining a method named 'setMockMethodCallHandler'.
```

<img width="851" alt="Screenshot 2021-10-13 at 2 38 06 AM" src="https://user-images.githubusercontent.com/7347854/137029591-252964a5-9b3c-4185-894e-6ca59659f9e5.png">

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
