### PR TITLE
[share_plus] document sharePositionOrigin for Macs

### DIFF
--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -23,8 +23,8 @@ class Share {
   /// user chooses to send an email.
   ///
   /// The optional [sharePositionOrigin] parameter can be used to specify a global
-  /// origin rect for the share sheet to popover from on iPads. It has no effect
-  /// on non-iPads.
+  /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
+  /// on other devices.
   ///
   /// May throw [PlatformException] or [FormatException]
   /// from [MethodChannel].
@@ -59,8 +59,8 @@ class Share {
   /// every other MIME type is considered a normal file.
   ///
   /// The optional `sharePositionOrigin` parameter can be used to specify a global
-  /// origin rect for the share sheet to popover from on iPads. It has no effect
-  /// on non-iPads.
+  /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
+  /// on other devices.
   ///
   /// May throw [PlatformException] or [FormatException]
   /// from [MethodChannel].


### PR DESCRIPTION
Amend documentation to avoid confusion as in #864

## Description

It was not clear that this parameter could be used on Macs.

## Related Issues
#864

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
