### PR TITLE
[Github Actions] Separate Flutter Analyze from pub.dev validation

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   analyze:
-    name: "Analyze"
+    name: "Flutter Analyze"
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -29,8 +29,23 @@ jobs:
           ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
         run: melos bootstrap
-      - name: "Run Analyze"
+      - name: "Run Flutter Analyze"
         run: melos run analyze
+  
+  pub_dev_publish_check:
+    name: "Check pub.dev requirements"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: |
+          ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
       - name: "Pub Check"
         run: |
           melos exec -c 1 --no-private --ignore="*example*" -- \
@@ -54,7 +69,7 @@ jobs:
             "flutter pub get"
 
   check_formatting:
-    name: "Check formatting"
+    name: "Check code formatting"
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:


### PR DESCRIPTION
## Description

This PR separates Flutter analyze step from validations if pub.dev requirements are met for publishing. This change will provide more clarity when something fails from publishing point of view or the code analyzer.

For further updates for even better granularity I would move more operations to corresponding plugins workflows and run `all_plugins` workflows only after merging the PR, while run all validations/checks in the corresponding plugin related workflow.

## Related Issues

-

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
