### PR TITLE
[website] Add FAQ for Alarm Manager, fix Edit this page link

### DIFF
--- a/docs/android_alarm_manager_plus/usage.mdx
+++ b/docs/android_alarm_manager_plus/usage.mdx
@@ -79,6 +79,27 @@ alarm manager plugin itself, it may be necessary to inform the background servic
 to initialize plugins depending on which Flutter Android embedding the application is
 using.
 
+## FAQ
+
+### Does this plugin support to invoke a method after reboot?
+
+From the Android AlarmManager documentation:
+
+> Registered alarms are retained while the device is asleep (and can optionally wake the device up if they go off
+during that time), but will be cleared if it is turned off and rebooted.
+https://developer.android.com/reference/android/app/AlarmManager
+
+### My alarm is not firing after force stopping the app
+
+The Android OS will not fire alarms for apps that have been force stopped.
+
+StackOverflow response: https://stackoverflow.com/questions/11241794/alarm-set-in-app-with-alarmmanager-got-removed-when-app-force-stop
+
+### My alarm is not firing on a specific device
+
+Likely the device is running some battery optimization software that is preventing the alarm from firing.
+Check out https://dontkillmyapp.com/ to find out about more about optimizations done by different vendors.
+
 ## Plugin Development
 
 ### Running Flutter unit tests

--- a/packages/android_alarm_manager_plus/README.md
+++ b/packages/android_alarm_manager_plus/README.md
@@ -104,6 +104,7 @@ StackOverflow response: https://stackoverflow.com/questions/11241794/alarm-set-i
 ### My alarm is not firing on a specific device
 
 Likely the device is running some battery optimization software that is preventing the alarm from firing.
+Check out https://dontkillmyapp.com/ to find out about more about optimizations done by different vendors.
 
 ## Plugin Development
 
@@ -136,5 +137,3 @@ To run the Flutter Driver tests, cd into `example` and run:
 ```
 flutter driver test_driver/android_alarm_manager_plus_e2e.dart
 ```
-
-**Important:** As of January 2021, the Flutter team is no longer accepting non-critical PRs for the original set of plugins in `flutter/plugins`, and instead they should be submitted in this project. [You can read more about this announcement here.](https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md#important-note) as well as [in the Flutter 2 announcement blog post.](https://medium.com/flutter/whats-new-in-flutter-2-0-fe8e95ecc65)

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -67,7 +67,7 @@ module.exports = {
         docs: {
           path: '../docs',
           sidebarPath: require.resolve('../docs/sidebars.js'),
-          editUrl: 'https://github.com/fluttercommunity/plus/edit/master/docs/',
+          editUrl: 'https://github.com/fluttercommunity/plus/edit/main/docs/',
         },
         theme: {
           customCss: require.resolve('./src/styles.scss'),


### PR DESCRIPTION
## Description

Recently added FAQ in Alarm Manager README should be added to Plus plugins website as well. This PR adds it. I also added a link to https://dontkillmyapp.com/ to let people find more info on possible battery optimisation issues they might have.

Also found out that `Edit this page` button at the bottom of every page on the website doesn't work because of wrong path. Fixed it as well.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
