### PR TITLE
[share_plus] fix 'Save Image' option not showing

### DIFF
--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.8
+
+- iOS: Fix 'Save Image' option not showing
+
 ## 4.0.7
 
 - Add documentation iPad

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -126,7 +126,8 @@ TopViewControllerForViewController(UIViewController *viewController) {
 
 - (id)activityViewControllerPlaceholderItem:
     (UIActivityViewController *)activityViewController {
-  return @"";
+  return [self activityViewController:activityViewController
+                  itemForActivityType:nil];
 }
 
 - (id)activityViewController:(UIActivityViewController *)activityViewController

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 4.0.7
+version: 4.0.8
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

The 'Save Image' option was not showing when invoking the ShareSheet with share_plus after `4.0.6` which switched to use the before abandoned `ShareDate` class again. The implementation of `activityViewControllerPlaceholderItem` did not provide enough context to the OS however to display the image specific options. Other apps that allow sharing were not effected as they relied upon `itemForActivityType`.

As always, I provide a working example [here](https://github.com/Coronon/share_plus_example).

## Related Issues

Fixes #897

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
