### PR TITLE
[share_plus] minSdkVersion 16 & graceful fallback

### DIFF
--- a/docs/share_plus/usage.mdx
+++ b/docs/share_plus/usage.mdx
@@ -35,3 +35,21 @@ To share one or multiple files invoke the static `shareFiles` method anywhere in
 Share.shareFiles(['${directory.path}/image.jpg'], text: 'Great picture');
 Share.shareFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
 ```
+
+If you are interested in the action your user performed with the share sheet, you can instead use the `shareWithResult` and `shareFilesWithResult` methods.
+
+```dart
+final result = await Share.shareWithResult('check out my website https://example.com');
+
+if (result.status != ShareResultStatus.success) {
+    print('thank you for sharing my website!');
+}
+```
+
+```dart
+final result = await Share.shareFilesWithResult(['${directory.path}/image.jpg'], text: 'Great picture');
+
+if (result.status == ShareResultStatus.dismissed) {
+    print('did you not like the picture?');
+}
+```

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Android: Revert increased minSdkVersion back to 16
 - Gracefully fall back to normal share methods on not supported platforms
+- Improve documentation for `shareWithResult` methods
 
 ## 4.0.2
 

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 4.0.3
 
 - Android: Revert increased minSdkVersion back to 16
-- Gracefully fall back to normal share methods on not supported platforms
+- Gracefully fall back from `shareWithResult` to regular `share` methods on unsupported platforms
 - Improve documentation for `shareWithResult` methods
 
 ## 4.0.2

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.3
+
+- Android: Revert increased minSdkVersion back to 16
+
 ## 4.0.2
 
 - Fix type mismatch on Android for some users

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 4.0.3
 
 - Android: Revert increased minSdkVersion back to 16
+- Gracefully fall back to normal share methods on not supported platforms
 
 ## 4.0.2
 

--- a/packages/share_plus/share_plus/android/build.gradle
+++ b/packages/share_plus/share_plus/android/build.gradle
@@ -28,7 +28,7 @@ android {
   compileSdkVersion 31
 
   defaultConfig {
-    minSdkVersion 22
+    minSdkVersion 16
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
   lintOptions {

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
@@ -13,24 +13,24 @@ internal class MethodCallHandler(
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         // The user used a *WithResult method
-        val calledWithResult = call.method.endsWith("WithResult")
+        val isResultRequested = call.method.endsWith("WithResult")
         // We don't attempt to return a result if the current API version doesn't support it
-        val withResult = calledWithResult && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
+        val isWithResult = isResultRequested && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
 
         when (call.method) {
             "share", "shareWithResult" -> {
                 expectMapArguments(call)
-                if (withResult && !manager.setCallback(result)) return
+                if (isWithResult && !manager.setCallback(result)) return
 
                 // Android does not support showing the share sheet at a particular point on screen.
                 share.share(
                     call.argument<Any>("text") as String,
                     call.argument<Any>("subject") as String?,
-                    withResult,
+                    isWithResult,
                 )
 
-                if (!withResult) {
-                    if (calledWithResult) {
+                if (!isWithResult) {
+                    if (isResultRequested) {
                         result.success("dev.fluttercommunity.plus/share/unavailable")
                     } else {
                         result.success(null)
@@ -39,7 +39,7 @@ internal class MethodCallHandler(
             }
             "shareFiles", "shareFilesWithResult" -> {
                 expectMapArguments(call)
-                if (withResult && !manager.setCallback(result)) return
+                if (isWithResult && !manager.setCallback(result)) return
 
                 // Android does not support showing the share sheet at a particular point on screen.
                 try {
@@ -48,11 +48,11 @@ internal class MethodCallHandler(
                         call.argument<List<String>?>("mimeTypes"),
                         call.argument<String?>("text"),
                         call.argument<String?>("subject"),
-                        withResult,
+                        isWithResult,
                     )
 
-                    if (!withResult) {
-                        if (calledWithResult) {
+                    if (!isWithResult) {
+                        if (isResultRequested) {
                             result.success("dev.fluttercommunity.plus/share/unavailable")
                         } else {
                             result.success(null)

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
@@ -1,5 +1,6 @@
 package dev.fluttercommunity.plus.share
 
+import android.os.Build
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.io.IOException
@@ -11,48 +12,34 @@ internal class MethodCallHandler(
 ) : MethodChannel.MethodCallHandler {
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        // The user used a *WithResult method
+        val calledWithResult = call.method.endsWith("WithResult")
+        // We don't attempt to return a result if the current API version doesn't support it
+        val withResult = calledWithResult && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
+
         when (call.method) {
-            "share" -> {
+            "share", "shareWithResult" -> {
                 expectMapArguments(call)
+                if (withResult && !manager.setCallback(result)) return
+
                 // Android does not support showing the share sheet at a particular point on screen.
                 share.share(
                     call.argument<Any>("text") as String,
                     call.argument<Any>("subject") as String?,
-                    false,
+                    withResult,
                 )
-                result.success(null)
-            }
-            "shareFiles" -> {
-                expectMapArguments(call)
 
-                // Android does not support showing the share sheet at a particular point on screen.
-                try {
-                    share.shareFiles(
-                        call.argument<List<String>>("paths")!!,
-                        call.argument<List<String>?>("mimeTypes"),
-                        call.argument<String?>("text"),
-                        call.argument<String?>("subject"),
-                        false,
-                    )
-                    result.success(null)
-                } catch (e: IOException) {
-                    result.error("Share failed", e.message, null)
+                if (!withResult) {
+                    if (calledWithResult) {
+                        result.success("dev.fluttercommunity.plus/share/unavailable")
+                    } else {
+                        result.success(null)
+                    }
                 }
             }
-            "shareWithResult" -> {
+            "shareFiles", "shareFilesWithResult" -> {
                 expectMapArguments(call)
-                if (!manager.setCallback(result)) return
-
-                // Android does not support showing the share sheet at a particular point on screen.
-                share.share(
-                    call.argument<Any>("text") as String,
-                    call.argument<Any>("subject") as String?,
-                    true,
-                )
-            }
-            "shareFilesWithResult" -> {
-                expectMapArguments(call)
-                if (!manager.setCallback(result)) return
+                if (withResult && !manager.setCallback(result)) return
 
                 // Android does not support showing the share sheet at a particular point on screen.
                 try {
@@ -61,8 +48,16 @@ internal class MethodCallHandler(
                         call.argument<List<String>?>("mimeTypes"),
                         call.argument<String?>("text"),
                         call.argument<String?>("subject"),
-                        true,
+                        withResult,
                     )
+
+                    if (!withResult) {
+                        if (calledWithResult) {
+                            result.success("dev.fluttercommunity.plus/share/unavailable")
+                        } else {
+                            result.success(null)
+                        }
+                    }
                 } catch (e: IOException) {
                     result.error("Share failed", e.message, null)
                 }

--- a/packages/share_plus/share_plus/example/android/app/build.gradle
+++ b/packages/share_plus/share_plus/example/android/app/build.gradle
@@ -33,7 +33,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.shareexample"
-        minSdkVersion 22
+        minSdkVersion 16
         targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -87,12 +87,17 @@ class Share {
   /// any other call to any share method that returns a result _might_ result in
   /// a [PlatformException] (on Android).
   ///
-  /// Because IOS, Android and macOS provide different feedback on share-sheet interaction,
-  /// a result on IOS will be more specific than on Android or macOS. While IOS can detect if
-  /// the user actually completed his selected action or aborted it midway, Android and macOS
-  /// only record if the user selected an action or outright dismissed the share-sheet.
+  /// Because IOS, Android and macOS provide different feedback on share-sheet
+  /// interaction, a result on IOS will be more specific than on Android or macOS.
+  /// While on IOS the selected action can inform its caller that it was completed
+  /// or dismissed midway (_actions are free to return whatever they want_),
+  /// Android and macOS only record if the user selected an action or outright
+  /// dismissed the share-sheet.
   ///
   /// **Currently only implemented on IOS, Android and macOS.**
+  ///
+  /// Will gracefully fall back to the non result variant if not implemented
+  /// for the current environment and return [ShareResult.unavailable].
   static Future<ShareResult> shareWithResult(
     String text, {
     String? subject,
@@ -111,12 +116,17 @@ class Share {
   /// any other call to any share method that returns a result _might_ result in
   /// a [PlatformException] (on Android).
   ///
-  /// Because IOS, Android and macOS provide different feedback on share-sheet interaction,
-  /// a result on IOS will be more specific than on Android or macOS. While IOS can detect if
-  /// the user actually completed his selected action or aborted it midway, Android and macOS
-  /// only record if the user selected an action or outright dismissed the share-sheet.
+  /// Because IOS, Android and macOS provide different feedback on share-sheet
+  /// interaction, a result on IOS will be more specific than on Android or macOS.
+  /// While on IOS the selected action can inform its caller that it was completed
+  /// or dismissed midway (_actions are free to return whatever they want_),
+  /// Android and macOS only record if the user selected an action or outright
+  /// dismissed the share-sheet.
   ///
   /// **Currently only implemented on IOS, Android and macOS.**
+  ///
+  /// Will gracefully fall back to the non result variant if not implemented
+  /// for the current environment and return [ShareResult.unavailable].
   static Future<ShareResult> shareFilesWithResult(
     List<String> paths, {
     List<String>? mimeTypes,

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -92,7 +92,8 @@ class Share {
   /// While on IOS the selected action can inform its caller that it was completed
   /// or dismissed midway (_actions are free to return whatever they want_),
   /// Android and macOS only record if the user selected an action or outright
-  /// dismissed the share-sheet.
+  /// dismissed the share-sheet. It is not guaranteed that the user actually shared
+  /// something.
   ///
   /// **Currently only implemented on IOS, Android and macOS.**
   ///
@@ -121,7 +122,8 @@ class Share {
   /// While on IOS the selected action can inform its caller that it was completed
   /// or dismissed midway (_actions are free to return whatever they want_),
   /// Android and macOS only record if the user selected an action or outright
-  /// dismissed the share-sheet.
+  /// dismissed the share-sheet. It is not guaranteed that the user actually shared
+  /// something.
   ///
   /// **Currently only implemented on IOS, Android and macOS.**
   ///

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   mime: ^1.0.0
   flutter:
     sdk: flutter
-  share_plus_platform_interface: ^3.0.0
+  share_plus_platform_interface: ^3.0.2
   share_plus_linux: ^3.0.0
   share_plus_macos: ^3.0.0
   share_plus_windows: ^3.0.0

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 4.0.2
+version: 4.0.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
+++ b/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.0.2
 
-- Gracefully fall back to normal share methods on not supported platforms
+- Gracefully fall back from `shareWithResult` to regular `share` methods on unsupported platforms
 
 ## 3.0.1
 

--- a/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
+++ b/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.2
+
+- Gracefully fall back to normal share methods on not supported platforms
+
 ## 3.0.1
 
 - Set min Flutter to 1.20.0 to match Share plugins on all platforms

--- a/packages/share_plus/share_plus_platform_interface/lib/share_plus_platform_interface.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/share_plus_platform_interface.dart
@@ -66,8 +66,13 @@ class SharePlatform extends PlatformInterface {
     String? subject,
     Rect? sharePositionOrigin,
   }) async {
-    throw UnimplementedError(
-        'shareWithResult() has only been implemented on IOS, Android & macOS');
+    await _instance.share(
+      text,
+      subject: subject,
+      sharePositionOrigin: sharePositionOrigin,
+    );
+
+    return _resultUnavailable;
   }
 
   /// Share files with Result.
@@ -78,8 +83,15 @@ class SharePlatform extends PlatformInterface {
     String? text,
     Rect? sharePositionOrigin,
   }) async {
-    throw UnimplementedError(
-        'shareWithResult() has only been implemented on IOS, Android & macOS');
+    await _instance.shareFiles(
+      paths,
+      mimeTypes: mimeTypes,
+      subject: subject,
+      text: text,
+      sharePositionOrigin: sharePositionOrigin,
+    );
+
+    return _resultUnavailable;
   }
 }
 
@@ -94,8 +106,8 @@ class ShareResult {
   ///
   /// Note that an empty string means the share-sheet was
   /// dismissed without any action and the special value
-  /// `dev.fluttercommunity.plus/share/unavailable` is caused
-  /// by an unavailable Android Activity at runtime.
+  /// `dev.fluttercommunity.plus/share/unavailable` points
+  /// to the current environment not supporting share results.
   final String raw;
 
   /// The action the user has taken
@@ -115,3 +127,9 @@ enum ShareResultStatus {
   /// The status can not be determined
   unavailable,
 }
+
+/// Returned if the platform is not supported
+const _resultUnavailable = ShareResult(
+  'dev.fluttercommunity.plus/share/unavailable',
+  ShareResultStatus.unavailable,
+);

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_platform_interface
 description: A common platform interface for the share_plus plugin.
-version: 3.0.1
+version: 3.0.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

- Revert `minSdkVersion` back to 16 and dynamically determine support for `shareWithResult` at runtime
- Gracefully fall back to "normal" share without result if the environment does not support `shareWithResult`
- Improve documentation for `shareWithResult`

## Related Issues

Closes #789

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
