### PR TITLE
[battery_plus] Update dependencies

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@ J-P Nurmi <jpnurmi@gmail.com>
 Miguel Beltran <miquelbeltran@gmail.com>
 Neevash Ramdial <mail@neevash.dev>
 Andrew Teich <andrewteich@me.com>
+Volodymyr Buberenko <v.buberenko@gmail.com>

--- a/packages/battery_plus/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.3
+
+- Update battery_plus_linux dependency
+- Set min Flutter version to 1.20.0 for all platforms
+
 ## 2.1.2
 
 - Fix embedding issue in example

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 2.1.2
+version: 2.1.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -25,8 +25,8 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  battery_plus_platform_interface: ^1.2.0
-  battery_plus_linux: ^1.1.0
+  battery_plus_platform_interface: ^1.2.1
+  battery_plus_linux: ^1.1.1
   battery_plus_macos: ^1.1.0
   battery_plus_web: ^1.1.0
   battery_plus_windows: ^1.1.0
@@ -36,10 +36,10 @@ dev_dependencies:
     sdk: flutter
 
   async: ^2.5.0
-  plugin_platform_interface: ^2.0.0
+  plugin_platform_interface: ^2.1.2
   test: ^1.16.4
   flutter_lints: ^1.0.4
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  flutter: ">=1.20.0"

--- a/packages/battery_plus/battery_plus_linux/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Update dbus to 0.7.1
+
 ## 1.1.0
 
 - Add batteryState getter

--- a/packages/battery_plus/battery_plus_linux/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: battery_plus_linux
 description: Linux implementation of the battery_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -12,7 +12,7 @@ dependencies:
   flutter:
     sdk: flutter
   battery_plus_platform_interface: ^1.2.0
-  dbus: ^0.6.6
+  dbus: ^0.7.1
   meta: ^1.7.0
 
 dev_dependencies:

--- a/packages/battery_plus/battery_plus_platform_interface/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.2.1
+
+- Update plugin_platform_interface to 2.1.2
+- Set min Flutter version to 1.20.0
+
 ## 1.2.0
 
 - Add batteryState getter

--- a/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
@@ -1,18 +1,18 @@
 name: battery_plus_platform_interface
 description: A common platform interface for the battery_plus plugin.
-version: 1.2.0
+version: 1.2.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  plugin_platform_interface: ^2.0.2
+  plugin_platform_interface: ^2.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

This PR fixes reported issue with `battery_plus_linux` using old `dbus` version and, thus, being incompatible with fresh release of `connectivity_plus`. Additionally updated some other dependencies and set min Flutter version as `1.20.0` everywhere as before different plugins had different versions. Finally, added myself to `AUTHORS`.

## Related Issues

Closes #751

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
