### PR TITLE
[device_info_plus] update versions for publishing

### DIFF
--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+- Use automatic plugin registration on Linux and Windows
+
 ## 3.2.0
 
 - add `deviceInfo`

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 3.2.0
+version: 3.2.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -26,10 +26,10 @@ dependencies:
   flutter:
     sdk: flutter
   device_info_plus_platform_interface: ^2.3.0
-  device_info_plus_linux: ^2.1.0
+  device_info_plus_linux: ^2.1.1
   device_info_plus_macos: ^2.2.0
   device_info_plus_web: ^2.1.0
-  device_info_plus_windows: ^2.1.0
+  device_info_plus_windows: ^2.1.1
 
 dev_dependencies:
   test: ^1.16.4

--- a/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Use automatic plugin registration
+
 ## 2.1.0
 
 - add toMap to models

--- a/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_linux
 description: Linux implementation of the device_info_plus plugin
-version: 2.1.0
+version: 2.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- Use automatic plugin registration
+
 ## 2.1.0
 
 - add toMap to models

--- a/packages/device_info_plus/device_info_plus_windows/lib/src/device_info_plus_windows.dart
+++ b/packages/device_info_plus/device_info_plus_windows/lib/src/device_info_plus_windows.dart
@@ -9,7 +9,7 @@ import 'package:win32/win32.dart';
 
 /// The Windows implementation of [DeviceInfoPlatform].
 class DeviceInfoWindows extends DeviceInfoPlatform {
-  /// Register this dart class as the platform implementation for linux
+  /// Register this dart class as the platform implementation for windows
   static void registerWith() {
     DeviceInfoPlatform.instance = DeviceInfoWindows();
   }

--- a/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_windows
 description: Windows implementation of the device_info_plus plugin
-version: 2.1.0
+version: 2.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

Right now using published versions of `device_info_plus` on Windows and Linux fails with Flutter 2.8.1. #574 and #598 needs publishing. Fixes #646.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
