### PR TITLE
Remove Codecov coverage reports from PRs

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -110,7 +110,7 @@ jobs:
             find . -maxdepth 12 -name "*.java" -print0 \| xargs -0 java -jar $HOME/google-java-format.jar --replace
           ./.github/workflows/scripts/validate-formatting.sh
 
-  test_and_coverage:
+  test:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     steps:
@@ -132,3 +132,4 @@ jobs:
 
       - name: "Flutter Test - Web"
         run: melos run test:web --no-select
+

--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -132,13 +132,3 @@ jobs:
 
       - name: "Flutter Test - Web"
         run: melos run test:web --no-select
-
-      - name: "Collect Coverage"
-        run: melos run coverage
-
-      - name: Upload Coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          files: packages/*/coverage/lcov.info
-

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@
   <a href="https://github.com/fluttercommunity/plus_plugins/actions?query=workflow%3Aall_plugins">
     <img src="https://github.com/fluttercommunity/plus_plugins/workflows/all_plugins/badge.svg" alt="all_plugins GitHub Workflow Status"/>
   </a>
-  <a href="https://codecov.io/gh/flutter_community/plus_plugins/">
-    <img src="https://codecov.io/gh/fluttercommunity/plus_plugins/graph/badge.svg" alt="all_plugins Coverage"/>
-  </a>
   <a href="https://twitter.com/FlutterComm">
     <img src="https://img.shields.io/twitter/follow/FlutterComm.svg?colorA=1da1f2&colorB=&label=Follow%20on%20Twitter" alt="Follow on Twitter">
   </a>


### PR DESCRIPTION
## Description

Reporting code coverage sounds like a good idea, but it has some drawbacks:

1. Codecov only considers the coverage of Unit Tests.
2. Our code is mainly located in the native side of the plugin.
3. We rely on Integration Tests, which aren't considered for code coverage.
4. The report gives misleading results, marking a job as failed because the coverage changed.

Because of these, I'd like to remove the Codecov coverage reports.
