### PR TITLE
[CI/CD] Replace deprecated pub command

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: "Pub Check"
         run: |
           melos exec -c 1 --no-private --ignore="*example*" -- \
-            pub publish --dry-run
+            flutter pub publish --dry-run
 
   pub_get_check:
     name: "Check pub dependencies"


### PR DESCRIPTION
## Description

Job for pub.dev requirements check used just `pub` command, which [is deprecated and removed](https://dart.dev/tools/pub/cmd). Because of this command our recent CI runs fail on mentioned step.

## Related Issues

-

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
