### PR TITLE
[Device_info_plus] Update update SDK to >=1.20.0

### DIFF
--- a/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.1
 
 - Use automatic plugin registration
+- update Flutter SDK to >=1.20.0
 
 ## 2.1.0
 

--- a/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   device_info_plus_platform_interface: ^2.1.0

--- a/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 2.1.1
 
 - Use automatic plugin registration
+- update SDK to >=1.20.0
 
 ## 2.1.0
 

--- a/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4"
+  flutter: ">=1.20.0"
 
 dependencies:
   device_info_plus_platform_interface: ^2.1.0


### PR DESCRIPTION
## Description

We need to upgrade to fix 
`Uploading...
pubspec.yaml allows Flutter SDK version prior to 1.20.0, which does not support having no `ios/` folder.
Please consider increasing the Flutter SDK requirement to ^1.20.0 or higher (environment.sdk.flutter) or create an `ios/` folder.
`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ x No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
