### PR TITLE
[package_info_plus] fix MissingPluginException for windows and linux

### DIFF
--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.1
+
+- Windows: Fix MissingPluginException
+- Linux: Fix MissingPluginException
+
 ## 1.4.0
 
 - Android: Migrate to Kotlin

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -25,9 +25,9 @@ dependencies:
   flutter:
     sdk: flutter
   package_info_plus_platform_interface: ^1.0.2
-  package_info_plus_linux: ^1.0.3
+  package_info_plus_linux: ^1.0.4
   package_info_plus_macos: ^1.2.0
-  package_info_plus_windows: ^1.0.4
+  package_info_plus_windows: ^1.0.5
   package_info_plus_web: ^1.0.4
 
 dev_dependencies:

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 1.4.0
+version: 1.4.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/package_info_plus/package_info_plus_linux/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+- Fix MissingPluginException
+
 ## 1.0.3
 - Add `buildSignature` to Android package info to retrieve the signing certifiate SHA1 at runtime.
 

--- a/packages/package_info_plus/package_info_plus_linux/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_linux
 description: Linux implementation of the package_info_plus plugin
-version: 1.0.3
+version: 1.0.4
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/package_info_plus/package_info_plus_linux/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_linux/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   package_info_plus_platform_interface: ^1.0.2

--- a/packages/package_info_plus/package_info_plus_windows/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5
+
+- Fix MissingPluginException
+
 ## 1.0.4
 
 - Annotate int with external in preparation of Flutter 2.5

--- a/packages/package_info_plus/package_info_plus_windows/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_windows/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.17.0"
+  flutter: ">=1.20.0"
 
 dependencies:
   package_info_plus_platform_interface: ^1.0.2

--- a/packages/package_info_plus/package_info_plus_windows/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_windows
 description: Windows implementation of the package_info_plus plugin
-version: 1.0.4
+version: 1.0.5
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION


## Description

At commit 7e898675fbd18cb6ac90f36c1e6bd126aea1c64d the plugins for windows and linux had changes to auto register via `static void registerWith()`. But neither the plugins nor the main package versions were increased and published.

This commit fixes that by increasing the versions of the plugins and the main package.

## Related Issues

Closes #806
Closes #760
Closes #747
Closes #773

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
