### PR TITLE
[share_plus] fix subject when sharing raw url or files

### DIFF
--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.0.4
 
-- Fix subject not working when sharing raw url or files via email
+- iOS: Fix subject not working when sharing raw url or files via email
 
 ## 4.0.3
 

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.4
+
+- Fix subject not working when sharing raw url or files via email
+
 ## 4.0.3
 
 - Android: Revert increased minSdkVersion back to 16

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -250,7 +250,7 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
       [[UIActivityViewSuccessController alloc] initWithActivityItems:shareItems
                                                applicationActivities:nil];
   // Force subject when sharing a raw url or files
-  if(![subject isKindOfClass:[NSNull class]]) {
+  if (![subject isKindOfClass:[NSNull class]]) {
     [activityViewController setValue:subject forKey:@"subject"];
   }
   activityViewController.popoverPresentationController.sourceView = controller.view;
@@ -280,7 +280,7 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
   if (data == nil) {
     data = [[SharePlusData alloc] initWithSubject:subject text:shareText];
   }
-  
+
   [self share:@[ data ]
          withSubject:subject
       withController:controller
@@ -319,11 +319,7 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
     }
   }
 
-  [self share:items
-         withSubject:subject
-      withController:controller
-            atSource:origin
-            toResult:result];
+  [self share:items withSubject:subject withController:controller atSource:origin toResult:result];
 }
 
 @end

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -242,12 +242,17 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
 }
 
 + (void)share:(NSArray *)shareItems
+       withSubject:(NSString *)subject
     withController:(UIViewController *)controller
           atSource:(CGRect)origin
           toResult:(FlutterResult)result {
   UIActivityViewSuccessController *activityViewController =
       [[UIActivityViewSuccessController alloc] initWithActivityItems:shareItems
                                                applicationActivities:nil];
+  // Force subject when sharing a raw url or files
+  if(![subject isKindOfClass:[NSNull class]]) {
+    [activityViewController setValue:subject forKey:@"subject"];
+  }
   activityViewController.popoverPresentationController.sourceView = controller.view;
   if (!CGRectIsEmpty(origin)) {
     activityViewController.popoverPresentationController.sourceRect = origin;
@@ -275,7 +280,12 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
   if (data == nil) {
     data = [[SharePlusData alloc] initWithSubject:subject text:shareText];
   }
-  [self share:@[ data ] withController:controller atSource:origin toResult:result];
+  
+  [self share:@[ data ]
+         withSubject:subject
+      withController:controller
+            atSource:origin
+            toResult:result];
 }
 
 + (void)shareFiles:(NSArray *)paths
@@ -309,7 +319,11 @@ static UIViewController *TopViewControllerForViewController(UIViewController *vi
     }
   }
 
-  [self share:items withController:controller atSource:origin toResult:result];
+  [self share:items
+         withSubject:subject
+      withController:controller
+            atSource:origin
+            toResult:result];
 }
 
 @end

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 4.0.3
+version: 4.0.4
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

This PR fixes a bug where the subject is not set when sharing a raw URL e.g. "https://example.com" or files via email.

## Related Issues

Fixes #691

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
