### PR TITLE
[battery_plus] add batteryState getter

### DIFF
--- a/packages/battery_plus/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+- Add batteryState getter
+
 ## 2.0.2
 
 - Update Flutter dependencies

--- a/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
+++ b/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
@@ -73,6 +73,14 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
       } else {
         result.error("UNAVAILABLE", "Battery level not available.", null);
       }
+    } else if (call.method.equals("getBatteryState")) {
+      String batteryStatus = getBatteryStatus();
+
+      if (batteryStatus != null) {
+        result.success(batteryStatus);
+      } else {
+        result.error("UNAVAILABLE", "Charging status not available.", null);
+      }
     } else if (call.method.equals("isInBatterySaveMode")) {
       Boolean isInPowerSaveMode = this.isInPowerSaveMode();
 
@@ -93,13 +101,18 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
     applicationContext.registerReceiver(
         chargingStateChangeReceiver, new IntentFilter(Intent.ACTION_BATTERY_CHANGED));
 
+    String status = getBatteryStatus();
+    publishBatteryStatus(events, status);
+  }
+
+  private String getBatteryStatus() {
     int status;
     if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
       status = getBatteryProperty(BatteryManager.BATTERY_PROPERTY_STATUS);
     } else {
       status = BatteryManager.BATTERY_STATUS_UNKNOWN;
     }
-    publishBatteryStatus(events, status);
+    return convertBatteryStatus(status);
   }
 
   @Override
@@ -179,24 +192,27 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
     return batteryManager.getIntProperty(property);
   }
 
-  private static void publishBatteryStatus(final EventSink events, int status) {
+  private static String convertBatteryStatus(int status) {
     switch (status) {
       case BatteryManager.BATTERY_STATUS_CHARGING:
-        events.success("charging");
-        break;
+        return "charging";
       case BatteryManager.BATTERY_STATUS_FULL:
-        events.success("full");
-        break;
+        return "full";
       case BatteryManager.BATTERY_STATUS_DISCHARGING:
       case BatteryManager.BATTERY_STATUS_NOT_CHARGING:
-        events.success("discharging");
-        break;
+        return "discharging";
       case BatteryManager.BATTERY_STATUS_UNKNOWN:
-        events.success("unknown");
-        break;
+        return "unknown";
       default:
-        events.error("UNAVAILABLE", "Charging status unavailable", null);
-        break;
+        return null;
+    }
+  }
+
+  private static void publishBatteryStatus(final EventSink events, String status) {
+    if (status != null) {
+      events.success(status);
+    } else {
+      events.error("UNAVAILABLE", "Charging status unavailable", null);
     }
   }
 
@@ -205,7 +221,7 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
       @Override
       public void onReceive(Context context, Intent intent) {
         int status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
-        publishBatteryStatus(events, status);
+        publishBatteryStatus(events, convertBatteryStatus(status));
       }
     };
   }

--- a/packages/battery_plus/battery_plus/example/lib/main.dart
+++ b/packages/battery_plus/battery_plus/example/lib/main.dart
@@ -46,11 +46,15 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
+    _battery.batteryState.then(_updateBatteryState);
     _batteryStateSubscription =
