### PR TITLE
[website] Add explicit entry point for Firebase Deploy Action

### DIFF
--- a/.github/workflows/build_deploy_website.yaml
+++ b/.github/workflows/build_deploy_website.yaml
@@ -45,3 +45,4 @@ jobs:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT_FLUTTER_COMMUNITY_DASHBOARD }}"
           channelId: live
+          entryPoint: ./website


### PR DESCRIPTION
## Description

Looks like Firebase Action doesn't respect the `defaults` syntax as it didn't find `firebase.json` file: https://github.com/fluttercommunity/plus_plugins/actions/runs/3154184239/jobs/5131506340

Trying to fix it by using available `entryPoint` parameter.