### PR TITLE
Add issue tracker links

### DIFF
--- a/packages/android_alarm_manager_plus/CHANGELOG.md
+++ b/packages/android_alarm_manager_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.6+1
+
+- Add issue_tracker link.
+
 ## 2.0.6
 
 - Fix AndroidAlarmManager.periodic() not working.

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -1,9 +1,10 @@
 name: android_alarm_manager_plus
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 2.0.6
+version: 2.0.6+1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/android_alarm_manager_plus
 
 dependencies:
   flutter:

--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1+1
+
+- Add issue_tracker link.
+
 ## 3.1.1
 
 - Fix embedding issue in example

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,8 +1,9 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 3.1.1
+version: 3.1.1+1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/android_intent_plus
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/battery_plus/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.4+1
+
+- Add issue_tracker link.
+
 ## 2.1.4
 
 - Update flutter_lints to 2.0.1

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -3,6 +3,7 @@ description: Flutter plugin for accessing information about the battery state(fu
 version: 2.1.4
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/battery_plus
 
 flutter:
   plugin:

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 2.1.4
+version: 2.1.4+1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/battery_plus

--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.6+1
+
+- Add issue_tracker link.
+
 ## 2.3.6
 
 - Web: Fix Bad state: Stream has already been listened to (#943)

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,8 +1,9 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 2.3.6
+version: 2.3.6+1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/connectivity_plus
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3+1
+
+- Add issue_tracker link.
+
 ## 2.1.3
 
 - Update nm dependency to be compatible with fresh versions of other Plus plugins

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,8 +1,9 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 2.1.3
+version: 2.1.3+1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/network_info_plus
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.3+1
+
+- Add issue_tracker link.
+
 ## 1.4.3
 
 - Windows: Updated package_info_plus_windows to version 2.0.0.

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,8 +1,9 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 1.4.3
+version: 1.4.3+1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/package_info_plus
 
 flutter:
   plugin:

--- a/packages/sensors_plus/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.4+1
+
+- Add issue_tracker link.
+
 ## 1.3.4
 
 - Additonal fixes for crash issue: "Error: Sending a message before the FlutterEngine has been run."

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -1,8 +1,9 @@
 name: sensors_plus
 description: Flutter plugin for accessing accelerometer, gyroscope, and magnetometer sensors.
-version: 1.3.4
+version: 1.3.4+1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/sensors_plus
 
 flutter:
   plugin:

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.10+1
+
+- Add issue_tracker link.
+
 ## 4.0.10
 
 - iOS: Fix 'share text' not showing when share files

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,8 +1,9 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 4.0.10
+version: 4.0.10+1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Pub.dev now has the feature for adding custom links to GitHub issues (before, it was generated automatically).
This PR sets the link to plus_plugins issues filtered by the package's tag.
(the update for `device_info_plus` is included in https://github.com/fluttercommunity/plus_plugins/pull/1007)

## Related Issues

none

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
