### PR TITLE
[connectivity_plus_web] Disable network information api

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.4
+
+- Disables internal use of `NetworkInformationAPI` which is still experimental
+
 ## 2.3.3
 
 - macOS: Send events on main thread

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 2.3.3
+version: 2.3.4
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -31,7 +31,7 @@ dependencies:
   connectivity_plus_platform_interface: ^1.2.0
   connectivity_plus_linux: ^1.3.0
   connectivity_plus_macos: ^1.2.3
-  connectivity_plus_web: ^1.2.0
+  connectivity_plus_web: ^1.2.2
   connectivity_plus_windows: ^1.2.2
 
 dev_dependencies:

--- a/packages/connectivity_plus/connectivity_plus_web/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+
+- Disables internal use of `NetworkInformationAPI` which is still experimental
+
 ## 1.2.1
 
 - Update flutter_lints to 2.0.1

--- a/packages/connectivity_plus/connectivity_plus_web/lib/connectivity_plus_web.dart
+++ b/packages/connectivity_plus/connectivity_plus_web/lib/connectivity_plus_web.dart
@@ -9,7 +9,16 @@ class ConnectivityPlusPlugin extends ConnectivityPlatform {
   /// Factory method that initializes the connectivity plugin platform with an instance
   /// of the plugin for the web.
   static void registerWith(Registrar registrar) {
-    if (NetworkInformationApiConnectivityPlugin.isSupported()) {
+    // Since the `NetworkInformationApi` is currently an experimental API and
+    // does not provide a reliable way to check a connectivity change
+    // from an onnline state to an offline state,
+    // its implementation is disabled for now.
+    // See also: https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API
+    //
+    // TODO: use `NetworkInformationApiConnectivityPlugin.isSupported()` when it becomes a stable DOM API.
+    const isSupported = false;
+
+    if (isSupported) {
       ConnectivityPlatform.instance = NetworkInformationApiConnectivityPlugin();
     } else {
       ConnectivityPlatform.instance = DartHtmlConnectivityPlugin();

--- a/packages/connectivity_plus/connectivity_plus_web/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_web
 description: An implementation for the web platform of the Flutter `connectivity_plus` plugin. This uses the NetworkInformation Web API, with a fallback to Navigator.onLine.
-version: 1.2.1
+version: 1.2.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

This PR disables the use of the `NetworkInformationAPI` implementation, as it is still experimental.

I don't see this change as a breaking change, as the extra information that is exposed by `NetworkInformation` from `dart:html` is not exposed to end users.

Context: https://github.com/fluttercommunity/plus_plugins/issues/639#issuecomment-1153099644

See also [NetworkInformation API docs](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation)

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/639
https://github.com/fluttercommunity/plus_plugins/issues/856
https://github.com/fluttercommunity/plus_plugins/issues/641
https://github.com/fluttercommunity/plus_plugins/issues/436

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
