### PR TITLE
Redo changes in device_info_plus_platform_interface 2.6.0

### DIFF
--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 4.1.1
-
-- Revert changes in 4.1.0
-
 ## 4.1.0
 
 - Remove `androidId` (that already got removed from the method channel in 4.0.0, thus always returned null)

--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.1.2
+
+- Redo changes in 4.1.0
+- device_info_plus_platform_interface to 3.0.0
+
+## 4.1.1
+
+- Revert changes in 4.1.0
+
 ## 4.1.0
 
 - Remove `androidId` (that already got removed from the method channel in 4.0.0, thus always returned null)

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -5,9 +5,10 @@
 // @dart=2.9
 
 import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:device_info_plus/device_info_plus.dart';
 import 'package:integration_test/integration_test.dart';
 
 void main() {
@@ -97,7 +98,6 @@ void main() {
     expect(androidInfo.tags, isNotNull);
     expect(androidInfo.type, isNotNull);
     expect(androidInfo.isPhysicalDevice, isNotNull);
-    expect(androidInfo.androidId, isNull);
     expect(androidInfo.systemFeatures, isNotNull);
   }, skip: !Platform.isAndroid);
 }

--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -99,7 +99,6 @@ class _MyAppState extends State<MyApp> {
       'tags': build.tags,
       'type': build.type,
       'isPhysicalDevice': build.isPhysicalDevice,
-      'androidId': build.androidId,
       'systemFeatures': build.systemFeatures,
     };
   }

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 4.1.0
+version: 4.1.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus
@@ -26,7 +26,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus_platform_interface: ^2.6.0
+  device_info_plus_platform_interface: ^3.0.0
   device_info_plus_macos: ^2.2.3
   device_info_plus_linux: ^2.1.1
   device_info_plus_web: ^2.1.0

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,9 +1,10 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 4.1.1
+version: 4.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus
 
 flutter:
   plugin:
@@ -25,7 +26,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus_platform_interface: ^2.6.1
+  device_info_plus_platform_interface: ^2.6.0
   device_info_plus_macos: ^2.2.3
   device_info_plus_linux: ^2.1.1
   device_info_plus_web: ^2.1.0

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -27,10 +27,10 @@ dependencies:
   flutter:
     sdk: flutter
   device_info_plus_platform_interface: ^3.0.0
-  device_info_plus_macos: ^2.2.3
-  device_info_plus_linux: ^2.1.1
-  device_info_plus_web: ^2.1.0
-  device_info_plus_windows: ^3.0.3
+  device_info_plus_macos: ^3.0.0
+  device_info_plus_linux: ^3.0.0
+  device_info_plus_web: ^3.0.0
+  device_info_plus_windows: ^4.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0
+
+- platform interface to 3.0.0
+
 ## 2.1.1
 
 - Use automatic plugin registration

--- a/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_linux
 description: Linux implementation of the device_info_plus plugin
-version: 2.1.1
+version: 3.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^2.1.0
+  device_info_plus_platform_interface: ^3.0.0
   file: ^6.0.0
   flutter:
     sdk: flutter

--- a/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0
+
+- platform interface to 3.0.0
+
 ## 2.2.3
 
 - Fix crash on macOS running on Apple M1

--- a/packages/device_info_plus/device_info_plus_macos/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_macos/pubspec.yaml
@@ -2,14 +2,14 @@ name: device_info_plus_macos
 description: Macos implementation of the device_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 2.2.3
+version: 3.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^2.2.0
+  device_info_plus_platform_interface: ^3.0.0
   flutter:
     sdk: flutter
 

--- a/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 2.6.1
-
-- Revert 2.6.0
-
 ## 2.6.0
 
 - Remove `androidId` (that was removed in the MethodChannel, and always returned null)

--- a/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 3.0.0
+
+- Redo 2.6.0 into 3.0.0
+- Remove `androidId` (that was removed in the MethodChannel, and always returned null)
+
+## 2.6.1
+
+- Revert 2.6.0
+
 ## 2.6.0
 
 - Remove `androidId` (that was removed in the MethodChannel, and always returned null)

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
@@ -29,7 +29,6 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
     this.tags,
     this.type,
     this.isPhysicalDevice,
-    this.androidId,
     required List<String?> systemFeatures,
   })  : supported32BitAbis = List<String?>.unmodifiable(supported32BitAbis),
         supported64BitAbis = List<String?>.unmodifiable(supported64BitAbis),
@@ -93,9 +92,6 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
   /// `false` if the application is running in an emulator, `true` otherwise.
   final bool? isPhysicalDevice;
 
-  /// The Android hardware device ID that is unique between the device + user and app signing.
-  final String? androidId;
-
   /// Describes what features are available on the current device.
   ///
   /// This can be used to check if the device has, for example, a front-facing
@@ -127,7 +123,6 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
       'product': product,
       'display': display,
       'hardware': hardware,
-      'androidId': androidId,
       'bootloader': bootloader,
       'version': version.toMap(),
       'fingerprint': fingerprint,
@@ -163,7 +158,6 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
       tags: map['tags'],
       type: map['type'],
       isPhysicalDevice: map['isPhysicalDevice'],
-      androidId: map['androidId'],
       systemFeatures: _fromList(map['systemFeatures'] ?? []),
     );
   }

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_platform_interface
 description: A common platform interface for the device_info_plus plugin.
-version: 2.6.0
+version: 3.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_platform_interface
 description: A common platform interface for the device_info_plus plugin.
-version: 2.6.1
+version: 2.6.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
@@ -29,7 +29,6 @@ void main() {
         'product': 'product',
         'display': 'display',
         'hardware': 'hardware',
-        'androidId': 'androidId',
         'isPhysicalDevice': true,
         'bootloader': 'bootloader',
         'fingerprint': 'fingerprint',
@@ -56,7 +55,6 @@ void main() {
         expect(androidDeviceInfo.product, 'product');
         expect(androidDeviceInfo.display, 'display');
         expect(androidDeviceInfo.hardware, 'hardware');
-        expect(androidDeviceInfo.androidId, 'androidId');
         expect(androidDeviceInfo.bootloader, 'bootloader');
         expect(androidDeviceInfo.isPhysicalDevice, isTrue);
         expect(androidDeviceInfo.fingerprint, 'fingerprint');

--- a/packages/device_info_plus/device_info_plus_web/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.0
+
+- platform interface to 3.0.0
+
 ## 2.1.0
 
 - add toMap to models

--- a/packages/device_info_plus/device_info_plus_web/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_web
 description: An implementation for the web platform of the Flutter `device_info_plus` plugin.
-version: 2.1.0
+version: 3.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -12,7 +12,7 @@ flutter:
         fileName: device_info_plus_web.dart
 
 dependencies:
-  device_info_plus_platform_interface: ^2.1.0
+  device_info_plus_platform_interface: ^3.0.0
   flutter_web_plugins:
     sdk: flutter
   flutter:

--- a/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0
+
+- platform interface to 3.0.0
+
 ## 3.0.3
 
 - Revert changes in 3.0.2

--- a/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_windows
 description: Windows implementation of the device_info_plus plugin
-version: 3.0.3
+version: 4.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^2.5.0
+  device_info_plus_platform_interface: ^3.0.0
   ffi: ^2.0.1
   flutter:
     sdk: flutter


### PR DESCRIPTION
## Description

- Revert "Revert 4.1.0 device_info_plus changes (#1020)"
- Version bumps

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/939#issuecomment-1213044548
