### PR TITLE
[share_plus] add ability to get feedback on user action + 100% coverage

### DIFF
--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 4.0.0
 
-- iOS, Android: Add `shareWithResult` methods to get feedback on user action
+- iOS, Android, MacOS: Add `shareWithResult` methods to get feedback on user action
 - Android: Increased minSdkVersion to 23
+- MacOS: Native sharing implementation
 
 ## 3.1.0
 

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.2
+## 3.1.1
 
 - Add *WithResult methods to get feedback on user action
 

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,13 +1,12 @@
-## 3.2.0
+## 4.0.0
 
-- Add *WithResult methods to get feedback on user action
+- iOS, Android: Add `shareWithResult` methods to get feedback on user action
+- Android: Increased minSdkVersion to 23
 
 ## 3.1.0
 
 - Android: Migrate to Kotlin
 - Android: Update dependencies, build config updates
-- Example: Fix project title
-- Example: Set min Flutter version to 1.20.0
 
 ## 3.0.5
 

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+- Add *WithResult methods to get feedback on user action
+
 ## 3.1.0
 
 - Android: Migrate to Kotlin

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.1
+## 3.2.0
 
 - Add *WithResult methods to get feedback on user action
 

--- a/packages/share_plus/share_plus/android/build.gradle
+++ b/packages/share_plus/share_plus/android/build.gradle
@@ -28,7 +28,7 @@ android {
   compileSdkVersion 31
 
   defaultConfig {
-    minSdkVersion 21
+    minSdkVersion 23
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   lintOptions {

--- a/packages/share_plus/share_plus/android/build.gradle
+++ b/packages/share_plus/share_plus/android/build.gradle
@@ -28,7 +28,7 @@ android {
   compileSdkVersion 31
 
   defaultConfig {
-    minSdkVersion 16
+    minSdkVersion 21
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   lintOptions {

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -6,6 +6,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import androidx.core.content.FileProvider
 import java.io.File
 import java.io.IOException
@@ -22,6 +23,19 @@ internal class Share(private val context: Context, private var activity: Activit
 
   private val shareCacheFolder: File
     get() = File(getContext().cacheDir, "share_plus")
+
+  
+  /**
+   * API v31+ requires `PendingIntent.FLAG_MUTABLE`, which is not available before
+   * v31. We therefore have to use different flag sets for pre- and post-API v31.
+   */
+  private val pendingIntentFlags: Int by lazy {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+      PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+    } else {
+      PendingIntent.FLAG_UPDATE_CURRENT
+    }
+  }
 
   private fun getContext(): Context {
     if (activity != null) {
@@ -58,7 +72,7 @@ internal class Share(private val context: Context, private var activity: Activit
           context,
           0,
           Intent(ShareSuccessManager.BROADCAST_CHANNEL),
-          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+          pendingIntentFlags
         ).getIntentSender()
       )
     } else {
@@ -116,7 +130,7 @@ internal class Share(private val context: Context, private var activity: Activit
           context,
           0,
           Intent(ShareSuccessManager.BROADCAST_CHANNEL),
-          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+          pendingIntentFlags
         ).getIntentSender()
       )
     } else {

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -58,7 +58,7 @@ internal class Share(private val context: Context, private var activity: Activit
           context,
           0,
           Intent(ShareSuccessManager.BROADCAST_CHANNEL),
-          PendingIntent.FLAG_UPDATE_CURRENT
+          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         ).getIntentSender()
       )
     } else {
@@ -116,7 +116,7 @@ internal class Share(private val context: Context, private var activity: Activit
           context,
           0,
           Intent(ShareSuccessManager.BROADCAST_CHANNEL),
-          PendingIntent.FLAG_UPDATE_CURRENT
+          PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
         ).getIntentSender()
       )
     } else {

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/SharePlusPlugin.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/SharePlusPlugin.kt
@@ -9,20 +9,25 @@ import io.flutter.plugin.common.MethodChannel
 /** Plugin method host for presenting a share sheet via Intent  */
 class SharePlusPlugin : FlutterPlugin, ActivityAware {
   private lateinit var share: Share
+  private lateinit var manager: ShareSuccessManager
   private lateinit var methodChannel: MethodChannel
 
   override fun onAttachedToEngine(binding: FlutterPluginBinding) {
     methodChannel = MethodChannel(binding.binaryMessenger, CHANNEL)
-    share = Share(context = binding.applicationContext, activity = null)
-    val handler = MethodCallHandler(share)
+    manager = ShareSuccessManager(binding.applicationContext)
+    manager.register()
+    share = Share(context = binding.applicationContext, activity = null, manager = manager)
+    val handler = MethodCallHandler(share, manager)
     methodChannel.setMethodCallHandler(handler)
   }
 
   override fun onDetachedFromEngine(binding: FlutterPluginBinding) {
+    manager.discard()
     methodChannel.setMethodCallHandler(null)
   }
 
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+    binding.addActivityResultListener(manager)
     share.setActivity(binding.activity)
   }
 

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
@@ -1,0 +1,90 @@
+package dev.fluttercommunity.plus.share
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.BroadcastReceiver
+import android.content.Intent
+import android.content.IntentFilter
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.PluginRegistry.ActivityResultListener
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Handles the callback based status information about a successful or dismissed
+ * share. Used to link multiple different callbacks together for easier use.
+ */
+internal class ShareSuccessManager(private val context: Context): BroadcastReceiver(), ActivityResultListener {
+    private var callback: MethodChannel.Result? = null
+    private var calledBack: AtomicBoolean = AtomicBoolean(true)
+
+    /**
+     * Register listener. Must be called before any share sheet is opened.
+     */
+    fun register() {
+        context.registerReceiver(this, IntentFilter(BROADCAST_CHANNEL))
+    }
+
+    /**
+     * Deregister listener. Must be called before the base activity is invalidated.
+     */
+    fun discard() {
+        context.unregisterReceiver(this)
+    }
+
+    /**
+     * Set result callback that will wait for the share-sheet to close and get either
+     * the componentname of the chosen option or an empty string on dismissal.
+     */
+    fun setCallback(callback: MethodChannel.Result): Boolean {
+        if (calledBack.compareAndSet(true, false)) {
+            calledBack.set(false)
+            this.callback = callback
+            return true;
+        } else {
+            callback.error("prior share-sheet did not call back, did you await it? Maybe use non-result variant", null, null)
+            return false;
+        }
+    }
+
+    /**
+     * Must be called if `.startActivityForResult` is not available to avoid deadlocking.
+     */
+    fun unavailable() {
+        returnResult("dev.fluttercommunity.plus/share/unavailable")
+    }
+
+    /**
+     * Send the result to flutter by invoking the previously set callback.
+     */
+    private fun returnResult(result: String) {
+        if (calledBack.compareAndSet(false, true) && callback != null) {
+            callback!!.success(result)
+            callback = null
+        }
+    }
+
+    /**
+     * Handler called after a sharesheet was closed. Called regardless of success or
+     * dismissal.
+     */
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?): Boolean {
+        if (requestCode == ACTIVITY_CODE) {
+            returnResult("")
+            return true
+        }
+
+        return false
+    }
+
+    /**
+     * Handler called after a sharesheet was closed. Called only on success.
+     */
+    override fun onReceive(context: Context, intent: Intent) {
+        returnResult(intent.getParcelableExtra<ComponentName>(Intent.EXTRA_CHOSEN_COMPONENT).toString())
+    }
+
+    companion object {
+        const val BROADCAST_CHANNEL = "dev.fluttercommunity.plus/share/success"
+        const val ACTIVITY_CODE = 17062003
+    }
+}

--- a/packages/share_plus/share_plus/example/android/app/build.gradle
+++ b/packages/share_plus/share_plus/example/android/app/build.gradle
@@ -33,7 +33,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.shareexample"
-        minSdkVersion 16
+        minSdkVersion 23
         targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -88,6 +88,17 @@ class DemoAppState extends State<DemoApp> {
                       );
                     },
                   ),
+                  const Padding(padding: EdgeInsets.only(top: 12.0)),
+                  Builder(
+                    builder: (BuildContext context) {
+                      return ElevatedButton(
+                        onPressed: text.isEmpty && imagePaths.isEmpty
+                            ? null
+                            : () => _onShareWithResult(context),
+                        child: const Text('Share With Result'),
+                      );
+                    },
+                  ),
                 ],
               ),
             ),
