### PR TITLE
[Github Actions] Add ignored paths for Build website preview workflow

### DIFF
--- a/.github/workflows/build_preview_website.yaml
+++ b/.github/workflows/build_preview_website.yaml
@@ -1,13 +1,9 @@
 name: Build website preview
 on:
   pull_request:
-    paths-ignore:
-      - "packages/**"
-      - ".github/**"
-      - "**.yaml"
-      - "**.yml"
-      - "CODE_OF_CONDUCT.md"
-      - "CONTRIBUTING.md"
+    paths:
+      - "docs/**"
+      - "website/**"
 
 defaults:
   run:

--- a/.github/workflows/build_preview_website.yaml
+++ b/.github/workflows/build_preview_website.yaml
@@ -3,6 +3,11 @@ on:
   pull_request:
     paths-ignore:
       - "packages/**"
+      - ".github/**"
+      - "**.yaml"
+      - "**.yml"
+      - "CODE_OF_CONDUCT.md"
+      - "CONTRIBUTING.md"
 
 defaults:
   run:


### PR DESCRIPTION
## Description

Adding ignored paths to avoid triggering website preview build when non website related files are changed, so we don't have issues, like in #1113 where checks are marked as failed because of the failing website preview workflow.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
