### PR TITLE
[connectivity_plus] Stop sending events when detached from flutter

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.5
+
+- Stop sending events once flutter engine detached on iOS/macOS (#865)
+
 ## 2.3.4
 
 - Disables internal use of `NetworkInformationAPI` which is still experimental

--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/SwiftConnectivityPlusPlugin.swift
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/SwiftConnectivityPlusPlugin.swift
@@ -36,6 +36,11 @@ public class SwiftConnectivityPlusPlugin: NSObject, FlutterPlugin, FlutterStream
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
+  public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+    eventSink = nil
+    connectivityProvider.stop()
+  }
+
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
     case "check":

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 2.3.4
+version: 2.3.5
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -30,7 +30,7 @@ dependencies:
     sdk: flutter
   connectivity_plus_platform_interface: ^1.2.0
   connectivity_plus_linux: ^1.3.0
-  connectivity_plus_macos: ^1.2.3
+  connectivity_plus_macos: ^1.2.4
   connectivity_plus_web: ^1.2.2
   connectivity_plus_windows: ^1.2.2
 

--- a/packages/connectivity_plus/connectivity_plus_macos/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.4
+
+- Stop sending events once flutter engine detached
+
 ## 1.2.3
 
 - Send events on main thread

--- a/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/ConnectivityPlugin.swift
+++ b/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/ConnectivityPlugin.swift
@@ -37,6 +37,11 @@ public class ConnectivityPlugin: NSObject, FlutterPlugin, FlutterStreamHandler {
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
+  public func detachFromEngine(for registrar: FlutterPluginRegistrar) {
+    eventSink = nil
+    connectivityProvider.stop()
+  }
+
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
     case "check":

--- a/packages/connectivity_plus/connectivity_plus_macos/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_macos
 description: macOS implementation of the connectivity_plus plugin.
-version: 1.2.3
+version: 1.2.4
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

This PR ensures that once the flutter engine has been detached on iOS and macOS, the engine is no longer called with events. It appears to already have been done on android and I'm not familiar enough with the flutter <-> windows integration to tackle that (although it might need to be done eventually).

I'm really not sure how to write tests for this so I left that unchecked.

## Related Issues

#865 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
