### PR TITLE
Enable Integration tests for MacOS

### DIFF
--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -107,6 +107,19 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
+  macos-integration-test:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh macos battery_plus_example
+
   linux:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -108,6 +108,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
   macos-integration-test:
+    if: false # Disabled as battery_plus APIs don't complete in github actions macos VMs.
     runs-on: macos-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -107,6 +107,19 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
+  macos-integration-test:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh macos connectivity_plus_example
+
   linux:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -107,6 +107,20 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
+    
+  macos-integration-test:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh macos device_info_plus_example
+
   linux:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -108,6 +108,19 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
+  macos-integration-test:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh macos network_info_plus_example
+
   linux:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -107,6 +107,19 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
+  macos-integration-test:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh macos package_info_plus_example
+
   linux:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -107,6 +107,19 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
+  macos-integration-test:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh macos share_plus_example
+
   linux:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
+++ b/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
@@ -13,7 +13,7 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  final bool batteryLevelIsImplemented = Platform.isAndroid || Platform.isIOS;
+  final bool batteryLevelIsImplemented = Platform.isAndroid || Platform.isMacOS;
   final bool isInBatterySaveModeIsImplemented =
       Platform.isAndroid || Platform.isIOS || Platform.isWindows;
 

--- a/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
+++ b/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
@@ -18,11 +18,11 @@ void main() {
   testWidgets('Can get battery level', (WidgetTester tester) async {
     final batteryLevel = await Battery().batteryLevel;
     expect(batteryLevel, isNotNull);
-  }, skip: !Platform.isAndroid);
+  }, skip: !Platform.isAndroid && !Platform.isMacOS);
 
   testWidgets('Can get if device is in battery save mode',
       (WidgetTester tester) async {
     final isInBatterySaveMode = await Battery().isInBatterySaveMode;
     expect(isInBatterySaveMode, false);
-  });
+  }, skip: !Platform.isAndroid && !Platform.isIOS && !Platform.isWindows);
 }

--- a/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
+++ b/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
@@ -14,15 +14,24 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   final bool batteryLevelIsImplemented = Platform.isAndroid || Platform.isMacOS;
+  final bool batteryStateIsImplemented = Platform.isAndroid ||
+      Platform.isIOS ||
+      Platform.isMacOS ||
+      Platform.isWindows;
   final bool isInBatterySaveModeIsImplemented =
       Platform.isAndroid || Platform.isIOS || Platform.isWindows;
 
-  /// Throws [PlatformException] on iOS simulator.
+  /// Throws [PlatformException] on iOS simulator and Windows.
   /// Run on Android only.
   testWidgets('Can get battery level', (WidgetTester tester) async {
     final batteryLevel = await Battery().batteryLevel;
     expect(batteryLevel, isNotNull);
   }, skip: !batteryLevelIsImplemented);
+
+  testWidgets('Can get battery state', (WidgetTester tester) async {
+    final batteryState = await Battery().batteryState;
+    expect(batteryState, isNotNull);
+  }, skip: !batteryStateIsImplemented);
 
   testWidgets('Can get if device is in battery save mode',
       (WidgetTester tester) async {

--- a/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
+++ b/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
@@ -13,16 +13,20 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
+  final bool batteryLevelIsImplemented = Platform.isAndroid || Platform.isIOS;
+  final bool isInBatterySaveModeIsImplemented =
+      Platform.isAndroid || Platform.isIOS || Platform.isWindows;
+
   /// Throws [PlatformException] on iOS simulator.
   /// Run on Android only.
   testWidgets('Can get battery level', (WidgetTester tester) async {
     final batteryLevel = await Battery().batteryLevel;
     expect(batteryLevel, isNotNull);
-  }, skip: !Platform.isAndroid && !Platform.isMacOS);
+  }, skip: !batteryLevelIsImplemented);
 
   testWidgets('Can get if device is in battery save mode',
       (WidgetTester tester) async {
     final isInBatterySaveMode = await Battery().isInBatterySaveMode;
     expect(isInBatterySaveMode, false);
-  }, skip: !Platform.isAndroid && !Platform.isIOS && !Platform.isWindows);
+  }, skip: !isInBatterySaveModeIsImplemented);
 }

--- a/packages/battery_plus/battery_plus/lib/battery_plus.dart
+++ b/packages/battery_plus/battery_plus/lib/battery_plus.dart
@@ -37,6 +37,8 @@ class Battery {
   }
 
   /// check if device is on battery save mode
+  ///
+  /// Currently only impemented on Android, IOS and Windows.
   Future<bool> get isInBatterySaveMode {
     return _platform.isInBatterySaveMode;
   }

--- a/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -13,6 +13,14 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
+  String getPlatformName() {
+    String platformName = Platform.operatingSystem;
+    if (Platform.isAndroid) {
+      platformName += ' emulator';
+    }
+    return platformName;
+  }
+
   group('Connectivity test driver', () {
     Connectivity _connectivity;
 
@@ -25,11 +33,11 @@ void main() {
       expect(result, isNotNull);
     });
 
-    testWidgets('connectivity on Android emulator should be wifi',
+    testWidgets('connectivity on ${getPlatformName()} should be wifi',
         (WidgetTester tester) async {
       final result = await _connectivity.checkConnectivity();
 
       expect(result, ConnectivityResult.wifi);
-    }, skip: !Platform.isAndroid);
+    }, skip: !Platform.isMacOS && !Platform.isAndroid);
   });
 }

