### PR TITLE
[sensors_plus] Fixed crash when app closes if streams haven't been listened to

### DIFF
--- a/packages/sensors_plus/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.2
+
+- Fix: Android no longer crashes when app is closed if streams weren't listened to
+
 ## 1.3.1
 
 - Fix: unregister listeners on Android in `onDetachFromEngine` to not receive sensors events after app was killed

--- a/packages/sensors_plus/sensors_plus/android/src/main/kotlin/dev/fluttercommunity/plus/sensors/StreamHandlerImpl.kt
+++ b/packages/sensors_plus/sensors_plus/android/src/main/kotlin/dev/fluttercommunity/plus/sensors/StreamHandlerImpl.kt
@@ -11,7 +11,7 @@ internal class StreamHandlerImpl(
         private val sensorManager: SensorManager,
         sensorType: Int
 ) : EventChannel.StreamHandler {
-    private lateinit var sensorEventListener: SensorEventListener
+    private var sensorEventListener: SensorEventListener? = null
 
     private val sensor: Sensor by lazy {
         sensorManager.getDefaultSensor(sensorType)

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: sensors_plus
 description: >
   Flutter plugin for accessing accelerometer, gyroscope, and magnetometer
   sensors.
-version: 1.3.1
+version: 1.3.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

Fixed crash related to `lateinit` variable when closing app with back button on android

## Related Issues

https://github.com/fluttercommunity/plus_plugins/pull/753#issuecomment-1098022408

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
