### PR TITLE
Update to make android and IOS return the same expected wifi name.

### DIFF
--- a/packages/network_info_plus/network_info_plus/android/src/main/java/dev/fluttercommunity/plus/network_info/NetworkInfo.java
+++ b/packages/network_info_plus/network_info_plus/android/src/main/java/dev/fluttercommunity/plus/network_info/NetworkInfo.java
@@ -27,6 +27,11 @@ class NetworkInfo {
     WifiInfo wifiInfo = getWifiInfo();
     String ssid = null;
     if (wifiInfo != null) ssid = wifiInfo.getSSID();
+    if(ssid!=null)
+    {
+      ssid=ssid?.replaceFirst('"', '');
+      ssid=ssid?.replaceFirst('"', '',ssid.length-1);
+    }
     return ssid;
   }
 


### PR DESCRIPTION
without these changes users has to check for platform before calling getWifiName which is not the best situation.

