### PR TITLE
[ReadMe change] Fix package name not being in title format

### DIFF
--- a/packages/android_alarm_manager_plus/README.md
+++ b/packages/android_alarm_manager_plus/README.md
@@ -1,6 +1,7 @@
 [![Flutter Community: android_alarm_manager_plus](https://fluttercommunity.dev/_github/header/android_alarm_manager_plus)](https://github.com/fluttercommunity/community)
 
 <center><a href="https://flutter.dev/docs/development/packages-and-plugins/favorites" target="_blank" rel="noreferrer noopener"><img src="../../website/static/img/flutter-favorite-badge.png" width="100" alt="build"></a></center>
+
 # android_alarm_manager_plus
 
 A Flutter plugin for accessing the Android AlarmManager service, and running


### PR DESCRIPTION
# For android_alarm_manager_plus
## Description
  
At the top of the readme, android_alarm_manager_plus has a '#' in front of it, but since there wasn't a new line between that and the flutter favorite image, the package name was left in the body text style with a hashtag in front of it rather than being converted to the title 1 format.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] All existing and new tests are passing.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [ x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