-        _battery.onBatteryStateChanged.listen((BatteryState state) {
-      setState(() {
-        _batteryState = state;
-      });
+        _battery.onBatteryStateChanged.listen(_updateBatteryState);
+  }
+
+  void _updateBatteryState(BatteryState state) {
+    if (_batteryState == state) return;
+    setState(() {
+      _batteryState = state;
     });
   }
 

--- a/packages/battery_plus/battery_plus/lib/battery_plus.dart
+++ b/packages/battery_plus/battery_plus/lib/battery_plus.dart
@@ -41,6 +41,11 @@ class Battery {
     return _platform.isInBatterySaveMode;
   }
 
+  /// Get battery state
+  Future<BatteryState> get batteryState {
+    return _platform.batteryState;
+  }
+
   /// Fires whenever the battery state changes.
   Stream<BatteryState> get onBatteryStateChanged {
     return _platform.onBatteryStateChanged;

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 2.0.2
+version: 2.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -25,7 +25,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  battery_plus_platform_interface: ^1.1.0
+  battery_plus_platform_interface: ^1.2.0
   battery_plus_linux: ^1.0.3
   battery_plus_macos: ^1.0.2
   battery_plus_web: ^1.0.2

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -27,8 +27,8 @@ dependencies:
   meta: ^1.7.0
   battery_plus_platform_interface: ^1.2.0
   battery_plus_linux: ^1.1.0
-  battery_plus_macos: ^1.0.2
-  battery_plus_web: ^1.0.2
+  battery_plus_macos: ^1.1.0
+  battery_plus_web: ^1.1.0
   battery_plus_windows: ^1.0.2
 
 dev_dependencies:

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   battery_plus_linux: ^1.1.0
   battery_plus_macos: ^1.1.0
   battery_plus_web: ^1.1.0
-  battery_plus_windows: ^1.0.2
+  battery_plus_windows: ^1.1.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
     sdk: flutter
   meta: ^1.7.0
   battery_plus_platform_interface: ^1.2.0
-  battery_plus_linux: ^1.0.3
+  battery_plus_linux: ^1.1.0
   battery_plus_macos: ^1.0.2
   battery_plus_web: ^1.0.2
   battery_plus_windows: ^1.0.2

--- a/packages/battery_plus/battery_plus/test/battery_test.dart
+++ b/packages/battery_plus/battery_plus/test/battery_test.dart
@@ -19,6 +19,9 @@ class MockBatteryPlatform
   Future<int> get batteryLevel => Future.value(42);
 
   @override
+  Future<BatteryState> get batteryState => Future.value(BatteryState.charging);
+
+  @override
   Stream<BatteryState> get onBatteryStateChanged => controller.stream;
 
   @override
@@ -50,6 +53,10 @@ void main() {
 
     tearDown(() {
       controller.close();
+    });
+
+    test('current', () async {
+      expect(await battery.batteryState, BatteryState.charging);
     });
 
     test('receive values', () async {

--- a/packages/battery_plus/battery_plus_linux/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Add batteryState getter
+
 ## 1.0.4
 
 - Update Flutter dependencies

--- a/packages/battery_plus/battery_plus_linux/lib/src/battery_plus_linux.dart
+++ b/packages/battery_plus/battery_plus_linux/lib/src/battery_plus_linux.dart
@@ -41,6 +41,16 @@ class BatteryPlusLinux extends BatteryPlatform {
         .whenComplete(() => device.dispose());
   }
 
+  /// Returns the current battery state.
+  @override
+  Future<BatteryState> get batteryState {
+    final device = createDevice();
+    return device
+        .getState()
+        .then((value) => value.toBatteryState())
+        .whenComplete(() => device.dispose());
+  }
+
   /// Fires whenever the battery state changes.
   @override
   Stream<BatteryState> get onBatteryStateChanged {

--- a/packages/battery_plus/battery_plus_linux/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: battery_plus_linux
 description: Linux implementation of the battery_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 1.0.4
+version: 1.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  battery_plus_platform_interface: ^1.1.1
+  battery_plus_platform_interface: ^1.2.0
   dbus: ^0.6.6
   meta: ^1.7.0
 

--- a/packages/battery_plus/battery_plus_linux/test/battery_plus_linux_test.dart
+++ b/packages/battery_plus/battery_plus_linux/test/battery_plus_linux_test.dart
@@ -21,6 +21,14 @@ void main() {
     expect(battery.batteryLevel, completion(equals(57)));
   });
 
+  test('battery state', () async {
+    final battery = BatteryPlusLinux();
+    battery.createDevice = () {
+      return MockDevice();
+    };
+    expect(battery.batteryState, completion(BatteryState.charging));
+  });
+
   test('battery state changes', () {
     final battery = BatteryPlusLinux();
     battery.createDevice = () {

--- a/packages/battery_plus/battery_plus_macos/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Add batteryState getter
+
 ## 1.0.2
 
 - Upgrade battery_plus_platform_interface dependency

--- a/packages/battery_plus/battery_plus_macos/macos/Classes/BatteryPlusMacosPlugin.swift
+++ b/packages/battery_plus/battery_plus_macos/macos/Classes/BatteryPlusMacosPlugin.swift
@@ -3,27 +3,38 @@ import FlutterMacOS
 import IOKit.ps
 
 public class BatteryPlusMacosPlugin: NSObject, FlutterPlugin {
+    private var chargingHandler: BatteryPlusChargingHandler
+
+    init(chargingHandler: BatteryPlusChargingHandler) {
+        self.chargingHandler = chargingHandler
+        super.init()
+    }
+
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "dev.fluttercommunity.plus/battery", binaryMessenger: registrar.messenger)
         
         let eventChannel = FlutterEventChannel(name: "dev.fluttercommunity.plus/charging", binaryMessenger: registrar.messenger)
-        
-        let instance = BatteryPlusMacosPlugin()
+
+        let chargingHandler = BatteryPlusChargingHandler()
+
+        let instance = BatteryPlusMacosPlugin(chargingHandler: chargingHandler)
         registrar.addMethodCallDelegate(instance, channel: channel)
         
-        eventChannel.setStreamHandler(BatteryPlusChargingHandler())
+        eventChannel.setStreamHandler(chargingHandler)
     }
     
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "getBatteryLevel":
-            handleGetBatteryMethodCall(result)
+            handleGetBatteryLevelMethodCall(result)
+        case "getBatteryState":
+            handleGetBatteryStateMethodCall(result)
         default:
             result(FlutterMethodNotImplemented)
         }
     }
     
-    private func handleGetBatteryMethodCall(_ result: FlutterResult){
+    private func handleGetBatteryLevelMethodCall(_ result: FlutterResult){
         let level = getBatteryLevel()
         if(level != -1){
             result(level)
@@ -42,5 +53,10 @@ public class BatteryPlusMacosPlugin: NSObject, FlutterPlugin {
             return currentCapacity;
         }
         return -1
+    }
+
+    private func handleGetBatteryStateMethodCall(_ result: FlutterResult){
+        let state = self.chargingHandler.getBatteryStatus()
+        result(state);
     }
 }

--- a/packages/battery_plus/battery_plus_macos/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_macos/pubspec.yaml
@@ -2,14 +2,14 @@ name: battery_plus_macos
 description: An implementation for the macos platform of the Flutter `battery_plus` plugin.
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 1.0.2
+version: 1.1.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
-  battery_plus_platform_interface: ^1.1.0
+  battery_plus_platform_interface: ^1.2.0
   flutter:
     sdk: flutter
 

--- a/packages/battery_plus/battery_plus_platform_interface/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+
+- Add batteryState getter
+
 ## 1.1.1
 
 - Update Flutter dependencies

--- a/packages/battery_plus/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
@@ -47,6 +47,11 @@ abstract class BatteryPlatform extends PlatformInterface {
     throw UnimplementedError('isInBatterySaveMode() has not been implemented.');
   }
 
+  /// Returns the current battery state in percent.
+  Future<BatteryState> get batteryState {
+    throw UnimplementedError('batteryState() has not been implemented.');
+  }
+
   /// Returns a Stream of BatteryState changes.
   Stream<BatteryState> get onBatteryStateChanged {
     throw UnimplementedError(

--- a/packages/battery_plus/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
@@ -36,6 +36,12 @@ class MethodChannelBattery extends BatteryPlatform {
       .invokeMethod<bool>('isInBatterySaveMode')
       .then<bool>((dynamic result) => result);
 
+  /// Returns the current battery state in percent.
+  @override
+  Future<BatteryState> get batteryState => methodChannel
+      .invokeMethod<String>('getBatteryState')
+      .then<BatteryState>((dynamic result) => parseBatteryState(result));
+
   /// Fires whenever the battery state changes.
   @override
   Stream<BatteryState> get onBatteryStateChanged {

--- a/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_platform_interface
 description: A common platform interface for the battery_plus plugin.
-version: 1.1.1
+version: 1.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/battery_plus/battery_plus_platform_interface/test/battery_plus_platform_interface_test.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/test/battery_plus_platform_interface_test.dart
@@ -21,6 +21,8 @@ void main() {
             return 100;
           case 'isInBatterySaveMode':
             return true;
+          case 'getBatteryState':
+            return 'charging';
           default:
             return null;
         }
@@ -72,6 +74,20 @@ void main() {
         <Matcher>[
           isMethodCall(
             'isInBatterySaveMode',
+            arguments: null,
+          ),
+        ],
+      );
+    });
+
+    test('getBatteryState', () async {
+      final result = await methodChannelBattery.batteryState;
+      expect(result, BatteryState.charging);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'getBatteryState',
             arguments: null,
           ),
         ],

--- a/packages/battery_plus/battery_plus_web/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Add batteryState getter
+
 ## 1.0.2
 
 - Upgrade battery_plus_platform_interface dependency

--- a/packages/battery_plus/battery_plus_web/lib/battery_plus_web.dart
+++ b/packages/battery_plus/battery_plus_web/lib/battery_plus_web.dart
@@ -35,6 +35,18 @@ class BatteryPlusPlugin extends BatteryPlatform {
     return 0;
   }
 
+  /// Returns the current battery state.
+  @override
+  Future<BatteryState> get batteryState async {
+    if (isSupported) {
+      final battery = await _getBattery() as html.BatteryManager;
+      if (battery.charging != null) {
+        return _checkBatteryChargingState(battery.charging!);
+      }
+    }
+    return BatteryState.unknown;
+  }
+
   StreamController<BatteryState>? _batteryChangeStreamController;
   late Stream<BatteryState> _batteryChange;
 

--- a/packages/battery_plus/battery_plus_web/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_web
 description: An implementation for the web platform of the Flutter `battery_plus` plugin.
-version: 1.0.2
+version: 1.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -12,7 +12,7 @@ flutter:
         fileName: battery_plus_web.dart
 
 dependencies:
-  battery_plus_platform_interface: ^1.1.0
+  battery_plus_platform_interface: ^1.2.0
   flutter_web_plugins:
     sdk: flutter
   flutter:

--- a/packages/battery_plus/battery_plus_windows/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+- Add batteryState getter
+
 ## 1.0.2
 
 - Upgrade battery_plus_platform_interface dependency

--- a/packages/battery_plus/battery_plus_windows/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_windows
 description: Windows implementation of the battery_plus plugin
-version: 1.0.2
+version: 1.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  battery_plus_platform_interface: ^1.1.0
+  battery_plus_platform_interface: ^1.2.0
   flutter:
     sdk: flutter
 

--- a/packages/battery_plus/battery_plus_windows/windows/battery_plus_windows_plugin.cpp
+++ b/packages/battery_plus/battery_plus_windows/windows/battery_plus_windows_plugin.cpp
@@ -156,6 +156,9 @@ void BatteryPlusWindowsPlugin::HandleMethodCall(
       result->Error(std::to_string(battery.GetError()),
                     battery.GetErrorString());
     }
+  } else if (method_call.method_name().compare("getBatteryState") == 0) {
+    SystemBattery battery;
+    result->Success(flutter::EncodableValue(battery.GetStatusString()));
   } else {
     result->NotImplemented();
   }


### PR DESCRIPTION
## Description

This PR adds a `Battery.batteryState` getter on the side of the existing `Battery.onBatteryStateChanged` to make it straightforward to query the current battery state without having to listen to a stream.

## Related Issues

Closes: #685

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
