### PR TITLE
[device_info_plus] Fix crash on macOS running on Apple M1

### DIFF
--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.3
+
+- Fix crash on macOS running on Apple M1
+
 ## 3.2.2
 
 - Fix embedding issue in example

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 3.2.2
+version: 3.2.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -26,7 +26,7 @@ dependencies:
   flutter:
     sdk: flutter
   device_info_plus_platform_interface: ^2.3.0
-  device_info_plus_macos: ^2.2.1
+  device_info_plus_macos: ^2.2.3
   device_info_plus_linux: ^2.1.1
   device_info_plus_web: ^2.1.0
   device_info_plus_windows: ^2.1.1

--- a/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.3
+
+- Fix crash on macOS running on Apple M1
+
 ## 2.2.2
 
 - Fixed incorrect computer name and version on MacOS

--- a/packages/device_info_plus/device_info_plus_macos/macos/Classes/CwlSysctl.swift
+++ b/packages/device_info_plus/device_info_plus_macos/macos/Classes/CwlSysctl.swift
@@ -117,15 +117,15 @@ public struct Sysctl {
 
 	/// e.g. "MyComputer.local" (from System Preferences -> Sharing -> Computer Name) or
 	/// "My-Name-iPhone" (from Settings -> General -> About -> Name)
-	public static var hostName: String { return try! Sysctl.string(for: [CTL_KERN, KERN_HOSTNAME]) }
+	public static var hostName: String { return try? Sysctl.string(for: [CTL_KERN, KERN_HOSTNAME]) ?? "" }
 
 	/// e.g. "x86_64" or "N71mAP"
 	/// NOTE: this is *corrected* on iOS devices to fetch hw.model
 	public static var machine: String {
 		#if os(iOS) && !arch(x86_64) && !arch(i386)
-			return try! Sysctl.string(for: [CTL_HW, HW_MODEL])
+			return try? Sysctl.string(for: [CTL_HW, HW_MODEL]) ?? ""
 		#else
-			return try! Sysctl.string(for: [CTL_HW, HW_MACHINE])
+			return try? Sysctl.string(for: [CTL_HW, HW_MACHINE]) ?? ""
 		#endif
 	}
 
@@ -133,36 +133,36 @@ public struct Sysctl {
 	/// NOTE: this is *corrected* on iOS devices to fetch hw.machine
 	public static var model: String {
 		#if os(iOS) && !arch(x86_64) && !arch(i386)
-			return try! Sysctl.string(for: [CTL_HW, HW_MACHINE])
+			return try? Sysctl.string(for: [CTL_HW, HW_MACHINE]) ?? ""
 		#else
-			return try! Sysctl.string(for: [CTL_HW, HW_MODEL])
+			return try? Sysctl.string(for: [CTL_HW, HW_MODEL]) ?? ""
 		#endif
 	}
 
 	/// e.g. "8" or "2"
-	public static var activeCPUs: Int32 { return try! Sysctl.value(ofType: Int32.self, forKeys: [CTL_HW, HW_AVAILCPU]) }
+	public static var activeCPUs: Int32 { return try? Sysctl.value(ofType: Int32.self, forKeys: [CTL_HW, HW_AVAILCPU]) ?? 0 }
 
 	/// e.g. "15.3.0" or "15.0.0"
-	public static var osRelease: String { return try! Sysctl.string(for: [CTL_KERN, KERN_OSRELEASE]) }
+	public static var osRelease: String { return try? Sysctl.string(for: [CTL_KERN, KERN_OSRELEASE]) ?? "" }
 
 	/// e.g. "Darwin" or "Darwin"
-	public static var osType: String { return try! Sysctl.string(for: [CTL_KERN, KERN_OSTYPE]) }
+	public static var osType: String { return try? Sysctl.string(for: [CTL_KERN, KERN_OSTYPE]) ?? "" }
 
 	/// e.g. "15D21" or "13D20"
-	public static var osVersion: String { return try! Sysctl.string(for: [CTL_KERN, KERN_OSVERSION]) }
+	public static var osVersion: String { return try? Sysctl.string(for: [CTL_KERN, KERN_OSVERSION]) ?? "" }
 
 	/// e.g. "Darwin Kernel Version 15.3.0: Thu Dec 10 18:40:58 PST 2015; root:xnu-3248.30.4~1/RELEASE_X86_64" or
 	/// "Darwin Kernel Version 15.0.0: Wed Dec  9 22:19:38 PST 2015; root:xnu-3248.31.3~2/RELEASE_ARM64_S8000"
-	public static var version: String { return try! Sysctl.string(for: [CTL_KERN, KERN_VERSION]) }
+	public static var version: String { return try? Sysctl.string(for: [CTL_KERN, KERN_VERSION]) ?? "" }
 
 	#if os(macOS)
 		/// e.g. 199506 (not available on iOS)
-		public static var osRev: Int32 { return try! Sysctl.value(ofType: Int32.self, forKeys: [CTL_KERN, KERN_OSREV]) }
+		public static var osRev: Int32 { return try? Sysctl.value(ofType: Int32.self, forKeys: [CTL_KERN, KERN_OSREV]) ?? 0 }
 
 		/// e.g. 2659000000 (not available on iOS)
-		public static var cpuFreq: Int64 { return try! Sysctl.value(ofType: Int64.self, forName: "hw.cpufrequency") }
+		public static var cpuFreq: Int64 { return try? Sysctl.value(ofType: Int64.self, forName: "hw.cpufrequency") ?? 0 }
 
 		/// e.g. 25769803776 (not available on iOS)
-		public static var memSize: UInt64 { return try! Sysctl.value(ofType: UInt64.self, forKeys: [CTL_HW, HW_MEMSIZE]) }
+		public static var memSize: UInt64 { return try? Sysctl.value(ofType: UInt64.self, forKeys: [CTL_HW, HW_MEMSIZE]) ?? 0 }
 	#endif
 }

--- a/packages/device_info_plus/device_info_plus_macos/macos/Classes/CwlSysctl.swift
+++ b/packages/device_info_plus/device_info_plus_macos/macos/Classes/CwlSysctl.swift
@@ -117,15 +117,15 @@ public struct Sysctl {
 
 	/// e.g. "MyComputer.local" (from System Preferences -> Sharing -> Computer Name) or
 	/// "My-Name-iPhone" (from Settings -> General -> About -> Name)
-	public static var hostName: String { return try? Sysctl.string(for: [CTL_KERN, KERN_HOSTNAME]) ?? "" }
+	public static var hostName: String { return (try? Sysctl.string(for: [CTL_KERN, KERN_HOSTNAME])) ?? "" }
 
 	/// e.g. "x86_64" or "N71mAP"
 	/// NOTE: this is *corrected* on iOS devices to fetch hw.model
 	public static var machine: String {
 		#if os(iOS) && !arch(x86_64) && !arch(i386)
-			return try? Sysctl.string(for: [CTL_HW, HW_MODEL]) ?? ""
+			return (try? Sysctl.string(for: [CTL_HW, HW_MODEL])) ?? ""
 		#else
-			return try? Sysctl.string(for: [CTL_HW, HW_MACHINE]) ?? ""
+			return (try? Sysctl.string(for: [CTL_HW, HW_MACHINE])) ?? ""
 		#endif
 	}
 
@@ -133,36 +133,36 @@ public struct Sysctl {
 	/// NOTE: this is *corrected* on iOS devices to fetch hw.machine
 	public static var model: String {
 		#if os(iOS) && !arch(x86_64) && !arch(i386)
-			return try? Sysctl.string(for: [CTL_HW, HW_MACHINE]) ?? ""
+			return (try? Sysctl.string(for: [CTL_HW, HW_MACHINE])) ?? ""
 		#else
-			return try? Sysctl.string(for: [CTL_HW, HW_MODEL]) ?? ""
+			return (try? Sysctl.string(for: [CTL_HW, HW_MODEL])) ?? ""
 		#endif
 	}
 
 	/// e.g. "8" or "2"
-	public static var activeCPUs: Int32 { return try? Sysctl.value(ofType: Int32.self, forKeys: [CTL_HW, HW_AVAILCPU]) ?? 0 }
+	public static var activeCPUs: Int32 { return (try? Sysctl.value(ofType: Int32.self, forKeys: [CTL_HW, HW_AVAILCPU])) ?? 0 }
 
 	/// e.g. "15.3.0" or "15.0.0"
-	public static var osRelease: String { return try? Sysctl.string(for: [CTL_KERN, KERN_OSRELEASE]) ?? "" }
+	public static var osRelease: String { return (try? Sysctl.string(for: [CTL_KERN, KERN_OSRELEASE])) ?? "" }
 
 	/// e.g. "Darwin" or "Darwin"
-	public static var osType: String { return try? Sysctl.string(for: [CTL_KERN, KERN_OSTYPE]) ?? "" }
+	public static var osType: String { return (try? Sysctl.string(for: [CTL_KERN, KERN_OSTYPE])) ?? "" }
 
 	/// e.g. "15D21" or "13D20"
-	public static var osVersion: String { return try? Sysctl.string(for: [CTL_KERN, KERN_OSVERSION]) ?? "" }
+	public static var osVersion: String { return (try? Sysctl.string(for: [CTL_KERN, KERN_OSVERSION])) ?? "" }
 
 	/// e.g. "Darwin Kernel Version 15.3.0: Thu Dec 10 18:40:58 PST 2015; root:xnu-3248.30.4~1/RELEASE_X86_64" or
 	/// "Darwin Kernel Version 15.0.0: Wed Dec  9 22:19:38 PST 2015; root:xnu-3248.31.3~2/RELEASE_ARM64_S8000"
-	public static var version: String { return try? Sysctl.string(for: [CTL_KERN, KERN_VERSION]) ?? "" }
+	public static var version: String { return (try? Sysctl.string(for: [CTL_KERN, KERN_VERSION])) ?? "" }
 
 	#if os(macOS)
 		/// e.g. 199506 (not available on iOS)
-		public static var osRev: Int32 { return try? Sysctl.value(ofType: Int32.self, forKeys: [CTL_KERN, KERN_OSREV]) ?? 0 }
+		public static var osRev: Int32 { return (try? Sysctl.value(ofType: Int32.self, forKeys: [CTL_KERN, KERN_OSREV])) ?? 0 }
 
 		/// e.g. 2659000000 (not available on iOS)
-		public static var cpuFreq: Int64 { return try? Sysctl.value(ofType: Int64.self, forName: "hw.cpufrequency") ?? 0 }
+		public static var cpuFreq: Int64 { return (try? Sysctl.value(ofType: Int64.self, forName: "hw.cpufrequency")) ?? 0 }
 
 		/// e.g. 25769803776 (not available on iOS)
-		public static var memSize: UInt64 { return try? Sysctl.value(ofType: UInt64.self, forKeys: [CTL_HW, HW_MEMSIZE]) ?? 0 }
+		public static var memSize: UInt64 { return (try? Sysctl.value(ofType: UInt64.self, forKeys: [CTL_HW, HW_MEMSIZE])) ?? 0 }
 	#endif
 }

--- a/packages/device_info_plus/device_info_plus_macos/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: device_info_plus_macos
 description: Macos implementation of the device_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 2.2.2
+version: 2.2.3
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
## Description

This PR adds handling of macOS Sysctl.value() errors to avoid crashing when the sysctl call fails (e.g. no "hw.cpufrequency" present on Apple M1 macOS builds).

## Related Issues

Fixes #825.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
