### PR TITLE
[connectivity_plus_linux] Bump nm to 0.5.0

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+- Bump `nm` plugin to 0.5.0 (connectivity_plus_linux)
+
 ## 2.2.0
 
 - Add bluetooth as connectivity result. Supported on Android, Linux, and Web

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 2.2.0
+version: 2.2.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -29,7 +29,7 @@ dependencies:
   flutter:
     sdk: flutter
   connectivity_plus_platform_interface: ^1.2.0
-  connectivity_plus_linux: ^1.2.0
+  connectivity_plus_linux: ^1.3.0
   connectivity_plus_macos: ^1.2.0
   connectivity_plus_web: ^1.2.0
   connectivity_plus_windows: ^1.2.0

--- a/packages/connectivity_plus/connectivity_plus_linux/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.0
+
+- Bump nm plugin to 0.5.0
+
 ## 1.2.0
 
 - Add bluetooth as connectivity result

--- a/packages/connectivity_plus/connectivity_plus_linux/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: connectivity_plus_linux
 description: Linux implementation of the connectivity_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 1.2.0
+version: 1.3.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   connectivity_plus_platform_interface: ^1.2.0
   meta: ^1.7.0
-  nm: ^0.4.0
+  nm: ^0.5.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

`dbus` plugin 0.7.0 is out so `gsettings` is conflicting with `connectivity_plus` as they both are dependent on `dbus`. So I Bumped `nm` to 0.5.0.

Also I bumped `connectivity_plus_linux` to 1.3.0 and updated the CHANGELOG.

## Related Issues

N.A.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
