### PR TITLE
(share_plus) fix text share on iOS

### DIFF
--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 4.1.0
+
+- iOS: Fix text sharing.
+  - Previously, the text was being encoded as a URL, this caused the share sheet to appear empty.
+  - Now the shared text is not encoded as a URL anymore but rather shared as plain text.
+  - Sharing text + subject + attachments should work on apps that support that (e.g. Mail app).
+  - Example: Sharing Text + Image on Telegram is possible and both are shared.
+  - Some apps still have limitations with sharing. For example, Gmail app does not support the subject field.
+  - Related issue: #730
+
 ## 4.0.10+1
 
 - Add issue_tracker link.

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -348,7 +348,8 @@ TopViewControllerForViewController(UIViewController *viewController) {
     withController:(UIViewController *)controller
           atSource:(CGRect)origin
           toResult:(FlutterResult)result {
-  NSObject *data = [[SharePlusData alloc] initWithSubject:subject text:shareText];
+  NSObject *data = [[SharePlusData alloc] initWithSubject:subject
+                                                     text:shareText];
   [self share:@[ data ]
          withSubject:subject
       withController:controller

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -348,10 +348,7 @@ TopViewControllerForViewController(UIViewController *viewController) {
     withController:(UIViewController *)controller
           atSource:(CGRect)origin
           toResult:(FlutterResult)result {
-  NSObject *data = [[NSURL alloc] initWithString:shareText];
-  if (data == nil) {
-    data = [[SharePlusData alloc] initWithSubject:subject text:shareText];
-  }
+  NSObject *data = [[SharePlusData alloc] initWithSubject:subject text:shareText];
   [self share:@[ data ]
          withSubject:subject
       withController:controller
@@ -376,10 +373,7 @@ TopViewControllerForViewController(UIViewController *viewController) {
                                                  subject:subject]];
   }
   if (text != nil) {
-    NSObject *data = [[NSURL alloc] initWithString:text];
-    if (data == nil) {
-      data = [[SharePlusData alloc] initWithSubject:subject text:text];
-    }
+    NSObject *data = [[SharePlusData alloc] initWithSubject:subject text:text];
     [items addObject:data];
   }
 

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 4.0.10+1
+version: 4.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus


### PR DESCRIPTION
## Description

Following the issue reported in #730 and performing some tests, I've found that the share functionality on iOS doesn't seem to work well.

Trying to share text caused the app to show an empty share sheet (no apps listed).

Seems that the issue is caused by attempting to encode the incoming text string as a NSURL object.

I don't understand why we need to do that, but this causes issues.

This change removes that line of code, and sharing works again.

The following has been tested and worked:

- Sharing text with Telegram
- Sharing text + Image with Telegram (both appear)
- Sharing text + subject on Mail (text and subject are set correctly)
- Sharing text + subject + image on Mail (all three appear correctly - see screenshot in comments)

Gmail seems to have issues supporting the "subject" field, reported here: https://github.com/fluttercommunity/plus_plugins/issues/1056

## Related Issues

#730 


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

