### PR TITLE
[share_plus] Fix Instagram does not show up in provider list for web links

### DIFF
--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 4.2.0
+
+- iOS: Fix Instagram does not show up in provider list for web links
+  - issue #459 appear again
+  - put back NSURL for the shareText, and text is pure URL
+  - using LPMetadataProvider to get LPLinkMetadata make the user experience better
+
 ## 4.1.0
 
 - iOS: Fix text sharing.

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - iOS: Fix Instagram does not show up in provider list for web links
   - issue #459 appear again
-  - put back NSURL for the shareText, and text is pure URL
+  - put back NSURL for the shareText, when text is pure URL
   - using LPMetadataProvider to get LPLinkMetadata make the user experience better
 
 ## 4.1.0

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -82,7 +82,7 @@ TopViewControllerForViewController(UIViewController *viewController) {
 - (instancetype)initWithSubject:(NSString *)subject
                             url:(NSURL *)url NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithLinkMetadata:(LPLinkMetadata *)metadata 
+- (instancetype)initWithLinkMetadata:(LPLinkMetadata *)metadata
     NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithFile:(NSString *)path
@@ -397,7 +397,7 @@ TopViewControllerForViewController(UIViewController *viewController) {
     return;
   }
 
-  if (@available(iOS 13, *) && ([[url scheme] isEqualToString:@"http"] || 
+  if (@available(iOS 13, *) && ([[url scheme] isEqualToString:@"http"] ||
                                 [[url scheme] isEqualToString:@"https"])) {
     LPMetadataProvider *metadataProvider = [[LPMetadataProvider alloc] init];
     [metadataProvider

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -73,9 +73,16 @@ TopViewControllerForViewController(UIViewController *viewController) {
 @property(readonly, nonatomic, copy) NSString *text;
 @property(readonly, nonatomic, copy) NSString *path;
 @property(readonly, nonatomic, copy) NSString *mimeType;
+@property(readonly, nonatomic, copy) LPLinkMetadata *linkMetadata;
+@property(readonly, nonatomic, copy) NSURL *url;
 
 - (instancetype)initWithSubject:(NSString *)subject
                            text:(NSString *)text NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithSubject:(NSString *)subject
+                            url:(NSURL *)url NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)initWithLinkMetadata:(LPLinkMetadata *)metadata NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithFile:(NSString *)path
                     mimeType:(NSString *)mimeType NS_DESIGNATED_INITIALIZER;
@@ -101,6 +108,23 @@ TopViewControllerForViewController(UIViewController *viewController) {
   if (self) {
     _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
     _text = text;
+  }
+  return self;
+}
+
+- (instancetype)initWithSubject:(NSString *)subject url:(NSURL *)url {
+   self = [super init];
+   if (self) {
+     _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
+     _url = url;
+   }
+   return self;
+ }
+
+- (instancetype)initWithLinkMetadata:(LPLinkMetadata *)metadata {
+  self = [super init];
+  if (self) {
+    _linkMetadata = metadata;
   }
   return self;
 }
@@ -135,6 +159,14 @@ TopViewControllerForViewController(UIViewController *viewController) {
 
 - (id)activityViewController:(UIActivityViewController *)activityViewController
          itemForActivityType:(UIActivityType)activityType {
+  if (_linkMetadata != nil) {
+    return _linkMetadata.originalURL;
+  }
+
+  if (_url != nil) {
+      return _url;
+  }
+
   if (!_path || !_mimeType) {
     return _text;
   }
@@ -182,6 +214,10 @@ TopViewControllerForViewController(UIViewController *viewController) {
 - (LPLinkMetadata *)activityViewControllerLinkMetadata:
     (UIActivityViewController *)activityViewController
     API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0)) {
+  if (_linkMetadata != nil) {
+    return _linkMetadata;
+  }
+
   LPLinkMetadata *metadata = [[LPLinkMetadata alloc] init];
 
   if ([_subject length] > 0) {
@@ -348,13 +384,61 @@ TopViewControllerForViewController(UIViewController *viewController) {
     withController:(UIViewController *)controller
           atSource:(CGRect)origin
           toResult:(FlutterResult)result {
-  NSObject *data = [[SharePlusData alloc] initWithSubject:subject
-                                                     text:shareText];
-  [self share:@[ data ]
-         withSubject:subject
-      withController:controller
-            atSource:origin
-            toResult:result];
+  NSURL *url = [NSURL URLWithString:shareText];
+  if (!url || ![url scheme] || ![url host]) {
+    NSObject *data = [[SharePlusData alloc] initWithSubject:subject
+                                                       text:shareText];
+    [self share:@[ data ]
+           withSubject:subject
+        withController:controller
+              atSource:origin
+              toResult:result];
+    return;
+  }
+
+  if (@available(iOS 13, *) && ([[url scheme] isEqualToString:@"http"] || [[url scheme] isEqualToString:@"https"])) {
+    LPMetadataProvider *metadataProvider = [[LPMetadataProvider alloc] init];
+    [metadataProvider startFetchingMetadataForURL:url
+                                completionHandler:^(LPLinkMetadata *metadata, NSError *error){
+        if(!error){
+            if (subject != nil && [subject length] > 0) {
+                metadata.title = subject;
+            }
+            NSObject *data = [[SharePlusData alloc] initWithLinkMetadata:metadata];
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [self share:@[ data ]
+                       withSubject:subject
+                    withController:controller
+                          atSource:origin
+                          toResult:result];
+            });
+
+            return;
+        }
+
+        NSLog(@"FetchingMetadataForURL %@ got error: %@", url, error);
+        NSObject *data = [[SharePlusData alloc] initWithSubject:subject
+                                                            url:url];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self share:@[ data ]
+                   withSubject:subject
+                withController:controller
+                      atSource:origin
+                      toResult:result];
+        });
+
+    }];
+  }
+  else {
+    NSObject *data = [[SharePlusData alloc] initWithSubject:subject
+                                                        url:url];
+    [self share:@[ data ]
+           withSubject:subject
+        withController:controller
+              atSource:origin
+              toResult:result];
+    return;
+  }
 }
 
 + (void)shareFiles:(NSArray *)paths

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -82,7 +82,8 @@ TopViewControllerForViewController(UIViewController *viewController) {
 - (instancetype)initWithSubject:(NSString *)subject
                             url:(NSURL *)url NS_DESIGNATED_INITIALIZER;
 
-- (instancetype)initWithLinkMetadata:(LPLinkMetadata *)metadata NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithLinkMetadata:(LPLinkMetadata *)metadata 
+    NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)initWithFile:(NSString *)path
                     mimeType:(NSString *)mimeType NS_DESIGNATED_INITIALIZER;
@@ -113,13 +114,13 @@ TopViewControllerForViewController(UIViewController *viewController) {
 }
 
 - (instancetype)initWithSubject:(NSString *)subject url:(NSURL *)url {
-   self = [super init];
-   if (self) {
-     _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
-     _url = url;
-   }
-   return self;
- }
+  self = [super init];
+  if (self) {
+    _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
+    _url = url;
+  }
+  return self;
+}
 
 - (instancetype)initWithLinkMetadata:(LPLinkMetadata *)metadata {
   self = [super init];
@@ -164,7 +165,7 @@ TopViewControllerForViewController(UIViewController *viewController) {
   }
 
   if (_url != nil) {
-      return _url;
+    return _url;
   }
 
   if (!_path || !_mimeType) {
@@ -396,42 +397,44 @@ TopViewControllerForViewController(UIViewController *viewController) {
     return;
   }
 
-  if (@available(iOS 13, *) && ([[url scheme] isEqualToString:@"http"] || [[url scheme] isEqualToString:@"https"])) {
+  if (@available(iOS 13, *) && ([[url scheme] isEqualToString:@"http"] || 
+                                [[url scheme] isEqualToString:@"https"])) {
     LPMetadataProvider *metadataProvider = [[LPMetadataProvider alloc] init];
-    [metadataProvider startFetchingMetadataForURL:url
-                                completionHandler:^(LPLinkMetadata *metadata, NSError *error){
-        if(!error){
-            if (subject != nil && [subject length] > 0) {
-                metadata.title = subject;
-            }
-            NSObject *data = [[SharePlusData alloc] initWithLinkMetadata:metadata];
-            dispatch_async(dispatch_get_main_queue(), ^{
-                [self share:@[ data ]
-                       withSubject:subject
-                    withController:controller
-                          atSource:origin
-                          toResult:result];
-            });
+    [metadataProvider
+        startFetchingMetadataForURL:url
+                  completionHandler:^(LPLinkMetadata *metadata,
+                                      NSError *error) {
+                    if (!error) {
+                      if (subject != nil && [subject length] > 0) {
+                        metadata.title = subject;
+                      }
+                      NSObject *data =
+                          [[SharePlusData alloc] initWithLinkMetadata:metadata];
+                      dispatch_async(dispatch_get_main_queue(), ^{
+                        [self share:@[ data ]
+                               withSubject:subject
+                            withController:controller
+                                  atSource:origin
+                                  toResult:result];
+                      });
 
-            return;
-        }
+                      return;
+                    }
 
-        NSLog(@"FetchingMetadataForURL %@ got error: %@", url, error);
-        NSObject *data = [[SharePlusData alloc] initWithSubject:subject
-                                                            url:url];
-        dispatch_async(dispatch_get_main_queue(), ^{
-            [self share:@[ data ]
-                   withSubject:subject
-                withController:controller
-                      atSource:origin
-                      toResult:result];
-        });
-
-    }];
-  }
-  else {
-    NSObject *data = [[SharePlusData alloc] initWithSubject:subject
-                                                        url:url];
+                    NSLog(@"FetchingMetadataForURL %@ got error: %@", url,
+                          error);
+                    NSObject *data =
+                        [[SharePlusData alloc] initWithSubject:subject url:url];
+                    dispatch_async(dispatch_get_main_queue(), ^{
+                      [self share:@[ data ]
+                             withSubject:subject
+                          withController:controller
+                                atSource:origin
+                                toResult:result];
+                    });
+                  }];
+  } else {
+    NSObject *data = [[SharePlusData alloc] initWithSubject:subject url:url];
     [self share:@[ data ]
            withSubject:subject
         withController:controller

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 4.1.0
+version: 4.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus


### PR DESCRIPTION
## Description

iOS: Fix Instagram does not show up in provider list for web links
  - issue #459 appear again
  - put back NSURL for the shareText, when text is pure URL
  - using LPMetadataProvider to get LPLinkMetadata make the user experience better

## Related Issues

[#459](https://github.com/fluttercommunity/plus_plugins/issues/459)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
