### PR TITLE
[network_info_plus] Dependencies update

### DIFF
--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.3
+
+- Update nm dependency to be compatible with fresh versions of other Plus plugins
+- Set min Flutter version to 1.20.0 for all platforms
+
 ## 2.1.2
 
 - Update Flutter dependencies

--- a/packages/network_info_plus/network_info_plus/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/network_info_plus/network_info_plus/example/ios/Flutter/AppFrameworkInfo.plist
@@ -25,6 +25,6 @@
     <string>arm64</string>
   </array>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/packages/network_info_plus/network_info_plus/example/ios/Flutter/Flutter.podspec
+++ b/packages/network_info_plus/network_info_plus/example/ios/Flutter/Flutter.podspec
@@ -7,11 +7,11 @@ Pod::Spec.new do |s|
   s.name             = 'Flutter'
   s.version          = '1.0.0'
   s.summary          = 'High-performance, high-fidelity mobile apps.'
-  s.homepage         = 'https://plus.fluttercommunity.dev'
+  s.homepage         = 'https://flutter.io'
   s.license          = { :type => 'MIT' }
-  s.author           = { 'Flutter Community' => 'authors@fluttercommunity.dev' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
   # Framework linking is handled by Flutter tooling, not CocoaPods.
   # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
   s.vendored_frameworks = 'path/to/nothing'

--- a/packages/network_info_plus/network_info_plus/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/network_info_plus/network_info_plus/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -163,7 +163,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1100;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {
@@ -333,7 +333,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -383,7 +383,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/packages/network_info_plus/network_info_plus/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/packages/network_info_plus/network_info_plus/example/ios/Runner.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "group:Runner.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/packages/network_info_plus/network_info_plus/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/network_info_plus/network_info_plus/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,8 +1,12 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 2.1.2
+version: 2.1.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.20.0"
 
 flutter:
   plugin:
@@ -25,11 +29,11 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0
-  network_info_plus_platform_interface: ^1.1.0
-  network_info_plus_linux: ^1.0.0
+  network_info_plus_platform_interface: ^1.1.2
+  network_info_plus_linux: ^1.1.2
   network_info_plus_macos: ^1.3.0
   network_info_plus_windows: ^1.0.0
-  network_info_plus_web: ^1.0.0
+  network_info_plus_web: ^1.0.1
 
 dev_dependencies:
   flutter_test:
@@ -38,7 +42,3 @@ dev_dependencies:
   mockito: ^5.0.0
   plugin_platform_interface: ^2.0.0
   flutter_lints: ^1.0.4
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"

--- a/packages/network_info_plus/network_info_plus_linux/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+- Bump nm dependency to 0.5.0
+
 ## 1.1.1
 
 - Update Flutter dependencies

--- a/packages/network_info_plus/network_info_plus_linux/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_linux/pubspec.yaml
@@ -2,7 +2,7 @@ name: network_info_plus_linux
 description: Linux implementation of the network_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 1.1.1
+version: 1.1.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
   meta: ^1.7.0
   network_info_plus_platform_interface: ^1.1.0
-  nm: ^0.4.2
+  nm: ^0.5.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/network_info_plus/network_info_plus_macos/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_macos/pubspec.yaml
@@ -4,17 +4,17 @@ version: 1.3.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.20.0"
+
 flutter:
   plugin:
     platforms:
       macos:
         pluginClass: NetworkInfoPlusPlugin
 
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
-
 dependencies:
-  network_info_plus_platform_interface: ^1.0.0
+  network_info_plus_platform_interface: ^1.1.2
   flutter:
     sdk: flutter

--- a/packages/network_info_plus/network_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.2
+
+- Bump platform plugin_platform_interface to 2.1.2
+- Set min Flutter version to 1.20.0
+
 ## 1.1.1
 
 - Update Flutter dependencies

--- a/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
@@ -1,20 +1,20 @@
 name: network_info_plus_platform_interface
 description: A common platform interface for the network_info_plus plugin.
-version: 1.1.1
+version: 1.1.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.7.0
-  plugin_platform_interface: ^2.0.2
+  plugin_platform_interface: ^2.1.2
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^1.0.4
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"

--- a/packages/network_info_plus/network_info_plus_web/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_web/pubspec.yaml
@@ -4,16 +4,16 @@ version: 1.0.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
+environment:
+  sdk: ">=2.12.0 <3.0.0"
+  flutter: ">=1.20.0"
+
 dependencies:
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
   network_info_plus_platform_interface: ^1.0.0
-
-environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
 
 flutter:
   plugin:

--- a/packages/network_info_plus/network_info_plus_windows/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_windows/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus_platform_interface: ^1.0.0
+  network_info_plus_platform_interface: ^1.1.2
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## Description

PR to update `nm` dependency, so network_info_plus is compatible with latest `connectivity_plus` and `battery_plus` plugins.

Additionally, did the same change as in recent #755 and made every platform plugin use the same version min Flutter version.

## Related Issues

Closes #761

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
