### PR TITLE
[connectivity_plus] Add missing Gradle wrapper, dependencies bump

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.0.3'
     }
 }
 

--- a/packages/connectivity_plus/connectivity_plus/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/connectivity_plus/connectivity_plus/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionPath=wrapper/dists
+zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 2.0.2
+version: 2.0.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -28,7 +28,6 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
   connectivity_plus_platform_interface: ^1.1.0
   connectivity_plus_linux: ^1.1.0
   connectivity_plus_macos: ^1.2.0

--- a/packages/connectivity_plus/connectivity_plus_linux/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_plus_linux
 description: Linux implementation of the connectivity_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -12,9 +12,8 @@ dependencies:
   flutter:
     sdk: flutter
   connectivity_plus_platform_interface: ^1.1.0
-  dbus: ^0.5.1
-  meta: ^1.3.0
-  nm: ^0.3.0
+  meta: ^1.7.0
+  nm: ^0.4.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_platform_interface
 description: A common platform interface for the connectivity_plus plugin.
-version: 1.1.0
+version: 1.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
+  meta: ^1.7.0
   plugin_platform_interface: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
## Description

Found out that ConnectivityPlus for Android had no Gradle wrapper config pushed. To be consistent with other packages and to not rely on local Gradle version some maintainer might have I added `gradle-wrapper.properties`.
Also, went through other platforms and did some updates/clean ups for dependencies used.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