--- a/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -32,11 +32,11 @@ void main() {
       expect(result, ConnectivityResult.wifi);
     }, skip: !Platform.isAndroid);
 
-    testWidgets('connectivity on MacOS should be wifi',
+    testWidgets('connectivity on MacOS should be ethernet',
         (WidgetTester tester) async {
       final result = await _connectivity.checkConnectivity();
 
-      expect(result, ConnectivityResult.wifi);
+      expect(result, ConnectivityResult.ethernet);
     }, skip: !Platform.isMacOS);
   });
 }

--- a/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -13,14 +13,6 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  String getPlatformName() {
-    String platformName = Platform.operatingSystem;
-    if (Platform.isAndroid) {
-      platformName += ' emulator';
-    }
-    return platformName;
-  }
-
   group('Connectivity test driver', () {
     Connectivity _connectivity;
 
@@ -33,11 +25,18 @@ void main() {
       expect(result, isNotNull);
     });
 
-    testWidgets('connectivity on ${getPlatformName()} should be wifi',
+    testWidgets('connectivity on Android emulator should be wifi',
         (WidgetTester tester) async {
       final result = await _connectivity.checkConnectivity();
 
       expect(result, ConnectivityResult.wifi);
-    }, skip: !Platform.isMacOS && !Platform.isAndroid);
+    }, skip: !Platform.isAndroid);
+
+    testWidgets('connectivity on MacOS should be wifi',
+        (WidgetTester tester) async {
+      final result = await _connectivity.checkConnectivity();
+
+      expect(result, ConnectivityResult.wifi);
+    }, skip: !Platform.isMacOS);
   });
 }

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -100,4 +100,18 @@ void main() {
     expect(androidInfo.isPhysicalDevice, isNotNull);
     expect(androidInfo.systemFeatures, isNotNull);
   }, skip: !Platform.isAndroid);
+
+  testWidgets('Check all macos info values are set',
+      ((WidgetTester tester) async {
+    expect(macosInfo.computerName, isNotNull);
+    expect(macosInfo.hostName, isNotNull);
+    expect(macosInfo.arch, isNotNull);
+    expect(macosInfo.model, isNotNull);
+    expect(macosInfo.kernelVersion, isNotNull);
+    expect(macosInfo.osRelease, isNotNull);
+    expect(macosInfo.activeCPUs, isNotNull);
+    expect(macosInfo.memorySize, isNotNull);
+    expect(macosInfo.cpuFrequency, isNotNull);
+    expect(macosInfo.systemGUID, isNotNull);
+  }), skip: !Platform.isMacOS);
 }

--- a/packages/network_info_plus/network_info_plus/example/integration_test/network_info_plus_test.dart
+++ b/packages/network_info_plus/network_info_plus/example/integration_test/network_info_plus_test.dart
@@ -20,12 +20,13 @@ void main() {
       _networkInfo = NetworkInfo();
     });
 
-    testWidgets('test location methods, iOS only', (WidgetTester tester) async {
+    testWidgets('test location methods, iOS and MacOS only',
+        (WidgetTester tester) async {
       if (Platform.isIOS) {
         expect((await _networkInfo.getLocationServiceAuthorization()),
             LocationAuthorizationStatus.notDetermined);
       }
-    }, skip: !Platform.isIOS);
+    }, skip: !Platform.isIOS && !Platform.isMacOS);
 
     testWidgets('test non-null network value', (WidgetTester tester) async {
       expect(_networkInfo.getWifiName(), isNotNull);

--- a/packages/network_info_plus/network_info_plus/example/integration_test/network_info_plus_test.dart
+++ b/packages/network_info_plus/network_info_plus/example/integration_test/network_info_plus_test.dart
@@ -20,13 +20,12 @@ void main() {
       _networkInfo = NetworkInfo();
     });
 
-    testWidgets('test location methods, iOS and MacOS only',
-        (WidgetTester tester) async {
+    testWidgets('test location methods, iOS only', (WidgetTester tester) async {
       if (Platform.isIOS) {
         expect((await _networkInfo.getLocationServiceAuthorization()),
             LocationAuthorizationStatus.notDetermined);
       }
-    }, skip: !Platform.isIOS && !Platform.isMacOS);
+    }, skip: !Platform.isIOS);
 
     testWidgets('test non-null network value', (WidgetTester tester) async {
       expect(_networkInfo.getWifiName(), isNotNull);

--- a/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
+++ b/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
@@ -4,6 +4,8 @@
 
 // @dart=2.9
 
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:integration_test/integration_test.dart';
@@ -13,7 +15,11 @@ void main() {
 
   testWidgets('Can launch share', (WidgetTester tester) async {
     expect(Share.share('message', subject: 'title'), completes);
-  });
+  }, skip: Platform.isMacOS);
+
+  testWidgets('Can launch share in MacOS', (WidgetTester tester) async {
+    expect(Share.share('message', subject: 'title'), isNotNull);
+  }, skip: !Platform.isMacOS);
 
   testWidgets('Can launch shareWithResult', (WidgetTester tester) async {
     expect(Share.shareWithResult('message', subject: 'title'), isNotNull);


### PR DESCRIPTION
## Description

Adds workflow steps to run integration tests for MacOS for plugins:
- battery_plus
- connectivity_plus
- device_info_plus
- network_info_plus
- package_info_plus

Also, tweaked a few tests to adapt for MacOS

These packages / APIs aren't implemented in MacOS yet, so haven't added them.
- `sensors_plus`
- `share_plus`
- `battery_plus`'s `isInBatterySaveMode`

## Related Issues

Fixes #1105

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
