### PR TITLE
[device_info_plus] Remove AndroidId, update Windows dependencies

### DIFF
--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.0.0
 
-- Remove `AndroidId` getter to avoid Google Play policies violations
+- **Breaking change** Remove `AndroidId` getter to avoid Google Play policies violations
 - Update flutter_lints to 2.0.1
 - Remove explicit `test` dependency to use `flutter_test` from Flutter SDK
 

--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,6 +1,12 @@
+## 4.0.0
+
+- Remove `AndroidId` getter to avoid Google Play policies violations
+- Update flutter_lints to 2.0.1
+- Remove explicit `test` dependency to use `flutter_test` from Flutter SDK
+
 ## 3.2.4
 
-- Update the description of getAndroidId method  
+- Update the description of getAndroidId method
 
 ## 3.2.3
 

--- a/packages/device_info_plus/device_info_plus/android/src/main/java/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.java
+++ b/packages/device_info_plus/device_info_plus/android/src/main/java/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.java
@@ -4,12 +4,10 @@
 
 package dev.fluttercommunity.plus.device_info;
 
-import android.annotation.SuppressLint;
 import android.content.ContentResolver;
 import android.content.pm.FeatureInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.provider.Settings;
 import androidx.annotation.NonNull;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -23,7 +21,6 @@ import java.util.Map;
  */
 class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
-  private final ContentResolver contentResolver;
   private final PackageManager packageManager;
 
   /** Substitute for missing values. */
@@ -31,7 +28,6 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
   /** Constructs DeviceInfo. {@code contentResolver} and {@code packageManager} must not be null. */
   MethodCallHandlerImpl(ContentResolver contentResolver, PackageManager packageManager) {
-    this.contentResolver = contentResolver;
     this.packageManager = packageManager;
   }
 
@@ -63,7 +59,6 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
       build.put("tags", Build.TAGS);
       build.put("type", Build.TYPE);
       build.put("isPhysicalDevice", !isEmulator());
-      build.put("androidId", getAndroidId());
 
       build.put("systemFeatures", Arrays.asList(getSystemFeatures()));
 
@@ -95,20 +90,6 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
       features[i] = featureInfos[i].name;
     }
     return features;
-  }
-
-  /**
-   * On devices with Android >= 8.0 (API level 26) returns an ID that is unique to each combination
-   * of app-signing key, user, and device. The value may change if a factory reset is performed on
-   * the device or if an APK signing key changes. On devices with Android < 8.0 (API level 26)
-   * returns an ID that is randomly generated when the user first sets up the device and should
-   * remain constant for the lifetime of the user's device.
-   *
-   * @return The android ID
-   */
-  @SuppressLint("HardwareIds")
-  private String getAndroidId() {
-    return Settings.Secure.getString(contentResolver, Settings.Secure.ANDROID_ID);
   }
 
   /**

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 3.2.4
+version: 4.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -32,10 +32,9 @@ dependencies:
   device_info_plus_windows: ^2.1.1
 
 dev_dependencies:
-  test: ^1.16.4
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.0
+
+- Update ffi to 2.0.0
+- Update win32 to 2.7.0
+- **Breaking change** Min Dart version is 2.17 now due to dependencies requirements
+
 ## 2.1.1
 
 - Use automatic plugin registration

--- a/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
@@ -1,19 +1,19 @@
 name: device_info_plus_windows
 description: Windows implementation of the device_info_plus plugin
-version: 2.1.1
+version: 3.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
   device_info_plus_platform_interface: ^2.1.0
-  ffi: ^1.0.0
+  ffi: ^2.0.0
   flutter:
     sdk: flutter
-  win32: ^2.0.0
+  win32: ^2.7.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

According to report in #824 Google Play's new policies discourage usage of unique ids, by requiring to explicitly declare usage of such ids in Data Safety section. I recently had similar experience with `flutter_segment` package, which used segment_analytics Android library, which was accessing AndroidId as well: https://github.com/la-haus/flutter-segment/issues/30
I believe we should exclude AndroidId from set of data returned by `device_info_plus`, so people, who use the package don't have to declare collection of unique IDs in Data Safety section on their Google Play Store listing. Bumped the major version, since removal is a breaking change from my point of view. Those, who would still need to use AndroidId for some reason could use older version of `device_info_plus`.

Additionally, needed to update some dependencies for Windows plugin as building `example` app was failing for me. Due to changes in requirements on `ffi` and `win32` had to bump min Dart version to `2.17` in Windows plugin.

## Related Issues

Closes #824

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
