### PR TITLE
fix(connectivity_plus): Reachability.swift ".unavailable" is deprecated

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.2
+
+- Reachability.swift ".unavailable" for iOS is deprecated.
+
 ## 2.2.1
 
 - Bump `nm` plugin to 0.5.0 (connectivity_plus_linux)

--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/ReachabilityConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/ReachabilityConnectivityProvider.swift
@@ -6,7 +6,7 @@ public class ReachabilityConnectivityProvider: NSObject, ConnectivityProvider {
 
   public var currentConnectivityType: ConnectivityType {
     let reachability = try? self.reachability ?? Reachability()
-    switch reachability?.connection ?? .unavailable {
+    switch reachability?.connection {
     case .wifi:
       return .wifi
     case .cellular:

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 2.2.1
+version: 2.2.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

- Resolves "reference to member 'unavailable' cannot be resolved without a contextual type" error that occurs during ios compilation.

## Related Issues

Closes #656 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