@@ -121,5 +132,23 @@ class DemoAppState extends State<DemoApp> {
           subject: subject,
           sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
     }
+  }
+
+  void _onShareWithResult(BuildContext context) async {
+    final box = context.findRenderObject() as RenderBox?;
+    ShareResult result;
+    if (imagePaths.isNotEmpty) {
+      result = await Share.shareFilesWithResult(imagePaths,
+          text: text,
+          subject: subject,
+          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
+    } else {
+      result = await Share.shareWithResult(text,
+          subject: subject,
+          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
+    }
+    ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+      content: Text("Share result: ${result.status}"),
+    ));
   }
 }

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -25,7 +25,7 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
 // We need the companion to avoid ARC deadlock
 @interface UIActivityViewSuccessCompanion : NSObject
 
-@property FlutterResult result; 
+@property FlutterResult result;
 @property NSString *activityType;
 @property BOOL completed;
 
@@ -45,7 +45,7 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
 
 // We use dealloc as the share-sheet might disappear (e.g. iCloud photo album creation)
 // and could then reappear if the user cancels
--(void)dealloc {
+- (void)dealloc {
   if (self.completed) {
     self.result(self.activityType);
   } else {
@@ -182,7 +182,8 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
                               [originWidth doubleValue], [originHeight doubleValue]);
     }
 
-    if ([@"share" isEqualToString:call.method]  || [@"shareWithResult" isEqualToString:call.method]) {
+    if ([@"share" isEqualToString:call.method] ||
+        [@"shareWithResult" isEqualToString:call.method]) {
       NSString *shareText = arguments[@"text"];
       NSString *shareSubject = arguments[@"subject"];
 
@@ -201,7 +202,8 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
                 atSource:originRect
                 toResult:withResult ? result : nil];
       if (!withResult) result(nil);
-    } else if ([@"shareFiles" isEqualToString:call.method] || [@"shareFilesWithResult" isEqualToString:call.method]) {
+    } else if ([@"shareFiles" isEqualToString:call.method] ||
+               [@"shareFilesWithResult" isEqualToString:call.method]) {
       NSArray *paths = arguments[@"paths"];
       NSArray *mimeTypes = arguments[@"mimeTypes"];
       NSString *subject = arguments[@"subject"];
@@ -244,18 +246,22 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
           atSource:(CGRect)origin
           toResult:(FlutterResult)result {
   UIActivityViewSuccessController *activityViewController =
-      [[UIActivityViewSuccessController alloc] initWithActivityItems:shareItems applicationActivities:nil];
+      [[UIActivityViewSuccessController alloc] initWithActivityItems:shareItems
+                                               applicationActivities:nil];
   activityViewController.popoverPresentationController.sourceView = controller.view;
   if (!CGRectIsEmpty(origin)) {
     activityViewController.popoverPresentationController.sourceRect = origin;
   }
   if (result) {
-    UIActivityViewSuccessCompanion *companion = [[UIActivityViewSuccessCompanion alloc] initWithResult:result];
+    UIActivityViewSuccessCompanion *companion =
+        [[UIActivityViewSuccessCompanion alloc] initWithResult:result];
     activityViewController.companion = companion;
-    activityViewController.completionWithItemsHandler = ^(UIActivityType activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
-      companion.activityType = activityType;
-      companion.completed = completed;
-    };
+    activityViewController.completionWithItemsHandler =
+        ^(UIActivityType activityType, BOOL completed, NSArray *returnedItems,
+          NSError *activityError) {
+          companion.activityType = activityType;
+          companion.completed = completed;
+        };
   }
   [controller presentViewController:activityViewController animated:YES completion:nil];
 }

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -22,6 +22,48 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
   return viewController;
 }
 
+// We need the companion to avoid ARC deadlock
+@interface UIActivityViewSuccessCompanion : NSObject
+
+@property FlutterResult result; 
+@property NSString *activityType;
+@property BOOL completed;
+
+- (id)initWithResult:(FlutterResult)result;
+
+@end
+
+@implementation UIActivityViewSuccessCompanion
+
+- (id)initWithResult:(FlutterResult)result {
+  if (self = [super init]) {
+    self.result = result;
+    self.completed = false;
+  }
+  return self;
+}
+
+// We use dealloc as the share-sheet might disappear (e.g. iCloud photo album creation)
+// and could then reappear if the user cancels
+-(void)dealloc {
+  if (self.completed) {
+    self.result(self.activityType);
+  } else {
+    self.result(@"");
+  }
+}
+
+@end
+
+@interface UIActivityViewSuccessController : UIActivityViewController
+
+@property UIActivityViewSuccessCompanion *companion;
+
+@end
+
+@implementation UIActivityViewSuccessController
+@end
+
 @interface SharePlusData : NSObject <UIActivityItemSource>
 
 @property(readonly, nonatomic, copy) NSString *subject;
@@ -127,6 +169,7 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
                                   binaryMessenger:registrar.messenger];
 
   [shareChannel setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
+    BOOL withResult = [call.method hasSuffix:@"WithResult"];
     NSDictionary *arguments = [call arguments];
     NSNumber *originX = arguments[@"originX"];
     NSNumber *originY = arguments[@"originY"];
@@ -139,7 +182,7 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
                               [originWidth doubleValue], [originHeight doubleValue]);
     }
 
