### PR TITLE
WIP share_plus refactor

### DIFF
--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -88,17 +88,6 @@ class DemoAppState extends State<DemoApp> {
                       );
                     },
                   ),
-                  const Padding(padding: EdgeInsets.only(top: 12.0)),
-                  Builder(
-                    builder: (BuildContext context) {
-                      return ElevatedButton(
-                        onPressed: text.isEmpty && imagePaths.isEmpty
-                            ? null
-                            : () => _onShareWithResult(context),
-                        child: const Text('Share With Result'),
-                      );
-                    },
-                  ),
                 ],
               ),
             ),
@@ -113,40 +102,13 @@ class DemoAppState extends State<DemoApp> {
   }
 
   void _onShare(BuildContext context) async {
-    // A builder is used to retrieve the context immediately
-    // surrounding the ElevatedButton.
-    //
-    // The context's `findRenderObject` returns the first
-    // RenderObject in its descendent tree when it's not
-    // a RenderObjectWidget. The ElevatedButton's RenderObject
-    // has its position and size after it's built.
-    final box = context.findRenderObject() as RenderBox?;
-
-    if (imagePaths.isNotEmpty) {
-      await Share.shareFiles(imagePaths,
-          text: text,
-          subject: subject,
-          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
-    } else {
-      await Share.share(text,
-          subject: subject,
-          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
-    }
-  }
-
-  void _onShareWithResult(BuildContext context) async {
     final box = context.findRenderObject() as RenderBox?;
     ShareResult result;
-    if (imagePaths.isNotEmpty) {
-      result = await Share.shareFilesWithResult(imagePaths,
-          text: text,
-          subject: subject,
-          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
-    } else {
-      result = await Share.shareWithResult(text,
-          subject: subject,
-          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
-    }
+    result = await Share.shareV2(
+        text: text,
+        subject: subject,
+        paths: imagePaths,
+        sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
     ScaffoldMessenger.of(context).showSnackBar(SnackBar(
       content: Text("Share result: ${result.status}"),
     ));

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -15,6 +15,72 @@ class Share {
 
   /// Summons the platform's share sheet to share text.
   ///
+  /// Wraps the platform's native share dialog. Can share a text, a URL,
+  /// and/or files.
+  ///
+  /// This method replaces [share] and [shareFiles], which may be removed
+  /// in a future release.
+  ///
+  /// It uses the `ACTION_SEND` Intent on Android and `UIActivityViewController`
+  /// on iOS.
+  ///
+  /// The optional [subject] parameter can be used to populate a subject if the
+  /// user chooses to send an email.
+  ///
+  /// The optional `mimeTypes` parameter can be used to specify MIME types for
+  /// the provided files.
+  /// Android supports all natively available MIME types (wildcards like image/*
+  /// are also supported) and it's considered best practice to avoid mixing
+  /// unrelated file types (eg. image/jpg & application/pdf). If MIME types are
+  /// mixed the plugin attempts to find the lowest common denominator. Even
+  /// if MIME types are supplied the receiving app decides if those are used
+  /// or handled.
+  /// On iOS image/jpg, image/jpeg and image/png are handled as images, while
+  /// every other MIME type is considered a normal file.
+  ///
+  /// The optional [sharePositionOrigin] parameter can be used to specify a global
+  /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
+  /// on other devices.
+  ///
+  /// Returns a [Future] that completes with a [ShareResult] object.
+  ///
+  /// Until the returned future is completed, any other call to any share method
+  /// that returns a result _might_ result in a [PlatformException] (on Android).
+  ///
+  /// Because IOS, Android and macOS provide different feedback on share-sheet
+  /// interaction, a result on IOS will be more specific than on Android or macOS.
+  /// While on IOS the selected action can inform its caller that it was completed
+  /// or dismissed midway (_actions are free to return whatever they want_),
+  /// Android and macOS only record if the user selected an action or outright
+  /// dismissed the share-sheet. It is not guaranteed that the user actually shared
+  /// something.
+  ///
+  /// May throw [PlatformException] or [FormatException]
+  /// from [MethodChannel].
+  static Future<ShareResult> shareV2({
+    String? text,
+    String? subject,
+    Uri? url,
+    List<String>? paths,
+    List<String>? mimeTypes,
+    Rect? sharePositionOrigin,
+  }) {
+    // Either provide a text, url or files to share
+    assert((text?.isNotEmpty ?? false) ||
+        url != null ||
+        (paths?.isNotEmpty ?? false));
+    return _platform.shareInternal(
+      text: text,
+      subject: subject,
+      url: url,
+      paths: paths,
+      mimeTypes: mimeTypes,
+      sharePositionOrigin: sharePositionOrigin,
+    );
+  }
+
+  /// Summons the platform's share sheet to share text.
+  ///
   /// Wraps the platform's native share dialog. Can share a text and/or a URL.
   /// It uses the `ACTION_SEND` Intent on Android and `UIActivityViewController`
   /// on iOS.
@@ -28,6 +94,7 @@ class Share {
   ///
   /// May throw [PlatformException] or [FormatException]
   /// from [MethodChannel].
+  @Deprecated('Use shareV2 instead')
   static Future<void> share(
     String text, {
     String? subject,
@@ -64,6 +131,7 @@ class Share {
   ///
   /// May throw [PlatformException] or [FormatException]
   /// from [MethodChannel].
+  @Deprecated('Use shareV2 instead')
   static Future<void> shareFiles(
     List<String> paths, {
     List<String>? mimeTypes,
@@ -99,6 +167,7 @@ class Share {
   ///
   /// Will gracefully fall back to the non result variant if not implemented
   /// for the current environment and return [ShareResult.unavailable].
+  @Deprecated('Use shareV2 instead')
   static Future<ShareResult> shareWithResult(
     String text, {
     String? subject,
@@ -129,6 +198,7 @@ class Share {
   ///
   /// Will gracefully fall back to the non result variant if not implemented
   /// for the current environment and return [ShareResult.unavailable].
+  @Deprecated('Use shareV2 instead')
   static Future<ShareResult> shareFilesWithResult(
     List<String> paths, {
     List<String>? mimeTypes,

--- a/packages/share_plus/share_plus_linux/lib/share_plus_linux.dart
+++ b/packages/share_plus/share_plus_linux/lib/share_plus_linux.dart
@@ -49,4 +49,17 @@ class ShareLinux extends SharePlatform {
   }) {
     throw UnimplementedError('shareFiles() has not been implemented on Linux.');
   }
+
+  @override
+  Future<ShareResult> shareInternal({
+    String? text,
+    String? subject,
+    Uri? url,
+    List<String>? paths,
+    List<String>? mimeTypes,
+    Rect? sharePositionOrigin,
+  }) {
+    // TODO: implement shareInternal
+    throw UnimplementedError();
+  }
 }

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -18,6 +18,73 @@ class MethodChannelShare extends SharePlatform {
   static const MethodChannel channel =
       MethodChannel('dev.fluttercommunity.plus/share');
 
+  @override
+  Future<ShareResult> shareInternal({
+    String? text,
+    String? subject,
+    Uri? url,
+    List<String>? paths,
+    List<String>? mimeTypes,
+    Rect? sharePositionOrigin,
+  }) async {
+    final params = <String, dynamic>{
+      if (subject != null) 'subject': subject,
+      if (text != null) 'text': text,
+      if (url != null) 'url': url.toString(),
+      if (paths != null) 'paths': paths,
+      if (paths != null)
+        'mimeTypes': mimeTypes ??
+            paths.map((String path) => _mimeTypeForPath(path)).toList(),
+    };
+
+    if (sharePositionOrigin != null) {
+      params['originX'] = sharePositionOrigin.left;
+      params['originY'] = sharePositionOrigin.top;
+      params['originWidth'] = sharePositionOrigin.width;
+      params['originHeight'] = sharePositionOrigin.height;
+    }
+
+    final result =
+        await channel.invokeMethod<String>('shareInternal', params) ??
+            'dev.fluttercommunity.plus/share/unavailable';
+
+    return ShareResult(result, _statusFromResult(result));
+  }
+
+  /// Summons the platform's share sheet to share.
+  @override
+  Future<ShareResult> shareFilesWithResult(
+    List<String> paths, {
+    List<String>? mimeTypes,
+    String? subject,
+    String? text,
+    Rect? sharePositionOrigin,
+  }) async {
+    assert(paths.isNotEmpty);
+    assert(paths.every((element) => element.isNotEmpty));
+    final params = <String, dynamic>{
+      'paths': paths,
+      'mimeTypes': mimeTypes ??
+          paths.map((String path) => _mimeTypeForPath(path)).toList(),
+    };
+
+    if (subject != null) params['subject'] = subject;
+    if (text != null) params['text'] = text;
+
+    if (sharePositionOrigin != null) {
+      params['originX'] = sharePositionOrigin.left;
+      params['originY'] = sharePositionOrigin.top;
+      params['originWidth'] = sharePositionOrigin.width;
+      params['originHeight'] = sharePositionOrigin.height;
+    }
+
+    final result =
+        await channel.invokeMethod<String>('shareFilesWithResult', params) ??
+            'dev.fluttercommunity.plus/share/unavailable';
+
+    return ShareResult(result, _statusFromResult(result));
+  }
+
   /// Summons the platform's share sheet to share text.
   @override
   Future<void> share(

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -28,14 +28,16 @@ class MethodChannelShare extends SharePlatform {
     Rect? sharePositionOrigin,
   }) async {
     final params = <String, dynamic>{
-      if (subject != null) 'subject': subject,
       if (text != null) 'text': text,
+      if (subject != null) 'subject': subject,
       if (url != null) 'url': url.toString(),
       if (paths != null) 'paths': paths,
       if (paths != null)
         'mimeTypes': mimeTypes ??
             paths.map((String path) => _mimeTypeForPath(path)).toList(),
     };
+
+    assert(params.isNotEmpty, 'At least one of text, url or paths must be set');
 
     if (sharePositionOrigin != null) {
       params['originX'] = sharePositionOrigin.left;
@@ -46,40 +48,6 @@ class MethodChannelShare extends SharePlatform {
 
     final result =
         await channel.invokeMethod<String>('shareInternal', params) ??
-            'dev.fluttercommunity.plus/share/unavailable';
-
-    return ShareResult(result, _statusFromResult(result));
-  }
-
-  /// Summons the platform's share sheet to share.
-  @override
-  Future<ShareResult> shareFilesWithResult(
-    List<String> paths, {
-    List<String>? mimeTypes,
-    String? subject,
-    String? text,
-    Rect? sharePositionOrigin,
-  }) async {
-    assert(paths.isNotEmpty);
-    assert(paths.every((element) => element.isNotEmpty));
-    final params = <String, dynamic>{
-      'paths': paths,
-      'mimeTypes': mimeTypes ??
-          paths.map((String path) => _mimeTypeForPath(path)).toList(),
-    };
-
-    if (subject != null) params['subject'] = subject;
-    if (text != null) params['text'] = text;
-
-    if (sharePositionOrigin != null) {
-      params['originX'] = sharePositionOrigin.left;
-      params['originY'] = sharePositionOrigin.top;
-      params['originWidth'] = sharePositionOrigin.width;
-      params['originHeight'] = sharePositionOrigin.height;
-    }
-
-    final result =
-        await channel.invokeMethod<String>('shareFilesWithResult', params) ??
             'dev.fluttercommunity.plus/share/unavailable';
 
     return ShareResult(result, _statusFromResult(result));

--- a/packages/share_plus/share_plus_platform_interface/lib/share_plus_platform_interface.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/share_plus_platform_interface.dart
@@ -10,7 +10,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'method_channel/method_channel_share.dart';
 
 /// The interface that implementations of `share_plus` must implement.
-class SharePlatform extends PlatformInterface {
+abstract class SharePlatform extends PlatformInterface {
   /// Constructs a SharePlatform.
   SharePlatform() : super(token: _token);
 
@@ -29,6 +29,16 @@ class SharePlatform extends PlatformInterface {
     PlatformInterface.verifyToken(instance, _token);
     _instance = instance;
   }
+
+  /// Share internal method.
+  Future<ShareResult> shareInternal({
+    String? text,
+    String? subject,
+    Uri? url,
+    List<String>? paths,
+    List<String>? mimeTypes,
+    Rect? sharePositionOrigin,
+  });
 
   /// Share text.
   Future<void> share(

--- a/packages/share_plus/share_plus_web/lib/share_plus_web.dart
+++ b/packages/share_plus/share_plus_web/lib/share_plus_web.dart
@@ -64,4 +64,17 @@ class SharePlusPlugin extends SharePlatform {
   }) {
     throw UnimplementedError('shareFiles() has not been implemented on Web.');
   }
+
+  @override
+  Future<ShareResult> shareInternal({
+    String? text,
+    String? subject,
+    Uri? url,
+    List<String>? paths,
+    List<String>? mimeTypes,
+    Rect? sharePositionOrigin,
+  }) {
+    // TODO: implement shareInternal
+    throw UnimplementedError();
+  }
 }

--- a/packages/share_plus/share_plus_windows/lib/share_plus_windows.dart
+++ b/packages/share_plus/share_plus_windows/lib/share_plus_windows.dart
@@ -53,4 +53,17 @@ class ShareWindows extends SharePlatform {
     throw UnimplementedError(
         'shareFiles() has not been implemented on Windows.');
   }
+
+  @override
+  Future<ShareResult> shareInternal({
+    String? text,
+    String? subject,
+    Uri? url,
+    List<String>? paths,
+    List<String>? mimeTypes,
+    Rect? sharePositionOrigin,
+  }) {
+    // TODO: implement shareInternal
+    throw UnimplementedError();
+  }
 }


### PR DESCRIPTION
## Description

Currently, a work in progress.

This PR goal is to refactor share_plus into a single method to share text, files, and as well a URL.

It will not be a breaking change, but the existing methods will be marked as deprecated, and eventually deleted.

## Related Issues

todo

## TODO

- [ ] Implement Android
- [ ] Implement iOS
- [ ] Implement macOS
- [ ] Implement Windows
- [ ] Implement Linux
- [ ] Implement web

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

