### PR TITLE
[connectivity_plus] Add NWPathMonitor based ConnectivityProvider for iOS

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.0
+
+- Add iOS ConnectivityProvider based on NWPathMonitor for iOS 12+.
+
 ## 2.2.2
 
 - Reachability.swift ".unavailable" for iOS is deprecated.

--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/PathMonitorConnectivityProvider.swift
@@ -16,7 +16,9 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
       } else if path.usesInterfaceType(.cellular) {
         return .cellular
       } else if path.usesInterfaceType(.wiredEthernet) {
-        return .wiredEthernet
+        // .wiredEthernet is available in simulator
+        // but for consistency it is probably correct to report .wifi
+        return .wifi
       }
     }
     return .none

--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/PathMonitorConnectivityProvider.swift
@@ -3,7 +3,14 @@ import Network
 
 @available(iOS 12, *)
 public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
-  private let pathMonitor = NWPathMonitor()
+  private var pathMonitor: NWPathMonitor {
+      if (_pathMonitor == nil) {
+          _pathMonitor = NWPathMonitor()
+      }
+      return _pathMonitor!
+  }
+
+  private var _pathMonitor:NWPathMonitor?
 
   public var currentConnectivityType: ConnectivityType {
     let path = pathMonitor.currentPath
@@ -32,6 +39,7 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
 
   public func stop() {
     pathMonitor.cancel()
+    _pathMonitor = nil
   }
 
   private func pathUpdateHandler(path: NWPath) {

--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/PathMonitorConnectivityProvider.swift
@@ -1,0 +1,40 @@
+import Foundation
+import Network
+
+@available(iOS 12, *)
+public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
+  private let pathMonitor = NWPathMonitor()
+
+  public var currentConnectivityType: ConnectivityType {
+    let path = pathMonitor.currentPath
+    if path.status == .satisfied {
+      if path.usesInterfaceType(.wifi) {
+        return .wifi
+      } else if path.usesInterfaceType(.cellular) {
+        return .cellular
+      } else if path.usesInterfaceType(.wiredEthernet) {
+        return .wiredEthernet
+      }
+    }
+    return .none
+  }
+
+  public var connectivityUpdateHandler: ConnectivityUpdateHandler?
+
+  override init() {
+    super.init()
+    pathMonitor.pathUpdateHandler = pathUpdateHandler
+  }
+
+  public func start() {
+    pathMonitor.start(queue: .main)
+  }
+
+  public func stop() {
+    pathMonitor.cancel()
+  }
+
+  private func pathUpdateHandler(path: NWPath) {
+    connectivityUpdateHandler?(currentConnectivityType)
+  }
+}

--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/ReachabilityConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/ReachabilityConnectivityProvider.swift
@@ -2,11 +2,11 @@ import Foundation
 import Reachability
 
 public class ReachabilityConnectivityProvider: NSObject, ConnectivityProvider {
-  private var reachability: Reachability?
+  private var _reachability: Reachability?
 
   public var currentConnectivityType: ConnectivityType {
-    let reachability = try? self.reachability ?? Reachability()
-    switch reachability?.connection {
+    let reachability = ensureReachability()
+    switch reachability.connection {
     case .wifi:
       return .wifi
     case .cellular:
@@ -18,8 +18,13 @@ public class ReachabilityConnectivityProvider: NSObject, ConnectivityProvider {
 
   public var connectivityUpdateHandler: ConnectivityUpdateHandler?
 
+  override init() {
+    super.init()
+    ensureReachability()
+  }
+
   public func start() {
-    reachability = try? Reachability()
+    let reachability = ensureReachability()
 
     NotificationCenter.default.addObserver(
       self,
@@ -27,17 +32,25 @@ public class ReachabilityConnectivityProvider: NSObject, ConnectivityProvider {
       name: .reachabilityChanged,
       object: reachability)
 
-    try? reachability?.startNotifier()
+    try? reachability.startNotifier()
   }
 
   public func stop() {
     NotificationCenter.default.removeObserver(
       self,
       name: .reachabilityChanged,
-      object: reachability)
+      object: _reachability)
 
-    reachability?.stopNotifier()
-    reachability = nil
+    _reachability?.stopNotifier()
+    _reachability = nil
+  }
+
+  private func ensureReachability() -> Reachability {
+    if (_reachability == nil) {
+      let reachability = try? Reachability()
+      _reachability = reachability
+    }
+    return _reachability!
   }
 
   @objc private func reachabilityChanged(notification: NSNotification) {

--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/SwiftConnectivityPlusPlugin.swift
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/SwiftConnectivityPlusPlugin.swift
@@ -23,7 +23,12 @@ public class SwiftConnectivityPlusPlugin: NSObject, FlutterPlugin, FlutterStream
       name: "dev.fluttercommunity.plus/connectivity_status",
       binaryMessenger: registrar.messenger())
 
-    let connectivityProvider = ReachabilityConnectivityProvider()
+    let connectivityProvider: ConnectivityProvider
+    if #available(iOS 12, *) {
+      connectivityProvider = PathMonitorConnectivityProvider()
+    } else {
+      connectivityProvider = ReachabilityConnectivityProvider()
+    }
 
     let instance = SwiftConnectivityPlusPlugin(connectivityProvider: connectivityProvider)
     streamChannel.setStreamHandler(instance)

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
     sdk: flutter
   connectivity_plus_platform_interface: ^1.2.0
   connectivity_plus_linux: ^1.3.0
-  connectivity_plus_macos: ^1.2.0
+  connectivity_plus_macos: ^1.2.2
   connectivity_plus_web: ^1.2.0
   connectivity_plus_windows: ^1.2.0
 

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 2.2.2
+version: 2.3.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/connectivity_plus/connectivity_plus_macos/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+- Fix connectivity stream can not be reused (after hot-restart) on MacOS 10.14+.
+
 ## 1.2.1
 
 - Update license headers.

--- a/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/PathMonitorConnectivityProvider.swift
@@ -3,7 +3,14 @@ import Network
 
 @available(macOS 10.14, *)
 public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
-  private let pathMonitor = NWPathMonitor()
+  private let pathMonitor: NWPathMonitor
+
+  private var pathMonitor: NWPathMonitor {
+      if (_pathMonitor == nil) {
+          _pathMonitor = NWPathMonitor()
+      }
+      return _pathMonitor!
+  }
 
   public var currentConnectivityType: ConnectivityType {
     let path = pathMonitor.currentPath
@@ -32,6 +39,7 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
 
   public func stop() {
     pathMonitor.cancel()
+    _pathMonitor = nil
   }
 
   private func pathUpdateHandler(path: NWPath) {

--- a/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/PathMonitorConnectivityProvider.swift
@@ -3,17 +3,13 @@ import Network
 
 @available(macOS 10.14, *)
 public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
-  private let pathMonitor: NWPathMonitor
 
-  private var pathMonitor: NWPathMonitor {
-      if (_pathMonitor == nil) {
-          _pathMonitor = NWPathMonitor()
-      }
-      return _pathMonitor!
-  }
+  private let queue = DispatchQueue.global(qos: .background)
+
+  private var _pathMonitor: NWPathMonitor?
 
   public var currentConnectivityType: ConnectivityType {
-    let path = pathMonitor.currentPath
+    let path = ensurePathMonitor().currentPath
     if path.status == .satisfied {
       if path.usesInterfaceType(.wifi) {
         return .wifi
@@ -30,16 +26,26 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
 
   override init() {
     super.init()
-    pathMonitor.pathUpdateHandler = pathUpdateHandler
+    ensurePathMonitor()
   }
 
   public func start() {
-    pathMonitor.start(queue: .main)
+    ensurePathMonitor()
   }
 
   public func stop() {
-    pathMonitor.cancel()
+    _pathMonitor?.cancel()
     _pathMonitor = nil
+  }
+
+  private func ensurePathMonitor() -> NWPathMonitor {
+    if (_pathMonitor == nil) {
+      let pathMonitor = NWPathMonitor()
+      pathMonitor.start(queue: queue)
+      pathMonitor.pathUpdateHandler = pathUpdateHandler
+      _pathMonitor = pathMonitor
+    }
+    return _pathMonitor!
   }
 
   private func pathUpdateHandler(path: NWPath) {

--- a/packages/connectivity_plus/connectivity_plus_macos/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_macos
 description: macOS implementation of the connectivity_plus plugin.
-version: 1.2.1
+version: 1.2.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

* copied from MacOS implementation
* available on iOS 12+
* correctly notifies when switching between Wifi networks without internet access

## Related Issues

Fixes #632 for iOS 12+

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
