### PR TITLE
[android_alarm_manager_plus] fix initialization

### DIFF
--- a/packages/android_alarm_manager_plus/CHANGELOG.md
+++ b/packages/android_alarm_manager_plus/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.0.4
 
-- Fix FlutterEngine initialization
+- Fix FlutterEngine initialisation to avoid crashes when app is closed and plugin tries to schedule an alarm.
 
 ## 2.0.3
 

--- a/packages/android_alarm_manager_plus/CHANGELOG.md
+++ b/packages/android_alarm_manager_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.4
+
+- Fix FlutterEngine initialization
+
 ## 2.0.3
 
 - Handle Android 12 behavior changes for exact alarms scheduling

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/FlutterBackgroundExecutor.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/FlutterBackgroundExecutor.java
@@ -9,6 +9,7 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.AssetManager;
 import android.util.Log;
+import io.flutter.FlutterInjector;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.dart.DartExecutor.DartCallback;
@@ -21,7 +22,6 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
 import io.flutter.view.FlutterCallbackInformation;
-import io.flutter.view.FlutterMain;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -152,10 +152,11 @@ public class FlutterBackgroundExecutor implements MethodCallHandler {
     }
 
     Log.i(TAG, "Starting AlarmService...");
-    String appBundlePath = FlutterMain.findAppBundlePath(context);
-    AssetManager assets = context.getAssets();
-    if (appBundlePath != null && !isRunning()) {
+    if (!isRunning()) {
       backgroundFlutterEngine = new FlutterEngine(context);
+
+      String appBundlePath = FlutterInjector.instance().flutterLoader().findAppBundlePath();
+      AssetManager assets = context.getAssets();
 
       // We need to create an instance of `FlutterEngine` before looking up the
       // callback. If we don't, the callback cache won't be initialized and the

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager_plus
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 2.0.3
+version: 2.0.4
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

This PR fixes a small bug in `android_alarm_manager_plus` initialization code. 

There is a common workaround to include `io.flutter.app.FlutterApplication` as application name in manifest, but that does not feel right, because of mixing V1 embedding with V2. All `FlutterApplication` doing is initializing `FlutterLoader` explicitly. However more modern V2 embedding relies on implicit `FlutterLoader` initialization during instantiation of `FlutterEngine`. The fix is to instantiate `FlutterEngine` first, then call `findAppBundlePath` (which is annotated `NonNull`, so additional check is redundant).

Fixes #649, supersedes #690.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
