### PR TITLE
Cache device info futures across instances

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/device_info_plus.dart
+++ b/packages/device_info_plus/device_info_plus/lib/device_info_plus.dart
@@ -24,7 +24,7 @@ export 'package:device_info_plus_platform_interface/device_info_plus_platform_in
 class DeviceInfoPlugin {
   /// No work is done when instantiating the plugin. It's safe to call this
   /// repeatedly or in performance-sensitive blocks.
-  DeviceInfoPlugin();
+  const DeviceInfoPlugin();
 
   // This is to manually endorse the Linux plugin until automatic registration
   // of dart plugins is implemented.
@@ -34,51 +34,51 @@ class DeviceInfoPlugin {
   }
 
   /// This information does not change from call to call. Cache it.
-  AndroidDeviceInfo? _cachedAndroidDeviceInfo;
+  static Future<AndroidDeviceInfo>? _androidDeviceInfoFuture;
 
   /// Information derived from `android.os.Build`.
   ///
   /// See: https://developer.android.com/reference/android/os/Build.html
-  Future<AndroidDeviceInfo> get androidInfo async =>
-      _cachedAndroidDeviceInfo ??= await _platform.androidInfo();
+  Future<AndroidDeviceInfo> get androidInfo =>
+      _androidDeviceInfoFuture ??= _platform.androidInfo();
 
   /// This information does not change from call to call. Cache it.
-  IosDeviceInfo? _cachedIosDeviceInfo;
+  static Future<IosDeviceInfo>? _iosDeviceInfoFuture;
 
   /// Information derived from `UIDevice`.
   ///
   /// See: https://developer.apple.com/documentation/uikit/uidevice
-  Future<IosDeviceInfo> get iosInfo async =>
-      _cachedIosDeviceInfo ??= await _platform.iosInfo();
+  Future<IosDeviceInfo> get iosInfo =>
+      _iosDeviceInfoFuture ??= _platform.iosInfo();
 
   /// This information does not change from call to call. Cache it.
-  LinuxDeviceInfo? _cachedLinuxDeviceInfo;
+  static Future<LinuxDeviceInfo>? _linuxDeviceInfoFuture;
 
   /// Information derived from `/etc/os-release`.
   ///
   /// See: https://www.freedesktop.org/software/systemd/man/os-release.html
-  Future<LinuxDeviceInfo> get linuxInfo async =>
-      _cachedLinuxDeviceInfo ??= await _platform.linuxInfo();
+  Future<LinuxDeviceInfo> get linuxInfo =>
+      _linuxDeviceInfoFuture ??= _platform.linuxInfo();
 
   /// This information does not change from call to call. Cache it.
-  WebBrowserInfo? _cachedWebBrowserInfo;
+  static Future<WebBrowserInfo>? _webBrowserInfoFuture;
 
   /// Information derived from `Navigator`.
-  Future<WebBrowserInfo> get webBrowserInfo async =>
-      _cachedWebBrowserInfo ??= await _platform.webBrowserInfo();
+  Future<WebBrowserInfo> get webBrowserInfo =>
+      _webBrowserInfoFuture ??= _platform.webBrowserInfo();
 
   /// This information does not change from call to call. Cache it.
-  MacOsDeviceInfo? _cachedMacosDeviceInfo;
+  static Future<MacOsDeviceInfo>? _macosDeviceInfoFuture;
 
   /// Returns device information for macos. Information sourced from Sysctl.
-  Future<MacOsDeviceInfo> get macOsInfo async =>
-      _cachedMacosDeviceInfo ??= await _platform.macosInfo();
+  Future<MacOsDeviceInfo> get macOsInfo =>
+      _macosDeviceInfoFuture ??= _platform.macosInfo();
 
-  WindowsDeviceInfo? _cachedWindowsDeviceInfo;
+  static Future<WindowsDeviceInfo>? _windowsDeviceInfoFuture;
 
   /// Returns device information for Windows.
-  Future<WindowsDeviceInfo> get windowsInfo async =>
-      _cachedWindowsDeviceInfo ??= await _platform.windowsInfo()!;
+  Future<WindowsDeviceInfo> get windowsInfo =>
+      _windowsDeviceInfoFuture ??= _platform.windowsInfo()!;
 
   /// Returns device information for the current platform.
   Future<BaseDeviceInfo> get deviceInfo async {


### PR DESCRIPTION
Cache the futures themselves rather than the results (to avoid calling the underlying plugin calls when there is a pending operation going on).

Also make the caches static members (in order for them to be shared across instances) and make the constructor `const`.

## Description

Cache the futures themselves rather than the results (to avoid calling the underlying plugin calls when there is a pending operation going on).

Also make the caches static members (in order for them to be shared across instances) and make the constructor `const`.

## Related Issues

N/A. This is a small optimization.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
