### PR TITLE
[windows] Fixes crashes when listening to update streams in

### DIFF
--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   battery_plus_linux: ^1.1.1
   battery_plus_macos: ^1.1.0
   battery_plus_web: ^1.1.0
-  battery_plus_windows: ^1.1.2
+  battery_plus_windows: ^1.1.3
 
 dev_dependencies:
   flutter_test:

--- a/packages/battery_plus/battery_plus_windows/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+- Reapply the changes in 1.1.1 (no compile issues in this package).
+
 ## 1.1.2
 
 - Revert changes in 1.1.1 due to compile issues

--- a/packages/battery_plus/battery_plus_windows/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus_windows
 description: Windows implementation of the battery_plus plugin
-version: 1.1.2
+version: 1.1.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/battery_plus/battery_plus_windows/windows/battery_plus_windows_plugin.cpp
+++ b/packages/battery_plus/battery_plus_windows/windows/battery_plus_windows_plugin.cpp
@@ -34,6 +34,8 @@ public:
 private:
   void HandleMethodCall(const FlMethodCall &method_call,
                         std::unique_ptr<FlMethodResult> result);
+  std::unique_ptr<FlMethodChannel> _methodChannel;
+  std::unique_ptr<FlEventChannel> _eventChannel;
 };
 
 class BatteryStatusStreamHandler : public FlStreamHandler {
@@ -64,19 +66,19 @@ void BatteryPlusWindowsPlugin::RegisterWithRegistrar(
 
 BatteryPlusWindowsPlugin::BatteryPlusWindowsPlugin(
     flutter::PluginRegistrarWindows *registrar) {
-  auto methodChannel = std::make_unique<FlMethodChannel>(
+  _methodChannel = std::make_unique<FlMethodChannel>(
       registrar->messenger(), "dev.fluttercommunity.plus/battery",
       &flutter::StandardMethodCodec::GetInstance());
 
-  methodChannel->SetMethodCallHandler([this](const auto &call, auto result) {
+  _methodChannel->SetMethodCallHandler([this](const auto &call, auto result) {
     HandleMethodCall(call, std::move(result));
   });
 
-  auto eventChannel = std::make_unique<FlEventChannel>(
+  _eventChannel = std::make_unique<FlEventChannel>(
       registrar->messenger(), "dev.fluttercommunity.plus/charging",
       &flutter::StandardMethodCodec::GetInstance());
 
-  eventChannel->SetStreamHandler(
+  _eventChannel->SetStreamHandler(
       std::make_unique<BatteryStatusStreamHandler>(registrar));
 }
 


### PR DESCRIPTION
battery_plus_windows.

This commit only contains the changes to battery_plus_windows, without the fixes that caused compilation issues in connectivity_plus_windows.

## Description

Reapplies the reverted changes to battery_plus_windows

## Related Issues

#1086 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