-    if ([@"share" isEqualToString:call.method]) {
+    if ([@"share" isEqualToString:call.method]  || [@"shareWithResult" isEqualToString:call.method]) {
       NSString *shareText = arguments[@"text"];
       NSString *shareSubject = arguments[@"subject"];
 
@@ -155,9 +198,10 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
       [self shareText:shareText
                  subject:shareSubject
           withController:topViewController
-                atSource:originRect];
-      result(nil);
-    } else if ([@"shareFiles" isEqualToString:call.method]) {
+                atSource:originRect
+                toResult:withResult ? result : nil];
+      if (!withResult) result(nil);
+    } else if ([@"shareFiles" isEqualToString:call.method] || [@"shareFilesWithResult" isEqualToString:call.method]) {
       NSArray *paths = arguments[@"paths"];
       NSArray *mimeTypes = arguments[@"mimeTypes"];
       NSString *subject = arguments[@"subject"];
@@ -186,8 +230,9 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
              withSubject:subject
                 withText:text
           withController:topViewController
-                atSource:originRect];
-      result(nil);
+                atSource:originRect
+                toResult:withResult ? result : nil];
+      if (!withResult) result(nil);
     } else {
       result(FlutterMethodNotImplemented);
     }
@@ -196,12 +241,21 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
 
 + (void)share:(NSArray *)shareItems
     withController:(UIViewController *)controller
