### PR TITLE
[android_intent_plus] Fix example embedding issue, update Platform dependency

### DIFF
--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.1
+
+- Fix embedding issue in example
+- Update Platform dependency to not use deprecated function
+
 ## 3.1.0
 
 - Added `arrayArguments` to explicitly pass array values to an intent

--- a/packages/android_intent_plus/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/android_intent_plus/example/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
   <uses-permission android:name="android.permission.INTERNET" />
 
   <application
-    android:name="io.flutter.app.FlutterApplication"
+    android:name="${applicationName}"
     android:icon="@mipmap/ic_launcher"
     android:label="android_intent_example">
     <activity

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 3.1.0
+version: 3.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  platform: ^3.0.0
+  platform: ^3.1.0
   meta: ^1.3.0
 
 dev_dependencies:


### PR DESCRIPTION
## Description

Updates to make plugin work with Flutter 2.10 and not fail CI checks. 
- Changed AndriodManifest to use proper application name to not see warning about old embedding.
- Updated `platform` dependency to not use deprecated/removed functions.

## Related Issues

This PR supersedes #722, which lacked changelogs update and plugin version bump.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
