### PR TITLE
Update manifest with explicit minimum sdk level

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/AndroidManifest.xml
+++ b/packages/share_plus/share_plus/android/src/main/AndroidManifest.xml
@@ -11,4 +11,5 @@
           android:resource="@xml/flutter_share_file_paths"/>
       </provider>
     </application>
+  <uses-sdk android:minSdkVersion="22" />
 </manifest>


### PR DESCRIPTION
Need minimum of 22 to support Intent#createChooser.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
