### PR TITLE
[examples] explicitly override deps

### DIFF
--- a/packages/battery_plus/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/example/pubspec.yaml
@@ -10,15 +10,24 @@ dependencies:
   battery_plus:
     path: ../
 
+dependency_overrides:
+  battery_plus_linux:
+    path: ../../battery_plus_linux
+  battery_plus_macos:
+    path: ../../battery_plus_macos
+  battery_plus_platform_interface:
+    path: ../../battery_plus_platform_interface
+  battery_plus_web:
+    path: ../../battery_plus_web
+  battery_plus_windows:
+    path: ../../battery_plus_windows
+
 dev_dependencies:
   flutter_driver:
     sdk: flutter
   integration_test:
     sdk: flutter
   flutter_lints: ^1.0.4
-
-dependency_overrides:
-  args: ^2.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
@@ -10,6 +10,18 @@ dependencies:
   connectivity_plus:
     path: ../
 
+dependency_overrides:
+  connectivity_plus_linux:
+    path: ../../connectivity_plus_linux
+  connectivity_plus_macos:
+    path: ../../connectivity_plus_macos
+  connectivity_plus_platform_interface:
+    path: ../../connectivity_plus_platform_interface
+  connectivity_plus_web:
+    path: ../../connectivity_plus_web
+  connectivity_plus_windows:
+    path: ../../connectivity_plus_windows
+
 dev_dependencies:
   flutter_driver:
     sdk: flutter
@@ -17,9 +29,6 @@ dev_dependencies:
     sdk: flutter
   test: ^1.16.4
   flutter_lints: ^1.0.4
-
-dependency_overrides:
-  args: ^2.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -7,6 +7,18 @@ dependencies:
   device_info_plus:
     path: ../
 
+dependency_overrides:
+  device_info_plus_linux:
+    path: ../../device_info_plus_linux
+  device_info_plus_macos:
+    path: ../../device_info_plus_macos
+  device_info_plus_platform_interface:
+    path: ../../device_info_plus_platform_interface
+  device_info_plus_web:
+    path: ../../device_info_plus_web
+  device_info_plus_windows:
+    path: ../../device_info_plus_windows
+
 dev_dependencies:
   flutter_driver:
     sdk: flutter

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -10,6 +10,18 @@ dependencies:
   network_info_plus:
     path: ../
 
+dependency_overrides:
+  network_info_plus_linux:
+    path: ../../network_info_plus_linux
+  network_info_plus_macos:
+    path: ../../network_info_plus_macos
+  network_info_plus_platform_interface:
+    path: ../../network_info_plus_platform_interface
+  network_info_plus_web:
+    path: ../../network_info_plus_web
+  network_info_plus_windows:
+    path: ../../network_info_plus_windows
+
 dev_dependencies:
   flutter_driver:
     sdk: flutter
@@ -17,9 +29,6 @@ dev_dependencies:
     sdk: flutter
   test: ^1.16.4
   flutter_lints: ^1.0.4
-
-dependency_overrides:
-  args: ^2.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -13,6 +13,18 @@ dependencies:
   package_info_plus:
     path: ../
 
+dependency_overrides:
+  package_info_plus_linux:
+    path: ../../package_info_plus_linux
+  package_info_plus_macos:
+    path: ../../package_info_plus_macos
+  package_info_plus_platform_interface:
+    path: ../../package_info_plus_platform_interface
+  package_info_plus_web:
+    path: ../../package_info_plus_web
+  package_info_plus_windows:
+    path: ../../package_info_plus_windows
+
 dev_dependencies:
   integration_test:
     sdk: flutter

--- a/packages/sensors_plus/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/example/pubspec.yaml
@@ -7,6 +7,12 @@ dependencies:
   sensors_plus:
     path: ../
 
+dependency_overrides:
+  sensors_plus_platform_interface:
+    path: ../../sensors_plus_platform_interface
+  sensors_plus_web:
+    path: ../../sensors_plus_web
+
 dev_dependencies:
   flutter_driver:
     sdk: flutter

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -8,6 +8,18 @@ dependencies:
     path: ../
   image_picker: ^0.8.4+2
 
+dependency_overrides:
+  share_plus_linux:
+    path: ../../share_plus_linux
+  share_plus_macos:
+    path: ../../share_plus_macos
+  share_plus_platform_interface:
+    path: ../../share_plus_platform_interface
+  share_plus_web:
+    path: ../../share_plus_web
+  share_plus_windows:
+    path: ../../share_plus_windows
+
 dev_dependencies:
   flutter_driver:
     sdk: flutter


### PR DESCRIPTION
## Description

This PR explicitly specify platform-specific implementation paths in example apps.

The reason is the nature of federated plugins. In example apps main package is always specified via path. In case of unfederated plugin, it's platform-specific implementations are already part of the main package and will be picked up when building example (thus accounting for changes in any platform implementation). However with federated plugins main package has it's platform-specific implementations as version-locked dependencies. Building example app takes main package via path (thus accounting for changes Android/iOS implementations), but other platform implementations are resolved to published versions in pub ignoring current changes.

Specifying paths explicitly fixes CI's `pub_get_check` job and resolves failing check in #571 because it does not depend on running `melos`. As far as get this repo's CI configuration is built after [flutterfire] which uses same checks and build steps. See [firebase_core/example] how they do the same. A more complex example is [firebase_database/example] in which they specify platform-specific implementations for transitive dependencies for packages in the same monorepo.

It also removes `args` from examples' `dependency_overrides`. Some packages don't have it and they run perfectly fine. Not sure what it was used for, so I've removed it.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[flutterfire]: https://github.com/FirebaseExtended/flutterfire
[firebase_core/example]: https://github.com/FirebaseExtended/flutterfire/blob/cb510af6b401e909a883dcd8c17eadecf77016e1/packages/firebase_core/firebase_core/example/pubspec.yaml#L13-L17
[firebase_database/example]: https://github.com/FirebaseExtended/flutterfire/blob/cb510af6b401e909a883dcd8c17eadecf77016e1/packages/firebase_database/firebase_database/example/pubspec.yaml#L8-L30