### PR TITLE
[connectivity_plus_web] fix Bad state: Stream has already been listened to

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.6
 
-- fix Bad state: Stream has already been listened to (#943)
+- Web: Fix Bad state: Stream has already been listened to (#943)
 
 ## 2.3.5
 

--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.6
+
+- fix Bad state: Stream has already been listened to (#943)
+
 ## 2.3.5
 
 - Stop sending events once flutter engine detached on iOS/macOS (#865)

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 2.3.5
+version: 2.3.6
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -31,7 +31,7 @@ dependencies:
   connectivity_plus_platform_interface: ^1.2.0
   connectivity_plus_linux: ^1.3.0
   connectivity_plus_macos: ^1.2.4
-  connectivity_plus_web: ^1.2.2
+  connectivity_plus_web: ^1.2.3
   connectivity_plus_windows: ^1.2.2
 
 dev_dependencies:

--- a/packages/connectivity_plus/connectivity_plus_web/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.3
+
+- fix Bad state: Stream has already been listened to (#943)
+
 ## 1.2.2
 
 - Disables internal use of `NetworkInformationAPI` which is still experimental

--- a/packages/connectivity_plus/connectivity_plus_web/lib/src/dart_html_connectivity_plugin.dart
+++ b/packages/connectivity_plus/connectivity_plus_web/lib/src/dart_html_connectivity_plugin.dart
@@ -20,7 +20,7 @@ class DartHtmlConnectivityPlugin extends ConnectivityPlusPlugin {
   @override
   Stream<ConnectivityResult> get onConnectivityChanged {
     if (_connectivityResult == null) {
-      _connectivityResult = StreamController<ConnectivityResult>();
+      _connectivityResult = StreamController<ConnectivityResult>.broadcast();
       // Fallback to dart:html window.onOnline / window.onOffline
       html.window.onOnline.listen((event) {
         _connectivityResult!.add(ConnectivityResult.wifi);

--- a/packages/connectivity_plus/connectivity_plus_web/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_web
 description: An implementation for the web platform of the Flutter `connectivity_plus` plugin. This uses the NetworkInformation Web API, with a fallback to Navigator.onLine.
-version: 1.2.2
+version: 1.2.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
…
## Description

This was also changed on the original connectivity package but I think it happened right after this package was copied. See https://github.com/flutter/plugins/blob/connectivity-v3.0.6/packages/connectivity/connectivity_for_web/lib/src/dart_html_connectivity_plugin.dart


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
