### PR TITLE
[android_intent_plus]: Added a new argument to explicitly pass array arguments to an intent

### DIFF
--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,7 +1,11 @@
+## 3.1.0
+
+- Added `arrayArguments` to explicitly pass array values to an intent
+
 ## 3.0.2
 
 - Fixed the buildIntent method to do not set the pacakage to null if it's not resolvable
-- UPdated the example of resolving intent with explicitly defined package name
+- Updated the example of resolving intent with explicitly defined package name
 
 ## 3.0.1
 

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
@@ -77,6 +77,8 @@ public final class MethodCallHandlerImpl implements MethodCallHandler {
     String category = call.argument("category");
     Uri data = call.argument("data") != null ? Uri.parse((String) call.argument("data")) : null;
     Bundle arguments = convertArguments((Map<String, ?>) call.argument("arguments"));
+    Bundle arrayArguments = convertArrayArguments((Map<String, ?>) call.argument("arrayArguments"));
+    arguments.putAll(arrayArguments);
     String packageName = call.argument("package");
     ComponentName componentName =
         (!TextUtils.isEmpty(packageName)
@@ -159,6 +161,51 @@ public final class MethodCallHandlerImpl implements MethodCallHandler {
         bundle.putStringArrayList(key, (ArrayList<String>) value);
       } else if (isStringKeyedMap(value)) {
         bundle.putBundle(key, convertArguments((Map<String, ?>) value));
+      } else {
+        throw new UnsupportedOperationException("Unsupported type " + value);
+      }
+    }
+    return bundle;
+  }
+
+  private static Bundle convertArrayArguments(Map<String, ?> arrayArguments) {
+    Bundle bundle = new Bundle();
+    if (arrayArguments == null) {
+      return bundle;
+    }
+    for (String key : arrayArguments.keySet()) {
+      Object value = arrayArguments.get(key);
+      if (isTypedArrayList(value, Boolean.class)) {
+        ArrayList<Boolean> list = (ArrayList<Boolean>) value;
+        boolean[] array = new boolean[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+          array[i] = list.get(i);
+        }
+        bundle.putBooleanArray(key, array);
+      } else if (isTypedArrayList(value, Integer.class)) {
+        ArrayList<Integer> list = (ArrayList<Integer>) value;
+        int[] array = new int[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+          array[i] = list.get(i);
+        }
+        bundle.putIntArray(key, array);
+      } else if (isTypedArrayList(value, Long.class)) {
+        ArrayList<Long> list = (ArrayList<Long>) value;
+        long[] array = new long[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+          array[i] = list.get(i);
+        }
+        bundle.putLongArray(key, array);
+      } else if (isTypedArrayList(value, Double.class)) {
+        ArrayList<Double> list = (ArrayList<Double>) value;
+        double[] array = new double[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+          array[i] = list.get(i);
+        }
+        bundle.putDoubleArray(key, array);
+      } else if (isTypedArrayList(value, String.class)) {
+        ArrayList<String> list = (ArrayList<String>) value;
+        bundle.putStringArray(key, list.toArray(new String[list.size()]));
       } else {
         throw new UnsupportedOperationException("Unsupported type " + value);
       }

--- a/packages/android_intent_plus/example/lib/main.dart
+++ b/packages/android_intent_plus/example/lib/main.dart
@@ -184,6 +184,21 @@ class ExplicitIntentsWidget extends StatelessWidget {
     intent.launch();
   }
 
+  void _openGmail() {
+    const intent = AndroidIntent(
+      action: 'android.intent.action.SEND',
+      arguments: {'android.intent.extra.SUBJECT': 'I am the subject'},
+      arrayArguments: {
+        'android.intent.extra.EMAIL': ['eidac@me.com', 'overbom@mac.com'],
+        'android.intent.extra.CC': ['john@app.com', 'user@app.com'],
+        'android.intent.extra.BCC': ['liam@me.abc', 'abel@me.com'],
+      },
+      package: 'com.google.android.gm',
+      type: 'message/rfc822',
+    );
+    intent.launch();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -191,7 +206,7 @@ class ExplicitIntentsWidget extends StatelessWidget {
         title: const Text('Test explicit intents'),
       ),
       body: Center(
-        child: Padding(
+        child: SingleChildScrollView(
           padding: const EdgeInsets.symmetric(vertical: 15.0),
           child: Column(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
@@ -233,6 +248,12 @@ class ExplicitIntentsWidget extends StatelessWidget {
                 onPressed: _openApplicationDetails,
                 child: const Text(
                   'Tap here to open Application Details',
+                ),
+              ),
+              ElevatedButton(
+                onPressed: _openGmail,
+                child: const Text(
+                  'Tap here to open gmail app with details',
                 ),
               ),
             ],

--- a/packages/android_intent_plus/lib/android_intent.dart
+++ b/packages/android_intent_plus/lib/android_intent.dart
@@ -24,6 +24,8 @@ class AndroidIntent {
   /// intent.
   /// [arguments] is the map that will be converted into an extras bundle and
   /// passed to the intent.
+  /// [arrayArguments] is a map that will be converted into an extra bundle
+  /// as in an array and passed to the intent.
   /// [package] refers to the package parameter of the intent, can be null.
   /// [componentName] refers to the component name of the intent, can be null.
   /// If not null, then [package] but also be provided.
@@ -34,6 +36,7 @@ class AndroidIntent {
     this.category,
     this.data,
     this.arguments,
+    this.arrayArguments,
     this.package,
     this.componentName,
     Platform? platform,
@@ -54,6 +57,7 @@ class AndroidIntent {
     this.category,
     this.data,
     this.arguments,
+    this.arrayArguments,
     this.package,
     this.componentName,
     this.type,
@@ -87,8 +91,16 @@ class AndroidIntent {
   /// The equivalent of `extras`, a generic `Bundle` of data that the Intent can
   /// carry. This is a slot for extraneous data that the listener may use.
   ///
+  /// If the argument contains a list value, then the value will be put in as an
+  /// array list.
+  ///
   /// See https://developer.android.com/reference/android/content/Intent.html#intent-structure.
   final Map<String, dynamic>? arguments;
+
+  /// Similar to [arguments], but in this case the arguments are an array and
+  /// will be added to the intent as in an array extra instead of of an array
+  /// list.
+  final Map<String, List<dynamic>>? arrayArguments;
 
   /// Sets the [data] to only resolve within this given package.
   ///
@@ -190,6 +202,7 @@ class AndroidIntent {
       if (category != null) 'category': category,
       if (data != null) 'data': data,
       if (arguments != null) 'arguments': arguments,
+      if (arrayArguments != null) 'arrayArguments': arrayArguments,
       if (package != null) ...{
         'package': package,
         if (componentName != null) 'componentName': componentName,

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 3.0.2
+version: 3.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

In Android, the [Intent](https://developer.android.com/reference/android/content/Intent.html#intent-structure) class has two different methods to put an [array](https://developer.android.com/reference/android/content/Intent#putExtra(java.lang.String,%20java.lang.String[])) and [array list](https://developer.android.com/reference/android/content/Intent#putStringArrayListExtra(java.lang.String,%20java.util.ArrayList%3Cjava.lang.String%3E)) values to the intent. And in the previous implementation, we only use one of them, which is used to put array list values to the intent. And since dart `List` type is[ mapped to](https://docs.flutter.dev/development/platform-integration/platform-channels?tab=type-mappings-java-tab#codec) `ArrayList` in java, it limits users to pass array types to the Intent. 

So this PR fixes that by introducing a new argument to the `AndroidIntent` class to pass array arguments to the intent as I have mentioned [here](https://github.com/fluttercommunity/plus_plugins/issues/75#issuecomment-1011574088).

## Related Issues

Fixes flutter/flutter#54362 and closes #75

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
