### PR TITLE
[battery_plus_info] Fix NPE on modern Samsung devices

### DIFF
--- a/packages/battery_plus/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.1
+
+- (Android) Fix null pointer exception in `isInBatterySaveMode()` on Samsung devices with One UI
+
 ## 2.1.0
 
 - Add batteryState getter

--- a/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
+++ b/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
@@ -16,8 +16,12 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.PowerManager;
 import android.provider.Settings;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
+
+import java.util.Locale;
+
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
@@ -27,7 +31,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import java.util.Locale;
 
 /** BatteryPlusPlugin */
 public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, FlutterPlugin {
@@ -107,7 +110,7 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
 
   private String getBatteryStatus() {
     int status;
-    if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+    if (android.os.Build.VERSION.SDK_INT >= VERSION_CODES.O) {
       status = getBatteryProperty(BatteryManager.BATTERY_PROPERTY_STATUS);
     } else {
       status = BatteryManager.BATTERY_STATUS_UNKNOWN;
@@ -166,7 +169,7 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
     String mode = Settings.System.getString(applicationContext.getContentResolver(), "psm_switch");
     if (mode == null && (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP)) {
       PowerManager powerManager =
-              (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
+          (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
       return powerManager.isPowerSaveMode();
     } else {
       return (POWER_SAVE_MODE_SAMSUNG.equals(mode));

--- a/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
+++ b/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
@@ -16,12 +16,8 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.PowerManager;
 import android.provider.Settings;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
-
-import java.util.Locale;
-
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.EventChannel;
@@ -31,6 +27,7 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
+import java.util.Locale;
 
 /** BatteryPlusPlugin */
 public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, FlutterPlugin {

--- a/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
+++ b/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
@@ -164,7 +164,12 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
 
   private boolean getPowerSaveModeSamsung() {
     String mode = Settings.System.getString(applicationContext.getContentResolver(), "psm_switch");
-    return (mode.equals(POWER_SAVE_MODE_SAMSUNG));
+    if (mode == null && VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+      PowerManager powerManager = (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
+      return powerManager.isPowerSaveMode();
+    } else {
+      return (POWER_SAVE_MODE_SAMSUNG.equals(mode));
+    }
   }
 
   private Boolean getPowerSaveModeHuawei() {

--- a/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
+++ b/packages/battery_plus/battery_plus/android/src/main/java/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.java
@@ -162,10 +162,11 @@ public class BatteryPlusPlugin implements MethodCallHandler, StreamHandler, Flut
     return null;
   }
 
-  private boolean getPowerSaveModeSamsung() {
+  private Boolean getPowerSaveModeSamsung() {
     String mode = Settings.System.getString(applicationContext.getContentResolver(), "psm_switch");
-    if (mode == null && VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
-      PowerManager powerManager = (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
+    if (mode == null && (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP)) {
+      PowerManager powerManager =
+              (PowerManager) applicationContext.getSystemService(Context.POWER_SERVICE);
       return powerManager.isPowerSaveMode();
     } else {
       return (POWER_SAVE_MODE_SAMSUNG.equals(mode));

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 2.1.0
+version: 2.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

This PR addresses the issue for users with Samsung devices with new Android versions where check `isInBatterySaveMode()` was throwing a null pointer exception. It seems that since some time ago (I suspect it happened when Samsung switched from TouchWiz to OneUI) there is no need in using some Samsung specific APIs and values. Due to this change the standard Android API to check batter save mode works fine and returns proper result. 

Since we don't know for sure which Samsung devices use old Samsung way and which not I have just added an additional check to see if calling old API returns null and in such case just call an Android default `PowerManager` to check the mode.

Fix was tested on Galaxy S9+ with Android 10 / One UI 2.5

## Related Issues

Closes #713 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