-          atSource:(CGRect)origin {
-  UIActivityViewController *activityViewController =
-      [[UIActivityViewController alloc] initWithActivityItems:shareItems applicationActivities:nil];
+          atSource:(CGRect)origin
+          toResult:(FlutterResult)result {
+  UIActivityViewSuccessController *activityViewController =
+      [[UIActivityViewSuccessController alloc] initWithActivityItems:shareItems applicationActivities:nil];
   activityViewController.popoverPresentationController.sourceView = controller.view;
   if (!CGRectIsEmpty(origin)) {
     activityViewController.popoverPresentationController.sourceRect = origin;
+  }
+  if (result) {
+    UIActivityViewSuccessCompanion *companion = [[UIActivityViewSuccessCompanion alloc] initWithResult:result];
+    activityViewController.companion = companion;
+    activityViewController.completionWithItemsHandler = ^(UIActivityType activityType, BOOL completed, NSArray *returnedItems, NSError *activityError) {
+      companion.activityType = activityType;
+      companion.completed = completed;
+    };
   }
   [controller presentViewController:activityViewController animated:YES completion:nil];
 }
@@ -209,12 +263,13 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
 + (void)shareText:(NSString *)shareText
            subject:(NSString *)subject
     withController:(UIViewController *)controller
-          atSource:(CGRect)origin {
+          atSource:(CGRect)origin
+          toResult:(FlutterResult)result {
   NSObject *data = [[NSURL alloc] initWithString:shareText];
   if (data == nil) {
     data = [[SharePlusData alloc] initWithSubject:subject text:shareText];
   }
-  [self share:@[ data ] withController:controller atSource:origin];
+  [self share:@[ data ] withController:controller atSource:origin toResult:result];
 }
 
 + (void)shareFiles:(NSArray *)paths
@@ -222,7 +277,8 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
        withSubject:(NSString *)subject
           withText:(NSString *)text
     withController:(UIViewController *)controller
-          atSource:(CGRect)origin {
+          atSource:(CGRect)origin
+          toResult:(FlutterResult)result {
   NSMutableArray *items = [[NSMutableArray alloc] init];
 
   if (text || subject) {
@@ -247,7 +303,7 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
     }
   }
 
-  [self share:items withController:controller atSource:origin];
+  [self share:items withController:controller atSource:origin toResult:result];
 }
 
 @end

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
+export 'package:share_plus_platform_interface/share_plus_platform_interface.dart'
+    show ShareResult, ShareResultStatus;
 
 /// Plugin for summoning a platform share sheet.
 class Share {
@@ -82,10 +84,15 @@ class Share {
 
   /// Behaves exactly like [share] while providing feedback on how the user
   /// interacted with the share-sheet. Until the returned future is completed,
-  /// any other call to any share method that returns a result will result in
+  /// any other call to any share method that returns a result might result in
   /// a [PlatformException].
   ///
-  /// Currently only implemented on IOS & Android.
+  /// Because IOS and Android provide different feedback on share-sheet interaction,
+  /// a result on IOS will be more specific than on Android. While IOS can detect if
+  /// the user actually completed his selected action or aborted it midway, Android
+  /// only records if the user selected an action or outright dismissed the share-sheet.
+  ///
+  /// **Currently only implemented on IOS & Android.**
   static Future<ShareResult> shareWithResult(
     String text, {
     String? subject,
@@ -101,10 +108,15 @@ class Share {
 
   /// Behaves exactly like [shareFiles] while providing feedback on how the user
   /// interacted with the share-sheet. Until the returned future is completed,
-  /// any other call to any share method that returns a result will result in
+  /// any other call to any share method that returns a result might result in
   /// a [PlatformException].
   ///
-  /// Currently only implemented on IOS & Android.
+  /// Because IOS and Android provide different feedback on share-sheet interaction,
+  /// a result on IOS will be more specific than on Android. While IOS can detect if
+  /// the user actually completed his selected action or aborted it midway, Android
+  /// only records if the user selected an action or outright dismissed the share-sheet.
+  ///
+  /// **Currently only implemented on IOS & Android.**
   static Future<ShareResult> shareFilesWithResult(
     List<String> paths, {
     List<String>? mimeTypes,

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -84,15 +84,15 @@ class Share {
 
   /// Behaves exactly like [share] while providing feedback on how the user
   /// interacted with the share-sheet. Until the returned future is completed,
-  /// any other call to any share method that returns a result might result in
-  /// a [PlatformException].
+  /// any other call to any share method that returns a result _might_ result in
+  /// a [PlatformException] (on Android).
   ///
-  /// Because IOS and Android provide different feedback on share-sheet interaction,
-  /// a result on IOS will be more specific than on Android. While IOS can detect if
-  /// the user actually completed his selected action or aborted it midway, Android
-  /// only records if the user selected an action or outright dismissed the share-sheet.
+  /// Because IOS, Android and macOS provide different feedback on share-sheet interaction,
+  /// a result on IOS will be more specific than on Android or macOS. While IOS can detect if
+  /// the user actually completed his selected action or aborted it midway, Android and macOS
+  /// only record if the user selected an action or outright dismissed the share-sheet.
   ///
-  /// **Currently only implemented on IOS & Android.**
+  /// **Currently only implemented on IOS, Android and macOS.**
   static Future<ShareResult> shareWithResult(
     String text, {
     String? subject,
@@ -108,15 +108,15 @@ class Share {
 
   /// Behaves exactly like [shareFiles] while providing feedback on how the user
   /// interacted with the share-sheet. Until the returned future is completed,
-  /// any other call to any share method that returns a result might result in
-  /// a [PlatformException].
+  /// any other call to any share method that returns a result _might_ result in
+  /// a [PlatformException] (on Android).
   ///
-  /// Because IOS and Android provide different feedback on share-sheet interaction,
-  /// a result on IOS will be more specific than on Android. While IOS can detect if
-  /// the user actually completed his selected action or aborted it midway, Android
-  /// only records if the user selected an action or outright dismissed the share-sheet.
+  /// Because IOS, Android and macOS provide different feedback on share-sheet interaction,
+  /// a result on IOS will be more specific than on Android or macOS. While IOS can detect if
+  /// the user actually completed his selected action or aborted it midway, Android and macOS
+  /// only record if the user selected an action or outright dismissed the share-sheet.
   ///
-  /// **Currently only implemented on IOS & Android.**
+  /// **Currently only implemented on IOS, Android and macOS.**
   static Future<ShareResult> shareFilesWithResult(
     List<String> paths, {
     List<String>? mimeTypes,

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -79,4 +79,47 @@ class Share {
       sharePositionOrigin: sharePositionOrigin,
     );
   }
+
+  /// Behaves exactly like [share] while providing feedback on how the user
+  /// interacted with the share-sheet. Until the returned future is completed,
+  /// any other call to any share method that returns a result will result in
+  /// a [PlatformException].
+  ///
+  /// Currently only implemented on IOS & Android.
+  static Future<ShareResult> shareWithResult(
+    String text, {
+    String? subject,
+    Rect? sharePositionOrigin,
+  }) async {
+    assert(text.isNotEmpty);
+    return _platform.shareWithResult(
+      text,
+      subject: subject,
+      sharePositionOrigin: sharePositionOrigin,
+    );
+  }
+
+  /// Behaves exactly like [shareFiles] while providing feedback on how the user
+  /// interacted with the share-sheet. Until the returned future is completed,
+  /// any other call to any share method that returns a result will result in
+  /// a [PlatformException].
+  ///
+  /// Currently only implemented on IOS & Android.
+  static Future<ShareResult> shareFilesWithResult(
+    List<String> paths, {
+    List<String>? mimeTypes,
+    String? subject,
+    String? text,
+    Rect? sharePositionOrigin,
+  }) async {
+    assert(paths.isNotEmpty);
+    assert(paths.every((element) => element.isNotEmpty));
+    return _platform.shareFilesWithResult(
+      paths,
+      mimeTypes: mimeTypes,
+      subject: subject,
+      text: text,
+      sharePositionOrigin: sharePositionOrigin,
+    );
+  }
 }

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 3.1.0
+version: 3.1.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 3.2.0
+version: 4.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 3.1.1
+version: 3.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus_macos/CHANGELOG.md
+++ b/packages/share_plus/share_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+- Add *WithResult methods to get feedback on user action
+
 ## 2.0.2
 
 - Obtain Flutter view from the registrar

--- a/packages/share_plus/share_plus_macos/macos/Classes/SharePlusMacosPlugin.swift
+++ b/packages/share_plus/share_plus_macos/macos/Classes/SharePlusMacosPlugin.swift
@@ -30,6 +30,14 @@ public class SharePlusMacosPlugin: NSObject, FlutterPlugin, NSSharingServicePick
       let urls = paths.map { NSURL.fileURL(withPath: $0) }
       shareItems(urls, origin: origin, view: registrar.view!)
       result(true)
+    case "shareWithResult":
+      let text = args["text"] as! String
+      let subject = args["subject"] as? String
+      shareItems([text], subject: subject, origin: origin, view: registrar.view!, callback: result)
+    case "shareFilesWithResult":
+      let paths = args["paths"] as! [String]
+      let urls = paths.map { NSURL.fileURL(withPath: $0) }
+      shareItems(urls, origin: origin, view: registrar.view!, callback: result)
     default:
       result(FlutterMethodNotImplemented)
     }
@@ -40,10 +48,14 @@ public class SharePlusMacosPlugin: NSObject, FlutterPlugin, NSSharingServicePick
     return sharingService.delegate
   }
 
-  private func shareItems(_ items: [Any], subject: String? = nil, origin: NSRect, view: NSView) {
+  private func shareItems(_ items: [Any], subject: String? = nil, origin: NSRect, view: NSView, callback: FlutterResult? = nil) {
     let picker = NSSharingServicePicker(items: items)
-    picker.delegate = self
-    self.subject = subject
+    if callback != nil {
+      picker.delegate = SharePlusMacosSuccessDelegate(subject: subject, callback: callback!).keep()
+    } else {
+      picker.delegate = self
+      self.subject = subject
+    }
     picker.show(relativeTo: origin, of: view, preferredEdge: NSRectEdge.maxY)
   }
 
@@ -53,5 +65,43 @@ public class SharePlusMacosPlugin: NSObject, FlutterPlugin, NSSharingServicePick
     let width = CGFloat(args["originWidth"] as? Double ?? 0)
     let height = CGFloat(args["originHeight"] as? Double ?? 0)
     return NSMakeRect(x, y, width, height)
+  }
+}
+
+/// We need to be able to distinguish between withResult and normal shares.
+///
+/// With each share having its own delegate, we can assure the correct result
+/// is returned to each method call.
+class SharePlusMacosSuccessDelegate: NSObject, NSSharingServicePickerDelegate {
+  private var subject: String?
+  private var callback: FlutterResult
+  private var keepSelf: (() -> Void)?
+
+  init(subject: String?, callback: @escaping FlutterResult) {
+    self.subject = subject
+    self.callback = callback
+  }
+
+  /// This will create a reference cycle to keep ourselves alive.
+  ///
+  /// The delegate on `NSSharingServicePicker` only keeps us as a weak reference
+  /// -> we would go out of scope instantly.
+  /// Deinit is called after `didChoose` sets `keepSelf` to nil!
+  ///
+  /// Has to be an extra method as we may not use `self` in a closure in `init`
+  public func keep() -> Self {
+    self.keepSelf = { _ = self }
+    return self
+  }
+
+  public func sharingServicePicker(_ sharingServicePicker: NSSharingServicePicker, delegateFor sharingService: NSSharingService) -> NSSharingServiceDelegate? {
+    sharingService.subject = subject
+    return sharingService.delegate
+  }
+
+  public func sharingServicePicker(_ sharingServicePicker: NSSharingServicePicker, didChoose service: NSSharingService?) {
+    callback(service != nil ? service!.title : "")
+    // Break self referencing cycle -> deinit
+    self.keepSelf = nil
   }
 }

--- a/packages/share_plus/share_plus_macos/pubspec.yaml
+++ b/packages/share_plus/share_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_macos
 description: MacOS implementation of the share_plus plugin
-version: 2.0.2
+version: 2.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
+++ b/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.2
+## 2.1.0
 
 - Add *WithResult methods to get feedback on user action
 

--- a/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
+++ b/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+
+- Add *WithResult methods to get feedback on user action
+
 ## 2.0.1
 
 - Improve documentation

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -71,7 +71,79 @@ class MethodChannelShare extends SharePlatform {
     return channel.invokeMethod('shareFiles', params);
   }
 
+  /// Summons the platform's share sheet to share text and returns the result.
+  @override
+  Future<ShareResult> shareWithResult(
+    String text, {
+    String? subject,
+    Rect? sharePositionOrigin,
+  }) async {
+    assert(text.isNotEmpty);
+    final params = <String, dynamic>{
+      'text': text,
+      'subject': subject,
+    };
+
+    if (sharePositionOrigin != null) {
+      params['originX'] = sharePositionOrigin.left;
+      params['originY'] = sharePositionOrigin.top;
+      params['originWidth'] = sharePositionOrigin.width;
+      params['originHeight'] = sharePositionOrigin.height;
+    }
+
+    final result =
+        await channel.invokeMethod<String>('shareWithResult', params) ??
+            'dev.fluttercommunity.plus/share/unavailable';
+
+    return ShareResult(result, _statusFromResult(result));
+  }
+
+  /// Summons the platform's share sheet to share multiple files and returns the result.
+  @override
+  Future<ShareResult> shareFilesWithResult(
+    List<String> paths, {
+    List<String>? mimeTypes,
+    String? subject,
+    String? text,
+    Rect? sharePositionOrigin,
+  }) async {
+    assert(paths.isNotEmpty);
+    assert(paths.every((element) => element.isNotEmpty));
+    final params = <String, dynamic>{
+      'paths': paths,
+      'mimeTypes': mimeTypes ??
+          paths.map((String path) => _mimeTypeForPath(path)).toList(),
+    };
+
+    if (subject != null) params['subject'] = subject;
+    if (text != null) params['text'] = text;
+
+    if (sharePositionOrigin != null) {
+      params['originX'] = sharePositionOrigin.left;
+      params['originY'] = sharePositionOrigin.top;
+      params['originWidth'] = sharePositionOrigin.width;
+      params['originHeight'] = sharePositionOrigin.height;
+    }
+
+    final result =
+        await channel.invokeMethod<String>('shareFilesWithResult', params) ??
+            'dev.fluttercommunity.plus/share/unavailable';
+
+    return ShareResult(result, _statusFromResult(result));
+  }
+
   static String _mimeTypeForPath(String path) {
     return lookupMimeType(path) ?? 'application/octet-stream';
+  }
+
+  static ShareResultStatus _statusFromResult(String result) {
+    switch (result) {
+      case '':
+        return ShareResultStatus.dismissed;
+      case 'dev.fluttercommunity.plus/share/unavailable':
+        return ShareResultStatus.unavailable;
+      default:
+        return ShareResultStatus.success;
+    }
   }
 }

--- a/packages/share_plus/share_plus_platform_interface/lib/share_plus_platform_interface.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/share_plus_platform_interface.dart
@@ -67,7 +67,7 @@ class SharePlatform extends PlatformInterface {
     Rect? sharePositionOrigin,
   }) async {
     throw UnimplementedError(
-        'shareWithResult() has only been implemented on IOS & Android');
+        'shareWithResult() has only been implemented on IOS, Android & macOS');
   }
 
   /// Share files with Result.
@@ -79,7 +79,7 @@ class SharePlatform extends PlatformInterface {
     Rect? sharePositionOrigin,
   }) async {
     throw UnimplementedError(
-        'shareWithResult() has only been implemented on IOS & Android');
+        'shareWithResult() has only been implemented on IOS, Android & macOS');
   }
 }
 

--- a/packages/share_plus/share_plus_platform_interface/lib/share_plus_platform_interface.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/share_plus_platform_interface.dart
@@ -59,4 +59,59 @@ class SharePlatform extends PlatformInterface {
       sharePositionOrigin: sharePositionOrigin,
     );
   }
+
+  /// Share text with Result.
+  Future<ShareResult> shareWithResult(
+    String text, {
+    String? subject,
+    Rect? sharePositionOrigin,
+  }) async {
+    throw UnimplementedError(
+        'shareWithResult() has only been implemented on IOS & Android');
+  }
+
+  /// Share files with Result.
+  Future<ShareResult> shareFilesWithResult(
+    List<String> paths, {
+    List<String>? mimeTypes,
+    String? subject,
+    String? text,
+    Rect? sharePositionOrigin,
+  }) async {
+    throw UnimplementedError(
+        'shareWithResult() has only been implemented on IOS & Android');
+  }
+}
+
+/// The result of a share to determine what action the
+/// user has taken.
+///
+/// [status] provides an easy way to determine how the
+/// share-sheet was handled by the user, while [raw] provides
+/// possible access to the action selected.
+class ShareResult {
+  /// The raw return value from the share.
+  ///
+  /// Note that an empty string means the share-sheet was
+  /// dismissed without any action and the special value
+  /// `dev.fluttercommunity.plus/share/unavailable` is caused
+  /// by an unavailable Android Activity at runtime.
+  final String raw;
+
+  /// The action the user has taken
+  final ShareResultStatus status;
+
+  const ShareResult(this.raw, this.status);
+}
+
+/// How the user handled the share-sheet
+enum ShareResultStatus {
+  /// The user has selected an action
+  success,
+
+  /// The user dismissed the share-sheet
+  dismissed,
+
+  /// The status can not be determined
+  unavailable,
 }

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_platform_interface
 description: A common platform interface for the share_plus plugin.
-version: 2.0.2
+version: 2.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_platform_interface
 description: A common platform interface for the share_plus plugin.
-version: 2.0.1
+version: 2.0.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
+++ b/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
@@ -18,8 +18,10 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late MockMethodChannel mockChannel;
+  late SharePlatform sharePlatform;
 
   setUp(() {
+    sharePlatform = SharePlatform();
     mockChannel = MockMethodChannel();
     // Re-pipe to mockito for easier verifies.
     TestDefaultBinaryMessengerBinding.instance!.defaultBinaryMessenger
@@ -30,16 +32,38 @@ void main() {
     });
   });
 
+  test('can set SharePlatform instance', () async {
+    final currentId = identityHashCode(SharePlatform.instance);
+
+    final newInstance = MethodChannelShare();
+    final newInstanceId = identityHashCode(newInstance);
+
+    expect(currentId, isNot(equals(newInstanceId)));
+    expect(
+      identityHashCode(SharePlatform.instance),
+      equals(currentId),
+    );
+    SharePlatform.instance = newInstance;
+    expect(
+      identityHashCode(SharePlatform.instance),
+      equals(newInstanceId),
+    );
+  });
+
   test('sharing empty fails', () {
     expect(
-      () => SharePlatform.instance.share(''),
+      () => sharePlatform.share(''),
+      throwsA(const TypeMatcher<AssertionError>()),
+    );
+    expect(
+      () => SharePlatform.instance.shareWithResult(''),
       throwsA(const TypeMatcher<AssertionError>()),
     );
     verifyZeroInteractions(mockChannel);
   });
 
   test('sharing origin sets the right params', () async {
-    await SharePlatform.instance.share(
+    await sharePlatform.share(
       'some text to share',
       subject: 'some subject to share',
       sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
@@ -52,45 +76,133 @@ void main() {
       'originWidth': 3.0,
       'originHeight': 4.0,
     }));
+
+    await SharePlatform.instance.shareWithResult(
+      'some text to share',
+      subject: 'some subject to share',
+      sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
+    );
+    verify(mockChannel.invokeMethod<void>('shareWithResult', <String, dynamic>{
+      'text': 'some text to share',
+      'subject': 'some subject to share',
+      'originX': 1.0,
+      'originY': 2.0,
+      'originWidth': 3.0,
+      'originHeight': 4.0,
+    }));
+
+    await withFile('tempfile-83649a.png', (File fd) async {
+      await sharePlatform.shareFiles(
+        [fd.path],
+        subject: 'some subject to share',
+        text: 'some text to share',
+        sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
+      );
+      verify(mockChannel.invokeMethod<void>(
+        'shareFiles',
+        <String, dynamic>{
+          'paths': [fd.path],
+          'mimeTypes': ['image/png'],
+          'subject': 'some subject to share',
+          'text': 'some text to share',
+          'originX': 1.0,
+          'originY': 2.0,
+          'originWidth': 3.0,
+          'originHeight': 4.0,
+        },
+      ));
+
+      await SharePlatform.instance.shareFilesWithResult(
+        [fd.path],
+        subject: 'some subject to share',
+        text: 'some text to share',
+        sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
+      );
+      verify(mockChannel.invokeMethod<void>(
+        'shareFilesWithResult',
+        <String, dynamic>{
+          'paths': [fd.path],
+          'mimeTypes': ['image/png'],
+          'subject': 'some subject to share',
+          'text': 'some text to share',
+          'originX': 1.0,
+          'originY': 2.0,
+          'originWidth': 3.0,
+          'originHeight': 4.0,
+        },
+      ));
+    });
   });
 
   test('sharing empty file fails', () {
     expect(
-      () => SharePlatform.instance.shareFiles(['']),
+      () => sharePlatform.shareFiles(['']),
+      throwsA(const TypeMatcher<AssertionError>()),
+    );
+    expect(
+      () => SharePlatform.instance.shareFilesWithResult(['']),
       throwsA(const TypeMatcher<AssertionError>()),
     );
     verifyZeroInteractions(mockChannel);
   });
 
   test('sharing file sets correct mimeType', () async {
-    const path = 'tempfile-83649a.png';
-    final file = File(path);
-    try {
-      file.createSync();
-      await SharePlatform.instance.shareFiles([path]);
+    await withFile('tempfile-83649b.png', (File fd) async {
+      await sharePlatform.shareFiles([fd.path]);
       verify(mockChannel.invokeMethod('shareFiles', <String, dynamic>{
-        'paths': [path],
+        'paths': [fd.path],
         'mimeTypes': ['image/png'],
       }));
-    } finally {
-      file.deleteSync();
-    }
+
+      await SharePlatform.instance.shareFilesWithResult([fd.path]);
+      verify(mockChannel.invokeMethod('shareFilesWithResult', <String, dynamic>{
+        'paths': [fd.path],
+        'mimeTypes': ['image/png'],
+      }));
+    });
   });
 
   test('sharing file sets passed mimeType', () async {
-    const path = 'tempfile-83649a.png';
-    final file = File(path);
-    try {
-      file.createSync();
-      await SharePlatform.instance.shareFiles([path], mimeTypes: ['*/*']);
+    await withFile('tempfile-83649c.png', (File fd) async {
+      await sharePlatform.shareFiles([fd.path], mimeTypes: ['*/*']);
       verify(mockChannel.invokeMethod('shareFiles', <String, dynamic>{
-        'paths': [file.path],
+        'paths': [fd.path],
         'mimeTypes': ['*/*'],
       }));
-    } finally {
-      file.deleteSync();
-    }
+
+      await SharePlatform.instance
+          .shareFilesWithResult([fd.path], mimeTypes: ['*/*']);
+      verify(mockChannel.invokeMethod('shareFilesWithResult', <String, dynamic>{
+        'paths': [fd.path],
+        'mimeTypes': ['*/*'],
+      }));
+    });
   });
+
+  test('witResult methods throws unimplemented on non IOS & Android', () async {
+    expect(
+      () => sharePlatform.shareWithResult('some text to share'),
+      throwsA(const TypeMatcher<UnimplementedError>()),
+    );
+
+    await withFile('tempfile-83649d.png', (File fd) async {
+      expect(
+        () => sharePlatform.shareFilesWithResult([fd.path]),
+        throwsA(const TypeMatcher<UnimplementedError>()),
+      );
+    });
+  });
+}
+
+/// Execute a block within a context that handles creation and deletion of a helper file
+Future<T> withFile<T>(String filename, Future<T> Function(File fd) func) async {
+  final file = File(filename);
+  try {
+    file.createSync();
+    return await func(file);
+  } finally {
+    file.deleteSync();
+  }
 }
 
 // https://github.com/dart-lang/mockito/issues/316

