### PR TITLE
[package_info_plus] fix test on linux

### DIFF
--- a/packages/package_info_plus/package_info_plus/test/package_info_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_test.dart
@@ -44,6 +44,9 @@ void main() {
         isMethodCall('getAll', arguments: null),
       ],
     );
+  }, onPlatform: {
+    'linux':
+        const Skip('PackageInfoPlus on Linux does not use platform channels'),
   });
 
   test('Mock initial values', () async {


### PR DESCRIPTION
## Description

Skips failing test on Linux which causes all recently submitted PRs to fail `test_and_coverage` CI step.

Flutter 2.8 started to use platform implementations while running tests (flutter/flutter#90288). Linux implementation of `PackageInfoPlus` does not use platform channels thus failing test.

The second issue is versioning. When #574 landed the Linux implementation version and it's dependency in main package were not updated. I don't know if that was required for publishing new code in `pub`, but currently published version `1.0.3` still uses old way of registering Linux plugin. Whatever Flutter 2.8 uses to find and register platform plugins, it cannot find plugins that uses that old way of registering. If you bootstrap with `melos bootstrap --scope package_info_plus` (this is what CI does) new way of registering in `package_info_plus_linux` is connected via `.packages` where Flutter 2.8 can find it. I don't know if it's a matter of simply publishing the package, or incrementing versions is required.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
