### PR TITLE
[android_alarm_manager_plus] fix(rescheduleOnReboot)

### DIFF
--- a/packages/android_alarm_manager_plus/README.md
+++ b/packages/android_alarm_manager_plus/README.md
@@ -28,6 +28,11 @@ After importing this plugin to your project as usual, add the following to your
 <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
 ```
 
+Then, correct your existing `android:name` attribute belonging to the `<application>` tag:
+```plain
+android:name="io.flutter.app.FlutterApplication"
+```
+
 Next, within the `<application></application>` tags, add:
 
 ```xml


### PR DESCRIPTION
## Description

Fixes a NullPointerException exception on reboot when using android_alarm_manager_plus with feature rescheduleOnReboot=true:

```
01-10 17:43:13.812  9893  9893 E AndroidRuntime: java.lang.RuntimeException: Unable to create service dev.fluttercommunity.plus.androidalarmmanager.AlarmService: java.lang.NullPointerException: Attempt to read from field 'java.lang.String io.flutter.embedding.engine.loader.FlutterApplicationInfo.flutterAssetsDir' on a null object reference
01-10 17:43:13.812  9893  9893 E AndroidRuntime: 	at dev.fluttercommunity.plus.androidalarmmanager.FlutterBackgroundExecutor.startBackgroundIsolate(FlutterBackgroundExecutor.java:155)
01-10 17:43:13.812  9893  9893 E AndroidRuntime: 	at dev.fluttercommunity.plus.androidalarmmanager.FlutterBackgroundExecutor.startBackgroundIsolate(FlutterBackgroundExecutor.java:124)
01-10 17:43:13.812  9893  9893 E AndroidRuntime: 	at dev.fluttercommunity.plus.androidalarmmanager.AlarmService.onCreate(AlarmService.java:351)
```

I should point out though that I have little knowledge what downstream effects it might have to rename the `android:name` attribute, but at least it makes the code run for me, which is better than failing. I think it is therefore important to mention it in the README to save the average user from debugging.

Note: The given example subproject already has this attribute.

## Related Issues

should also fix https://github.com/fluttercommunity/plus_plugins/issues/649

From there I actually got the info about the fix, but it needs to be included in the README (hence this PR).
Only the line numbers of the exception seem to be a little of, but the actual exception is similar.

## Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
