### PR TITLE
[network_info_plus_ios] fix undefined behaviour

### DIFF
--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Fix issue with getWifiInterface on iOS. See PR #605 for more info.
+
 ## 2.1.0
 
 - macOS: Add submask, broadcast, gateway info

--- a/packages/network_info_plus/network_info_plus/ios/Classes/FLTNetworkInfoPlusPlugin.m
+++ b/packages/network_info_plus/network_info_plus/ios/Classes/FLTNetworkInfoPlusPlugin.m
@@ -16,6 +16,7 @@
 #include <ifaddrs.h>
 
 #include <arpa/inet.h>
+#include <netdb.h>
 
 @interface FLTNetworkInfoPlusPlugin () <CLLocationManagerDelegate>
 
@@ -60,50 +61,44 @@
   if (gatewayAdressResult >= 0) {
     return [NSString stringWithFormat:@"%s", inet_ntoa(gatewayAddr)];
   } else {
-    return @"error";
+    return nil;
   }
 }
 
 - (NSString*)getWifiIP {
-  struct ifaddrs* temp_addr = [self getWifiInterfaceIPv4];
-  if (temp_addr) {
-    return [NSString
-        stringWithUTF8String:inet_ntoa(((struct sockaddr_in*)temp_addr->ifa_addr)->sin_addr)];
-  } else {
-    return @"error";
-  }
+  __block NSString* addr = nil;
+  [self enumerateWifiAddresses:AF_INET
+                    usingBlock:^(struct ifaddrs* ifaddr) {
+                      addr = [self descriptionForAddress:ifaddr->ifa_addr];
+                    }];
+  return addr;
 }
 
 - (NSString*)getWifiIPv6 {
-  struct ifaddrs* temp_addr = [self getWifiInterfaceIPv6];
-  if (temp_addr) {
-    char ipv6AddressBuffer[MAX(INET_ADDRSTRLEN, INET6_ADDRSTRLEN)];
-    const struct sockaddr_in6* addr6 = (const struct sockaddr_in6*)temp_addr->ifa_addr;
-    return [NSString stringWithUTF8String:inet_ntop(AF_INET6, &addr6->sin6_addr, ipv6AddressBuffer,
-                                                    INET6_ADDRSTRLEN)];
-  } else {
-    return @"error";
-  }
+  __block NSString* addr = nil;
+  [self enumerateWifiAddresses:AF_INET6
+                    usingBlock:^(struct ifaddrs* ifaddr) {
+                      addr = [self descriptionForAddress:ifaddr->ifa_addr];
+                    }];
+  return addr;
 }
 
 - (NSString*)getWifiSubmask {
-  struct ifaddrs* temp_addr = [self getWifiInterfaceIPv4];
-  if (temp_addr) {
-    return [NSString
-        stringWithUTF8String:inet_ntoa(((struct sockaddr_in*)temp_addr->ifa_netmask)->sin_addr)];
-  } else {
-    return @"error";
-  }
+  __block NSString* addr = nil;
+  [self enumerateWifiAddresses:AF_INET
+                    usingBlock:^(struct ifaddrs* ifaddr) {
+                      addr = [self descriptionForAddress:ifaddr->ifa_netmask];
+                    }];
+  return addr;
 }
 
 - (NSString*)getWifiBroadcast {
-  struct ifaddrs* temp_addr = [self getWifiInterfaceIPv4];
-  if (temp_addr) {
-    return [NSString
-        stringWithUTF8String:inet_ntoa(((struct sockaddr_in*)temp_addr->ifa_dstaddr)->sin_addr)];
-  } else {
-    return @"error";
-  }
+  __block NSString* addr = nil;
+  [self enumerateWifiAddresses:AF_INET
+                    usingBlock:^(struct ifaddrs* ifaddr) {
+                      addr = [self descriptionForAddress:ifaddr->ifa_dstaddr];
+                    }];
+  return addr;
 }
 
 - (NSString*)convertCLAuthorizationStatusToString:(CLAuthorizationStatus)status {
@@ -174,18 +169,9 @@
 
 #pragma mark - Utils
 
-- (struct ifaddrs*)getWifiInterfaceIPv4 {
-  return [self getWifiInterface:AF_INET];
-}
-
-- (struct ifaddrs*)getWifiInterfaceIPv6 {
-  return [self getWifiInterface:AF_INET6];
-}
-
-- (struct ifaddrs*)getWifiInterface:(NSInteger)family {
+- (void)enumerateWifiAddresses:(NSInteger)family usingBlock:(void (^)(struct ifaddrs*))block {
   struct ifaddrs* interfaces = NULL;
   struct ifaddrs* temp_addr = NULL;
-  struct ifaddrs* wifi_addr = NULL;
   int success = 0;
 
   // retrieve the current interfaces - returns 0 on success
@@ -194,14 +180,10 @@
     // Loop through linked list of interfaces
     temp_addr = interfaces;
     while (temp_addr != NULL) {
-      if (temp_addr->ifa_addr->sa_family == AF_INET || temp_addr->ifa_addr->sa_family == AF_INET6) {
+      if (temp_addr->ifa_addr->sa_family == family) {
         // en0 is the wifi connection on iOS
         if ([[NSString stringWithUTF8String:temp_addr->ifa_name] isEqualToString:@"en0"]) {
-          if (temp_addr->ifa_addr->sa_family == family) {
-            wifi_addr = temp_addr;
-          } else if (temp_addr->ifa_addr->sa_family == family) {
-            wifi_addr = temp_addr;
-          }
+          block(temp_addr);
         }
       }
 
@@ -211,8 +193,12 @@
 
   // Free memory
   freeifaddrs(interfaces);
+}
 
-  return wifi_addr;
+- (NSString*)descriptionForAddress:(struct sockaddr*)addr {
+  char hostname[NI_MAXHOST];
+  getnameinfo(addr, addr->sa_len, hostname, NI_MAXHOST, NULL, 0, NI_NUMERICHOST);
+  return [NSString stringWithUTF8String:hostname];
 }
 
 @end

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 2.1.0
+version: 2.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

This PR fixes a small bug in `getWifiInterface` method. It returns address of `ifaddrs` struct that escapes `getifaddrs`/`freeifaddrs` pair. That is considered undefined behaviour and only works because iOS does not reclaim memory immediately.

For consistency with other platform implementations most methods changed to return `null` instead of `error` string, when corresponding piece of information is not available.

For consistency with `macOS` implementation I've replaced `inet_ntoa` with `getnameinfo` which uses [scoped IPv6 address] representation among other things. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[scoped IPv6 address]: https://en.wikipedia.org/wiki/IPv6_address#Scoped_literal_IPv6_addresses_(with_zone_index)