### PR TITLE
[device_info_plus] Fixed incorrect computer name and version on MacOS

### DIFF
--- a/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2
+
+- Fixed incorrect computer name and version on MacOS
+
 ## 2.2.1
 
 - Fix build warnings

--- a/packages/device_info_plus/device_info_plus_macos/macos/Classes/DeviceInfoPlusMacosPlugin.swift
+++ b/packages/device_info_plus/device_info_plus_macos/macos/Classes/DeviceInfoPlusMacosPlugin.swift
@@ -18,12 +18,12 @@ public class DeviceInfoPlusMacosPlugin: NSObject, FlutterPlugin {
     }
 
     private func handleDeviceInfo(result: @escaping FlutterResult)-> Void{
-        let computerName = Sysctl.hostName
+        let computerName = Host.current().localizedName ?? Sysctl.hostName
         let hostName = Sysctl.osType
         let arch = Sysctl.machine
         let model = Sysctl.model
         let kernelVersion = Sysctl.version
-        let osRelease = Sysctl.osRelease
+        let osRelease = ProcessInfo.processInfo.operatingSystemVersionString
         let activeCPUs = Sysctl.activeCPUs
         let memorySize = Sysctl.memSize
         let cpuFrequency = Sysctl.cpuFreq

--- a/packages/device_info_plus/device_info_plus_macos/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: device_info_plus_macos
 description: Macos implementation of the device_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 2.2.1
+version: 2.2.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
## Description

I have tested the lastest version on my macOS  Monterey 12.1, the computer name and os version is incorrect.
```
{arch: x86_64, model: MacBookPro14,1, hostName: Darwin, osRelease: 21.2.0, activeCPUs: 4, memorySize: 8589934592, cpuFrequency: 2300000000, computerName: 192.168.1.5, kernelVersion: Darwin Kernel Version 21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64, systemGUID: A23CF907-4FB2-50E8-A3F5-E8F2DE4BC121}
```
The computer name is IP address '192.168.1.5', but actually should be 'MegatronKing's Book'. And the os version should be Monterey 12.1 rather than the Darwin kernal version.

I fixed this bug and test seems ok.
```
{arch: x86_64, model: MacBookPro14,1, hostName: Darwin, osRelease: Version 12.1 (Build 21C52), activeCPUs: 4, memorySize: 8589934592, cpuFrequency: 2300000000, computerName: MegatronKing's Book, kernelVersion: Darwin Kernel Version 21.2.0: Sun Nov 28 20:28:54 PST 2021; root:xnu-8019.61.5~1/RELEASE_X86_64, systemGUID: A23CF907-4FB2-50E8-A3F5-E8F2DE4BC121}
```
The docs are here:
https://developer.apple.com/documentation/foundation/host/1409624-localizedname
https://developer.apple.com/documentation/foundation/processinfo/1408730-operatingsystemversionstring