### PR TITLE
[battery_plus_macos] Fix crash on macOS running on Apple Mac mini

### DIFF
--- a/packages/battery_plus/battery_plus_macos/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+- Fix crash on Apple Mac mini
+
 ## 1.1.0
 
 - Add batteryState getter

--- a/packages/battery_plus/battery_plus_macos/macos/Classes/BatteryPlusChargingHandler.swift
+++ b/packages/battery_plus/battery_plus_macos/macos/Classes/BatteryPlusChargingHandler.swift
@@ -64,6 +64,10 @@ class BatteryPlusChargingHandler: NSObject, FlutterStreamHandler {
         let powerSourceSnapshot = IOPSCopyPowerSourcesInfo().takeRetainedValue()
         let sources = IOPSCopyPowerSourcesList(powerSourceSnapshot).takeRetainedValue() as [CFTypeRef]
         
+        // Desktops do not have battery sources and are always charging.
+        if sources.isEmpty {
+            return "charging"
+        }
         let description = IOPSGetPowerSourceDescription(powerSourceSnapshot, sources[0]).takeUnretainedValue() as! [String: AnyObject]
         
         if let currentCapacity = description[kIOPSCurrentCapacityKey] as? Int {

--- a/packages/battery_plus/battery_plus_macos/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_macos/pubspec.yaml
@@ -2,7 +2,7 @@ name: battery_plus_macos
 description: An implementation for the macos platform of the Flutter `battery_plus` plugin.
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 1.1.0
+version: 1.1.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
## Description

Adds a case to handle macOS desktop such as Mac mini.

Withtout this check the application simply crashes when trying to access the first element of the empty list of battery sources.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
