### PR TITLE
[android_intent_plus] using deprecated member

### DIFF
--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  platform: ^3.0.0
+  platform: ^3.1.0
   meta: ^1.3.0
 
 dev_dependencies:


### PR DESCRIPTION
## Description

`android_intent_plus` using deprecated member `packageRoot`

ref: https://github.com/google/platform.dart/pull/38
ref: https://github.com/google/platform.dart/commit/1ffad63428bbd1b3ecaa15926bacfb724023648c#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR1

```
/opt/hostedtoolcache/flutter/2.10.0-stable/x64/.pub-cache/hosted/pub.dartlang.org/platform-3.0.0/lib/src/interface/local_platform.dart:46:19: Error: Member not found: 'packageRoot'.
      io.Platform.packageRoot; // ignore: deprecated_member_use
                  ^^^^^^^^^^^
```