### PR TITLE
[connectivity_plus] Send events on main thread, macos too

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.3
+
+- macOS: Send events on main thread
+
 ## 2.3.2
 
 - iOS: Send events on main thread (#846)

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 2.3.2
+version: 2.3.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -30,7 +30,7 @@ dependencies:
     sdk: flutter
   connectivity_plus_platform_interface: ^1.2.0
   connectivity_plus_linux: ^1.3.0
-  connectivity_plus_macos: ^1.2.2
+  connectivity_plus_macos: ^1.2.3
   connectivity_plus_web: ^1.2.0
   connectivity_plus_windows: ^1.2.2
 

--- a/packages/connectivity_plus/connectivity_plus_macos/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.3
+
+- Send events on main thread
+
 ## 1.2.2
 
 - Fix connectivity stream can not be reused (after hot-restart) on MacOS 10.14+.

--- a/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/ConnectivityPlugin.swift
+++ b/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/ConnectivityPlugin.swift
@@ -70,7 +70,9 @@ public class ConnectivityPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
   }
 
   private func connectivityUpdateHandler(connectivityType: ConnectivityType) {
-    eventSink?(statusFrom(connectivityType: connectivityType))
+    DispatchQueue.main.async {
+      self.eventSink?(self.statusFrom(connectivityType: connectivityType))
+    }
   }
 
   public func onCancel(withArguments _: Any?) -> FlutterError? {

--- a/packages/connectivity_plus/connectivity_plus_macos/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_macos
 description: macOS implementation of the connectivity_plus plugin.
-version: 1.2.2
+version: 1.2.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

I stumbled on bug #845 on macOS and noticed that there was a PR to fix it (#846). However that PR only fixes the iOS plugin, so I replicated the change made to `connectivity_plus/ios/Classes/SwiftConnectivityPlusPlugin.swift` also to `connectivity_plus_macos/macos/Classes/ConnectivityPlugin.swift`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
