### PR TITLE
[CI/CD] Exclude feature requests from stale state, adjust time periods

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,10 +13,11 @@ jobs:
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 15 days'
-          days-before-stale: 60
+          days-before-issue-stale: 90
+          days-before-pr-stale: 180
           days-before-close: 15
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: keep-open
+          exempt-issue-labels: enhancement, wontfix
           exempt-pr-labels: keep-open
           operations-per-run: 1000

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,6 @@ jobs:
           days-before-close: 15
           stale-issue-label: stale
           stale-pr-label: stale
-          exempt-issue-labels: enhancement, wontfix
+          exempt-issue-labels: enhancement
           exempt-pr-labels: keep-open
           operations-per-run: 1000


### PR DESCRIPTION
## Description

We don't want feature requests to be marked as stale and closed automatically by a recently added bot. In this PR I added an exclusion, so `enhancement` labeled issues won't be touched by the bot.

Additionally adjusted the time period after which bot marks issues and PRs as stale to better match the activity in the repository by maintainers.

## Related Issues

No related issue

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
