### PR TITLE
[package_info_plus] Resolve package name linux and web

### DIFF
--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.2
+
+- Web: Resolve package_name
+- Linux: Resolve package_name
+
 ## 1.4.1
 
 - Windows: Fix MissingPluginException

--- a/packages/package_info_plus/package_info_plus/example/test_driver/package_info_plus_e2e.dart
+++ b/packages/package_info_plus/package_info_plus/example/test_driver/package_info_plus_e2e.dart
@@ -20,7 +20,7 @@ void main() {
       expect(info.appName, 'package_info_example');
       expect(info.buildNumber, '4');
       expect(info.buildSignature, isEmpty);
-      expect(info.packageName, isEmpty);
+      expect(info.packageName, 'package_info_example');
       expect(info.version, '1.2.3');
     } else {
       if (Platform.isAndroid) {
@@ -45,7 +45,7 @@ void main() {
         expect(info.appName, 'package_info_example');
         expect(info.buildNumber, '4');
         expect(info.buildSignature, isEmpty);
-        expect(info.packageName, isEmpty);
+        expect(info.packageName, 'package_info_example');
         expect(info.version, '1.2.3');
       } else {
         throw (UnsupportedError('platform not supported'));
@@ -57,10 +57,10 @@ void main() {
     await tester.pumpWidget(const MyApp());
     await tester.pumpAndSettle();
     if (kIsWeb) {
-      expect(find.text('package_info_example'), findsOneWidget);
+      expect(find.text('package_info_example'), findsNWidgets(2));
       expect(find.text('1.2.3'), findsOneWidget);
       expect(find.text('4'), findsOneWidget);
-      expect(find.text('Not set'), findsNWidgets(2));
+      expect(find.text('Not set'), findsOneWidget);
     } else {
       if (Platform.isAndroid) {
         expect(find.text('package_info_example'), findsOneWidget);
@@ -84,10 +84,10 @@ void main() {
         expect(find.text('1.2.3'), findsOneWidget);
         expect(find.text('Not set'), findsOneWidget);
       } else if (Platform.isLinux) {
-        expect(find.text('package_info_example'), findsOneWidget);
+        expect(find.text('package_info_example'), findsNWidgets(2));
         expect(find.text('1.2.3'), findsOneWidget);
         expect(find.text('4'), findsOneWidget);
-        expect(find.text('Not set'), findsNWidgets(2));
+        expect(find.text('Not set'), findsOneWidget);
       } else {
         throw (UnsupportedError('platform not supported'));
       }

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 1.4.1
+version: 1.4.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -29,7 +29,6 @@ dependencies:
   package_info_plus_macos: ^1.2.0
   package_info_plus_windows: ^1.0.5
   package_info_plus_web: ^1.0.5
-
 
 dev_dependencies:
   flutter_test:

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -25,10 +25,11 @@ dependencies:
   flutter:
     sdk: flutter
   package_info_plus_platform_interface: ^1.0.2
-  package_info_plus_linux: ^1.0.4
+  package_info_plus_linux: ^1.0.5
   package_info_plus_macos: ^1.2.0
   package_info_plus_windows: ^1.0.5
-  package_info_plus_web: ^1.0.4
+  package_info_plus_web: ^1.0.5
+
 
 dev_dependencies:
   flutter_test:

--- a/packages/package_info_plus/package_info_plus_linux/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus_linux/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fix MissingPluginException
 
 ## 1.0.3
-- Add `buildSignature` to Android package info to retrieve the signing certificate SHA1 at runtime.
+- Add `buildSignature` to Android package info to retrieve the signing certifiate SHA1 at runtime.
 
 ## 1.0.2
 

--- a/packages/package_info_plus/package_info_plus_linux/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus_linux/CHANGELOG.md
@@ -1,9 +1,13 @@
+## 1.0.5
+
+- Resolve package_name
+
 ## 1.0.4
 
 - Fix MissingPluginException
 
 ## 1.0.3
-- Add `buildSignature` to Android package info to retrieve the signing certifiate SHA1 at runtime.
+- Add `buildSignature` to Android package info to retrieve the signing certificate SHA1 at runtime.
 
 ## 1.0.2
 

--- a/packages/package_info_plus/package_info_plus_linux/lib/src/package_info.dart
+++ b/packages/package_info_plus/package_info_plus_linux/lib/src/package_info.dart
@@ -21,7 +21,7 @@ class PackageInfoLinux extends PackageInfoPlatform {
       appName: versionJson['app_name'] ?? '',
       version: versionJson['version'] ?? '',
       buildNumber: versionJson['build_number'] ?? '',
-      packageName: '',
+      packageName: versionJson['package_name'] ?? '',
       buildSignature: '',
     );
   }

--- a/packages/package_info_plus/package_info_plus_linux/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_linux
 description: Linux implementation of the package_info_plus plugin
-version: 1.0.4
+version: 1.0.5
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/package_info_plus/package_info_plus_web/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus_web/CHANGELOG.md
@@ -1,9 +1,13 @@
+## 1.0.5
+
+- Resolve package_name
+
 ## 1.0.4
 
 - Fixed url resolving for the version.json
 
 ## 1.0.3
-- Add `buildSignature` to Android package info to retrieve the signing certifiate SHA1 at runtime.
+- Add `buildSignature` to Android package info to retrieve the signing certificate SHA1 at runtime.
 
 ## 1.0.2
 

--- a/packages/package_info_plus/package_info_plus_web/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus_web/CHANGELOG.md
@@ -7,7 +7,7 @@
 - Fixed url resolving for the version.json
 
 ## 1.0.3
-- Add `buildSignature` to Android package info to retrieve the signing certificate SHA1 at runtime.
+- Add `buildSignature` to Android package info to retrieve the signing certifiate SHA1 at runtime.
 
 ## 1.0.2
 

--- a/packages/package_info_plus/package_info_plus_web/lib/package_info_plus_web.dart
+++ b/packages/package_info_plus/package_info_plus_web/lib/package_info_plus_web.dart
@@ -41,7 +41,7 @@ class PackageInfoPlugin extends PackageInfoPlatform {
       appName: versionMap['app_name'] ?? '',
       version: versionMap['version'] ?? '',
       buildNumber: versionMap['build_number'] ?? '',
-      packageName: '',
+      packageName: versionMap['package_name'] ?? '',
       buildSignature: '',
     );
   }

--- a/packages/package_info_plus/package_info_plus_web/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_web
 description: Web platform implementation of package_info_plus
-version: 1.0.4
+version: 1.0.5
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/package_info_plus/package_info_plus_web/test/package_info_plus_web_test.dart
+++ b/packages/package_info_plus/package_info_plus_web/test/package_info_plus_web_test.dart
@@ -42,7 +42,7 @@ void main() {
 
           expect(versionMap.appName, VERSION_JSON['app_name']);
           expect(versionMap.buildNumber, VERSION_JSON['build_number']);
-          expect(versionMap.packageName, isEmpty);
+          expect(versionMap.packageName, VERSION_JSON['package_name']);
           expect(versionMap.version, VERSION_JSON['version']);
         },
       );


### PR DESCRIPTION
## Description

package_info_plus for linux and web returns now return the `package_name` contained in the `version.json` file (which was introduced in [this PR](https://github.com/flutter/flutter/pull/88457)) 
 
See the data returned on both web and linux platforms :
![image](https://user-images.githubusercontent.com/37002358/161341949-02b0e695-573b-4516-bb9a-94d94faffdfe.png)

## Related Issues

Closes #203

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
