### PR TITLE
[share_plus] fix image file names not preserved

### DIFF
--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.9
+
+- iOS: Fix image file names not preserved
+
 ## 4.0.8
 
 - iOS: Fix 'Save Image' option not showing

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -126,8 +126,9 @@ TopViewControllerForViewController(UIViewController *viewController) {
 
 - (id)activityViewControllerPlaceholderItem:
     (UIActivityViewController *)activityViewController {
-  return [self activityViewController:activityViewController
-                  itemForActivityType:nil];
+  return [self
+      activityViewController:activityViewController
+         itemForActivityType:@"dev.fluttercommunity.share_plus.placeholder"];
 }
 
 - (id)activityViewController:(UIActivityViewController *)activityViewController
@@ -136,13 +137,18 @@ TopViewControllerForViewController(UIViewController *viewController) {
     return _text;
   }
 
-  if ([_mimeType hasPrefix:@"image/"]) {
+  // If the shared file is an image return an UIImage for the placeholder
+  // to show a preview.
+  if ([activityType
+          isEqualToString:@"dev.fluttercommunity.share_plus.placeholder"] &&
+      [_mimeType hasPrefix:@"image/"]) {
     UIImage *image = [UIImage imageWithContentsOfFile:_path];
     return image;
-  } else {
-    NSURL *url = [NSURL fileURLWithPath:_path];
-    return url;
   }
+
+  // Return an NSURL for the real share to conserve the file name
+  NSURL *url = [NSURL fileURLWithPath:_path];
+  return url;
 }
 
 - (NSString *)activityViewController:
@@ -362,7 +368,6 @@ TopViewControllerForViewController(UIViewController *viewController) {
 
   for (int i = 0; i < [paths count]; i++) {
     NSString *path = paths[i];
-    NSString *pathExtension = [path pathExtension];
     NSString *mimeType = mimeTypes[i];
     [items addObject:[[SharePlusData alloc] initWithFile:path
                                                 mimeType:mimeType

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 4.0.8
+version: 4.0.9
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

A previous fix shared images in `itemForActivityType` as `UIImage` instances, which allowed proper previews to be shown, while it also fixed file names by sharing other mime types as `NSURL`. This broke the file name for images, which were converted to PNG by `UIImage imageWithContentsOfFile:`.

With this fix, previews are shown and the file name/type is properly preserved.

I provide a [test project](https://github.com/Coronon/share_plus_example) as always.

## Related Issues

Fixes #914

Also fixes #900 on a sidenote

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
