### PR TITLE
fix(android_intent_plus): fixed a bug!

### DIFF
--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.2
+
+- Fixed the buildIntent method to do not set the pacakage to null if it's not resolvable
+- UPdated the example of resolving intent with explicitly defined package name
+
 ## 3.0.1
 
 - Upgrade dependencies and Android compile version

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
@@ -98,6 +98,9 @@ public final class IntentSender {
     }
 
     final PackageManager packageManager = applicationContext.getPackageManager();
+    boolean result =
+        packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null;
+    Log.d(TAG, "" + result);
 
     return packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null;
   }
@@ -171,10 +174,6 @@ public final class IntentSender {
       intent.setPackage(packageName);
       if (componentName != null) {
         intent.setComponent(componentName);
-      }
-      if (intent.resolveActivity(applicationContext.getPackageManager()) == null) {
-        Log.i(TAG, "Cannot resolve explicit intent - ignoring package");
-        intent.setPackage(null);
       }
     }
 

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
@@ -98,10 +98,6 @@ public final class IntentSender {
     }
 
     final PackageManager packageManager = applicationContext.getPackageManager();
-    boolean result =
-        packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null;
-    Log.d(TAG, "" + result);
-
     return packageManager.resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY) != null;
   }
 

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
@@ -172,6 +172,9 @@ public final class IntentSender {
         intent.setComponent(componentName);
       }
     }
+    if (intent.resolveActivity(applicationContext.getPackageManager()) == null) {
+      Log.i(TAG, "Cannot resolve explicit intent");
+    }
 
     return intent;
   }

--- a/packages/android_intent_plus/example/lib/main.dart
+++ b/packages/android_intent_plus/example/lib/main.dart
@@ -112,18 +112,13 @@ class MyHomePage extends StatelessWidget {
 }
 
 /// Launches intents to specific Android activities.
-class ExplicitIntentsWidget extends StatefulWidget {
+class ExplicitIntentsWidget extends StatelessWidget {
   // ignore: use_key_in_widget_constructors
   const ExplicitIntentsWidget(); // ignore: public_member_api_docs
 
   // ignore: public_member_api_docs
   static const String routeName = '/explicitIntents';
 
-  @override
-  State<ExplicitIntentsWidget> createState() => _ExplicitIntentsWidgetState();
-}
-
-class _ExplicitIntentsWidgetState extends State<ExplicitIntentsWidget> {
   void _openGoogleMapsStreetView() {
     final intent = AndroidIntent(
         action: 'action_view',
@@ -149,19 +144,12 @@ class _ExplicitIntentsWidgetState extends State<ExplicitIntentsWidget> {
     intent.launch();
   }
 
-  bool _intentResolved;
-
-  Future<void> _openLinkInGoogleChrome() async {
+  void _openLinkInGoogleChrome() {
     final intent = AndroidIntent(
         action: 'action_view',
         data: Uri.encodeFull('https://flutter.dev'),
         package: 'com.android.chrome');
-    bool intentResolved;
-    final bool result = await intent.canResolveActivity();
-    intentResolved = result;
-    setState(() {
-      _intentResolved = intentResolved;
-    });
+    intent.launch();
   }
 
   void _startActivityInNewTask() {
@@ -226,7 +214,6 @@ class _ExplicitIntentsWidgetState extends State<ExplicitIntentsWidget> {
                 onPressed: _openLinkInGoogleChrome,
                 child: const Text('Tap here to open link in Google Chrome.'),
               ),
-              Text("Chrome application exists: $_intentResolved"),
               ElevatedButton(
                 onPressed: _startActivityInNewTask,
                 child: const Text('Tap here to start activity in new task.'),

--- a/packages/android_intent_plus/example/lib/main.dart
+++ b/packages/android_intent_plus/example/lib/main.dart
@@ -112,13 +112,18 @@ class MyHomePage extends StatelessWidget {
 }
 
 /// Launches intents to specific Android activities.
-class ExplicitIntentsWidget extends StatelessWidget {
+class ExplicitIntentsWidget extends StatefulWidget {
   // ignore: use_key_in_widget_constructors
   const ExplicitIntentsWidget(); // ignore: public_member_api_docs
 
   // ignore: public_member_api_docs
   static const String routeName = '/explicitIntents';
 
+  @override
+  State<ExplicitIntentsWidget> createState() => _ExplicitIntentsWidgetState();
+}
+
+class _ExplicitIntentsWidgetState extends State<ExplicitIntentsWidget> {
   void _openGoogleMapsStreetView() {
     final intent = AndroidIntent(
         action: 'action_view',
@@ -144,12 +149,19 @@ class ExplicitIntentsWidget extends StatelessWidget {
     intent.launch();
   }
 
-  void _openLinkInGoogleChrome() {
+  bool _intentResolved;
+
+  Future<void> _openLinkInGoogleChrome() async {
     final intent = AndroidIntent(
         action: 'action_view',
         data: Uri.encodeFull('https://flutter.dev'),
         package: 'com.android.chrome');
-    intent.launch();
+    bool intentResolved;
+    final bool result = await intent.canResolveActivity();
+    intentResolved = result;
+    setState(() {
+      _intentResolved = intentResolved;
+    });
   }
 
   void _startActivityInNewTask() {
@@ -214,6 +226,7 @@ class ExplicitIntentsWidget extends StatelessWidget {
                 onPressed: _openLinkInGoogleChrome,
                 child: const Text('Tap here to open link in Google Chrome.'),
               ),
+              Text("Chrome application exists: $_intentResolved"),
               ElevatedButton(
                 onPressed: _startActivityInNewTask,
                 child: const Text('Tap here to start activity in new task.'),

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 3.0.1
+version: 3.0.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

* In this PR, I have fixed the issue related to setting the package to `null` in `buildIntent()` method. With this fix, `buildIntent()` will not reset the package if the given `intent` is not resolvable which helps to get the expected results from `canResolveActivity()` method.

## Related Issues

[#245](https://github.com/fluttercommunity/plus_plugins/issues/245)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
