### PR TITLE
[package_info_plus] Update dependencies

### DIFF
--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.0.0
-- Windows: Update ffi dependency
+- **Breaking change**. Bump minimum dart version to 2.17.0.
+- Windows: Updated package_info_plus_windows to version 2.0.0.
+- MacOS: Updated package_info_plus_macos to 1.3.0.
+- Updated test to 1.21.1.
+- Updated flutter_lints to 2.0.1.
 
 ## 1.4.2
 

--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 2.0.0
-- **Breaking change**. Bump minimum dart version to 2.17.0.
+## 1.4.3
+
 - Windows: Updated package_info_plus_windows to version 2.0.0.
 - MacOS: Updated package_info_plus_macos to 1.3.0.
 - Updated test to 1.21.1.

--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.0
+- Windows: Update ffi dependency
+
 ## 1.4.2
 
 - Web: Resolve package_name

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_example
 description: Demonstrates how to use the package_info_plus plugin.
-version: 1.2.4
+version: 1.2.3+4
 publish_to: 'none'
 
 environment:

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_example
 description: Demonstrates how to use the package_info_plus plugin.
-version: 1.2.3+4
+version: 1.2.4
 publish_to: 'none'
 
 environment:
@@ -29,7 +29,7 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 flutter:
   uses-material-design: true

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 2.0.0
+version: 1.4.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -37,5 +37,5 @@ dev_dependencies:
   flutter_lints: ^2.0.1
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 1.4.3
+version: 2.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 1.4.2
+version: 1.4.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -26,16 +26,16 @@ dependencies:
     sdk: flutter
   package_info_plus_platform_interface: ^1.0.2
   package_info_plus_linux: ^1.0.5
-  package_info_plus_macos: ^1.2.0
-  package_info_plus_windows: ^1.0.5
+  package_info_plus_macos: ^1.3.0
+  package_info_plus_windows: ^2.0.0
   package_info_plus_web: ^1.0.5
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: ^1.16.4
-  flutter_lints: ^1.0.4
+  test: ^1.21.1
+  flutter_lints: ^2.0.1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5"

--- a/packages/package_info_plus/package_info_plus_windows/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus_windows/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.0
+- **Breaking change**. Bump minimum dart version to 2.17.0.
+- Updated ffi to 2.0.1.
+- Updated win32 to 2.7.0.
+- Updated flutter_lints to 2.0.1.
+
 ## 1.0.5
 
 - Fix MissingPluginException

--- a/packages/package_info_plus/package_info_plus_windows/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_windows/pubspec.yaml
@@ -1,24 +1,24 @@
 name: package_info_plus_windows
 description: Windows implementation of the package_info_plus plugin
-version: 1.0.5
+version: 2.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.17.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
   package_info_plus_platform_interface: ^1.0.2
-  ffi: ^1.0.0
+  ffi: ^2.0.1
   flutter:
     sdk: flutter
-  win32: ^2.0.0
+  win32: ^2.7.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

`package_info_plus`:
Bump minimum dart version to 2.17.0.
Updated package_info_plus_windows to version 2.0.0.
Updated package_info_plus_macos to 1.3.0.
Updated test to 1.21.1.
Updated flutter_lints to 2.0.1.

`package_info_plus_windows`:
Bump minimum dart version to 2.17.0.
Update ffi dependency to 2.0.1 (#941).
Updated win32 to 2.7.0.
Updated flutter_lints to 2.0.1.

## Related Issues

#941 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
