### PR TITLE
feat(device_info_plus): add toMap method to WebBrowserInfo

### DIFF
--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+- add toMap to WebBrowserInfo
+
 ## 3.1.0
 
 - add System GUID to MacOS

--- a/packages/device_info_plus/device_info_plus/lib/device_info_plus.dart
+++ b/packages/device_info_plus/device_info_plus/lib/device_info_plus.dart
@@ -14,7 +14,8 @@ export 'package:device_info_plus_platform_interface/device_info_plus_platform_in
         LinuxDeviceInfo,
         MacOsDeviceInfo,
         WindowsDeviceInfo,
-        WebBrowserInfo;
+        WebBrowserInfo,
+        BrowserName;
 
 /// Provides device and operating system information.
 class DeviceInfoPlugin {

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 3.1.0
+version: 3.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+- add toMap to WebBrowserInfo
+
 ## 2.2.0
 
 - add System GUID to MacOS

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/web_browser_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/web_browser_info.dart
@@ -129,6 +129,7 @@ class WebBrowserInfo {
   /// Serializes [ WebBrowserInfo ] to a map.
   Map<String, dynamic> toMap() {
     return {
+      'browserName': browserName,
       'appCodeName': appCodeName,
       'appName': appName,
       'appVersion': appVersion,

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/web_browser_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/web_browser_info.dart
@@ -126,6 +126,26 @@ class WebBrowserInfo {
     );
   }
 
+  /// Serializes [ WebBrowserInfo ] to a map.
+  Map<String, dynamic> toMap() {
+    return {
+      'appCodeName': appCodeName,
+      'appName': appName,
+      'appVersion': appVersion,
+      'deviceMemory': deviceMemory,
+      'language': language,
+      'languages': languages,
+      'platform': platform,
+      'product': product,
+      'productSub': productSub,
+      'userAgent': userAgent,
+      'vendor': vendor,
+      'vendorSub': vendorSub,
+      'hardwareConcurrency': hardwareConcurrency,
+      'maxTouchPoints': maxTouchPoints,
+    };
+  }
+
   BrowserName _parseUserAgentToBrowserName() {
     final _userAgent = userAgent;
     if (_userAgent == null) {

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_platform_interface
-description: A common platform interface for the device_info_plis plugin.
-version: 2.2.0
+description: A common platform interface for the device_info_plus plugin.
+version: 2.2.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/web_browser_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/web_browser_info_test.dart
@@ -1,0 +1,51 @@
+import 'package:device_info_plus_platform_interface/model/web_browser_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('$WebBrowserInfo', () {
+    group('fromMap | toMap', () {
+      const webBrowserInfoMap = <String, dynamic>{
+        'browserName': BrowserName.safari,
+        'appCodeName': 'appCodeName',
+        'appName': 'appName',
+        'appVersion': 'appVersion',
+        'deviceMemory': 42,
+        'language': 'language',
+        'languages': ['en', 'es'],
+        'platform': 'platform',
+        'product': 'product',
+        'productSub': 'productSub',
+        'userAgent': 'Safari',
+        'vendor': 'vendor',
+        'vendorSub': 'vendorSub',
+        'hardwareConcurrency': 2,
+        'maxTouchPoints': 42,
+      };
+
+      test('fromMap should return $WebBrowserInfo with correct values', () {
+        final webBrowserInfo = WebBrowserInfo.fromMap(webBrowserInfoMap);
+
+        expect(webBrowserInfo.browserName, BrowserName.safari);
+        expect(webBrowserInfo.appCodeName, 'appCodeName');
+        expect(webBrowserInfo.appName, 'appName');
+        expect(webBrowserInfo.appVersion, 'appVersion');
+        expect(webBrowserInfo.deviceMemory, 42);
+        expect(webBrowserInfo.language, 'language');
+        expect(webBrowserInfo.languages, ['en', 'es']);
+        expect(webBrowserInfo.platform, 'platform');
+        expect(webBrowserInfo.product, 'product');
+        expect(webBrowserInfo.productSub, 'productSub');
+        expect(webBrowserInfo.userAgent, 'Safari');
+        expect(webBrowserInfo.vendor, 'vendor');
+        expect(webBrowserInfo.vendorSub, 'vendorSub');
+        expect(webBrowserInfo.hardwareConcurrency, 2);
+        expect(webBrowserInfo.maxTouchPoints, 42);
+      });
+
+      test('toMap should return map with correct key and map', () {
+        final webBrowserInfo = WebBrowserInfo.fromMap(webBrowserInfoMap);
+        expect(webBrowserInfo.toMap(), webBrowserInfoMap);
+      });
+    });
+  });
+}


### PR DESCRIPTION
## Description

Adds `toMap` method to serialize `WebBrowserInfo` on `device_info_plus`.

## Related Issues

Closes #592.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