--- a/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
+++ b/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
@@ -32,7 +32,7 @@ void main() {
     });
   });
 
-  test('can set SharePlatform instance', () async {
+  test('can set SharePlatform instance', () {
     final currentId = identityHashCode(SharePlatform.instance);
 
     final newInstance = MethodChannelShare();
@@ -179,7 +179,7 @@ void main() {
     });
   });
 
-  test('witResult methods throws unimplemented on non IOS & Android', () async {
+  test('withResult methods throw unimplemented on non IOS & Android', () async {
     expect(
       () => sharePlatform.shareWithResult('some text to share'),
       throwsA(const TypeMatcher<UnimplementedError>()),


### PR DESCRIPTION
## Description

As per #386 a lot of users would like to know how the user interacted with the share-sheet, so this PR adds exactly this capability. It does this by providing the two extra methods `shareWithResult` and `shareFilesWithResult` on `Share`, which both return a `ShareResult` which can then be used to determine if the user completed an action or dismissed the dialogue. It also provides the user with information on the specific share action (app/build-in) the user might have taken.

By adding this as two new methods, no other APIs have to change. It would be possible to add this feature as an argument to the "old" `share` and `shareFiles` -> `bool withResult = false`, but that would require updating all other *share_plus* platforms implementation, which could probably break some code somewhere and does not seem that good of an idea if not even all platforms support this feature at the moment.

While adding tests for my two new methods I also rewrote parts of the old tests to make them easier and boost coverage to 100% for _share_plus_platform_interface_.

**This requires Android API version 21:**
This simply can not be implemented without writing our completely own sharing-sheet in API version 16(2012) and it should be reasonable to require version 21+(2014).

**Update! requirement for API version 23:**
API Version 31 made it mandatory to either specify [`FLAG_IMMUTABLE`](https://developer.android.com/reference/android/app/PendingIntent#FLAG_IMMUTABLE)(API v.23) or [`FLAG_MUTABLE`](https://developer.android.com/reference/android/app/PendingIntent#FLAG_MUTABLE)(API v.31). This means that in order to support API version 31 - the most current and desirable - we need to set our lower bound to 23+(2015) which should still be reasonable.

This has been my first time writing Kotlin, Objective C and Swift, so any feedback is greatly appreciated ;)

## Related Issues

Resolves #386, resolves #748, resolves #186.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
