### PR TITLE
Fix files filtering in workflow triggers

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -3,12 +3,11 @@ name: android_alarm_manager_plus
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.gitignore"
     paths:
       - "packages/android_alarm_manager_plus/**"
       - ".github/workflows/android_alarm_manager_plus.yaml"
+      - "!**.md"
+      - "!**.gitignore"
 
 env:
   PLUGIN_SCOPE: "*android_alarm_manager_plus*"

--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -3,12 +3,11 @@ name: android_intent_plus
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.gitignore"
     paths:
       - "packages/android_intent_plus/**"
       - ".github/workflows/android_intent_plus.yaml"
+      - "!**.md"
+      - "!**.gitignore"
 
 env:
   PLUGIN_SCOPE: "*android_intent_plus*"

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -3,12 +3,11 @@ name: battery_plus
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.gitignore"
     paths:
       - "packages/battery_plus/**"
       - ".github/workflows/battery_plus.yaml"
+      - "!**.md"
+      - "!**.gitignore"
 
 env:
   PLUGIN_SCOPE: "*battery_plus*"

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -3,12 +3,11 @@ name: connectivity_plus
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.gitignore"
     paths:
       - "packages/connectivity_plus/**"
       - ".github/workflows/connectivity_plus.yaml"
+      - "!**.md"
+      - "!**.gitignore"
 
 env:
   PLUGIN_SCOPE: "*connectivity_plus*"

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -3,12 +3,11 @@ name: device_info_plus
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.gitignore"
     paths:
       - "packages/device_info_plus/**"
       - ".github/workflows/device_info_plus.yaml"
+      - "!**.md"
+      - "!**.gitignore"
 
 env:
   PLUGIN_SCOPE: "*device_info_plus*"

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -3,12 +3,11 @@ name: network_info_plus
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.gitignore"
     paths:
       - "packages/network_info_plus/**"
       - ".github/workflows/network_info_plus.yaml"
+      - "!**.md"
+      - "!**.gitignore"
 
 env:
   PLUGIN_SCOPE: "*network_info_plus*"

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -3,12 +3,11 @@ name: package_info_plus
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.gitignore"
     paths:
       - "packages/package_info_plus/**"
       - ".github/workflows/package_info_plus.yaml"
+      - "!**.md"
+      - "!**.gitignore"
 
 env:
   PLUGIN_SCOPE: "*package_info_plus*"

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -3,12 +3,11 @@ name: sensors_plus
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.gitignore"
     paths:
       - "packages/sensors_plus/**"
       - ".github/workflows/sensors_plus.yaml"
+      - "!**.md"
+      - "!**.gitignore"
 
 env:
   PLUGIN_SCOPE: "*sensors_plus*"

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -3,12 +3,11 @@ name: share_plus
 
 on:
   pull_request:
-    paths-ignore:
-      - "**.md"
-      - "**.gitignore"
     paths:
       - "packages/share_plus/**"
       - ".github/workflows/share_plus.yaml"
+      - "!**.md"
+      - "!**.gitignore"
 
 env:
   PLUGIN_SCOPE: "*share_plus*"


### PR DESCRIPTION
## Description

In #687 I broke workflow files for every individual plugin due to including both `paths` and `paths-ignore` which is not allowed for Github Actions. This PR address the issue by using proper filtering according to docs: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#example-using-positive-and-negative-patterns-1

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
