### PR TITLE
make toMap() json compatible

### DIFF
--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
@@ -138,6 +138,7 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
   }
 
   /// `toJson()` returns a JSON string representation of [AndroidDeviceInfo] Model.
+  @override
   String toJson() => jsonEncode(toMap());
 
   /// Deserializes from the message received from [_kChannel].

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'base_device_info.dart';
 
 /// Information derived from `android.os.Build`.
@@ -135,6 +137,9 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
     };
   }
 
+  /// `toJson()` returns a JSON string representation of [AndroidDeviceInfo] Model.
+  String toJson() => jsonEncode(toMap());
+
   /// Deserializes from the message received from [_kChannel].
   static AndroidDeviceInfo fromMap(Map<String, dynamic> map) {
     return AndroidDeviceInfo(
@@ -219,6 +224,9 @@ class AndroidBuildVersion {
       'securityPatch': securityPatch,
     };
   }
+
+  /// `toJson()` returns a JSON string representation of [AndroidBuildVersion] Model.
+  String toJson() => jsonEncode(toMap());
 
   /// Deserializes from the map message received from [_kChannel].
   static AndroidBuildVersion _fromMap(Map<String, dynamic> map) {

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/base_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/base_device_info.dart
@@ -1,5 +1,10 @@
+import 'dart:convert';
+
 /// The base class for platform's device info.
 abstract class BaseDeviceInfo {
   /// Serializes device info properties to a map.
   Map<String, dynamic> toMap();
+
+  /// `toJson()` returns a JSON string representation of [BaseDeviceInfo] Model.
+  String toJson() => jsonEncode(toMap());
 }

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/ios_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/ios_device_info.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'base_device_info.dart';
 
 /// Information derived from `UIDevice`.
@@ -73,6 +75,10 @@ class IosDeviceInfo implements BaseDeviceInfo {
       'isPhysicalDevice': isPhysicalDevice.toString(),
     };
   }
+
+  /// `toJson()` returns a JSON string representation of [IosDeviceInfo] Model.
+  @override
+  String toJson() => jsonEncode(toMap());
 }
 
 /// Information derived from `utsname`.

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/linux_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/linux_device_info.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'base_device_info.dart';
 
 /// Device information for a Linux system.
@@ -156,4 +158,8 @@ class LinuxDeviceInfo implements BaseDeviceInfo {
       'machineId': machineId,
     };
   }
+
+  /// `toJson()` returns a JSON string representation of [LinuxDeviceInfo] Model.
+  @override
+  String toJson() => jsonEncode(toMap());
 }

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/macos_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/macos_device_info.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'base_device_info.dart';
 
 /// Object encapsulating MACOS device information.
@@ -86,4 +88,8 @@ class MacOsDeviceInfo implements BaseDeviceInfo {
       systemGUID: map['systemGUID'],
     );
   }
+
+  /// `toJson()` returns a JSON string representation of [MacOsDeviceInfo] Model.
+  @override
+  String toJson() => jsonEncode(toMap());
 }

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/web_browser_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/web_browser_info.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'base_device_info.dart';
 
 /// List of supported browsers
@@ -149,6 +151,10 @@ class WebBrowserInfo implements BaseDeviceInfo {
       'maxTouchPoints': maxTouchPoints,
     };
   }
+
+  /// `toJson()` returns a JSON string representation of [WebBrowserInfo] Model.
+  @override
+  String toJson() => jsonEncode(toMap());
 
   BrowserName _parseUserAgentToBrowserName() {
     final _userAgent = userAgent;

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/web_browser_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/web_browser_info.dart
@@ -134,7 +134,6 @@ class WebBrowserInfo implements BaseDeviceInfo {
   @override
   Map<String, dynamic> toMap() {
     return {
-      'browserName': browserName,
       'appCodeName': appCodeName,
       'appName': appName,
       'appVersion': appVersion,

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/windows_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/windows_device_info.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'base_device_info.dart';
 
 /// Object encapsulating WINDOWS device information.
@@ -32,4 +34,8 @@ class WindowsDeviceInfo implements BaseDeviceInfo {
       'systemMemoryInMegabytes': systemMemoryInMegabytes,
     };
   }
+
+  /// `toJson()` returns a JSON string representation of [WindowsDeviceInfo] Model.
+  @override
+  String toJson() => jsonEncode(toMap());
 }

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:device_info_plus_platform_interface/model/android_device_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -77,6 +79,16 @@ void main() {
             AndroidDeviceInfo.fromMap(androidDeviceInfoMap);
 
         expect(androidDeviceInfo.toMap(), androidDeviceInfoMap);
+      });
+      test('toJson should return correct json string', () {
+        final androidDeviceInfo =
+            AndroidDeviceInfo.fromMap(androidDeviceInfoMap);
+        final androidDeviceInfoJson = jsonEncode(androidDeviceInfo.toMap());
+        expect(
+          androidDeviceInfo.toJson(),
+          androidDeviceInfoJson,
+          reason: 'toJson should return correct json string',
+        );
       });
     });
   });

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/ios_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/ios_device_info_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:device_info_plus_platform_interface/model/ios_device_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -42,6 +44,15 @@ void main() {
         final iosDeviceInfo = IosDeviceInfo.fromMap(iosDeviceInfoMap);
 
         expect(iosDeviceInfo.toMap(), iosDeviceInfoMap);
+      });
+      test('toJson should return correct json string', () {
+        final iosDeviceInfo = IosDeviceInfo.fromMap(iosDeviceInfoMap);
+        final iosDeviceInfoJson = jsonEncode(iosDeviceInfo.toMap());
+        expect(
+          iosDeviceInfo.toJson(),
+          iosDeviceInfoJson,
+          reason: 'toJson should return correct json string',
+        );
       });
     });
   });

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/linux_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/linux_device_info_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:device_info_plus_platform_interface/model/linux_device_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -30,6 +32,14 @@ void main() {
         'variant': 'variant',
         'variantId': 'variantId',
         'machineId': 'machineId',
+      });
+      test('toJson should return correct json string', () {
+        final linuxDeviceInfoJson = jsonEncode(linuxDeviceInfo.toMap());
+        expect(
+          linuxDeviceInfo.toJson(),
+          linuxDeviceInfoJson,
+          reason: 'toJson should return correct json string',
+        );
       });
     });
   });

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/linux_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/linux_device_info_test.dart
@@ -5,21 +5,20 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('$LinuxDeviceInfo', () {
+    final linuxDeviceInfo = LinuxDeviceInfo(
+      name: 'name',
+      version: 'version',
+      id: 'id',
+      idLike: ['idLike'],
+      versionCodename: 'versionCodename',
+      versionId: 'versionId',
+      prettyName: 'prettyName',
+      buildId: 'buildId',
+      variant: 'variant',
+      variantId: 'variantId',
+      machineId: 'machineId',
+    );
     test('toMap should return map with correct key and map', () {
-      final linuxDeviceInfo = LinuxDeviceInfo(
-        name: 'name',
-        version: 'version',
-        id: 'id',
-        idLike: ['idLike'],
-        versionCodename: 'versionCodename',
-        versionId: 'versionId',
-        prettyName: 'prettyName',
-        buildId: 'buildId',
-        variant: 'variant',
-        variantId: 'variantId',
-        machineId: 'machineId',
-      );
-
       expect(linuxDeviceInfo.toMap(), {
         'name': 'name',
         'version': 'version',
@@ -33,14 +32,14 @@ void main() {
         'variantId': 'variantId',
         'machineId': 'machineId',
       });
-      test('toJson should return correct json string', () {
-        final linuxDeviceInfoJson = jsonEncode(linuxDeviceInfo.toMap());
-        expect(
-          linuxDeviceInfo.toJson(),
-          linuxDeviceInfoJson,
-          reason: 'toJson should return correct json string',
-        );
-      });
+    });
+    test('toJson should return correct json string', () {
+      final linuxDeviceInfoJson = jsonEncode(linuxDeviceInfo.toMap());
+      expect(
+        linuxDeviceInfo.toJson(),
+        linuxDeviceInfoJson,
+        reason: 'toJson should return correct json string',
+      );
     });
   });
 }

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/macos_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/macos_device_info_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:device_info_plus_platform_interface/model/macos_device_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -68,6 +70,15 @@ void main() {
         final macosDeviceInfo = MacOsDeviceInfo.fromMap(macosDeviceInfoMap);
 
         expect(macosDeviceInfo.toMap(), macosDeviceInfoMap);
+      });
+      test('toJson should return correct json string', () {
+        final macosDeviceInfo = MacOsDeviceInfo.fromMap(macosDeviceInfoMap);
+        final macosDeviceInfoJson = jsonEncode(macosDeviceInfo.toMap());
+        expect(
+          macosDeviceInfo.toJson(),
+          macosDeviceInfoJson,
+          reason: 'toJson should return correct json string',
+        );
       });
     });
   });

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/web_browser_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/web_browser_info_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:device_info_plus_platform_interface/model/web_browser_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -45,6 +47,15 @@ void main() {
       test('toMap should return map with correct key and map', () {
         final webBrowserInfo = WebBrowserInfo.fromMap(webBrowserInfoMap);
         expect(webBrowserInfo.toMap(), webBrowserInfoMap);
+      });
+      test('toJson should return correct json string', () {
+        final webBrowserInfo = WebBrowserInfo.fromMap(webBrowserInfoMap);
+        final webBrowserInfoJson = jsonEncode(webBrowserInfo.toMap());
+        expect(
+          webBrowserInfo.toJson(),
+          webBrowserInfoJson,
+          reason: 'toJson should return correct json string',
+        );
       });
     });
   });

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/web_browser_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/web_browser_info_test.dart
@@ -7,7 +7,6 @@ void main() {
   group('$WebBrowserInfo', () {
     group('fromMap | toMap', () {
       const webBrowserInfoMap = <String, dynamic>{
-        'browserName': BrowserName.safari,
         'appCodeName': 'appCodeName',
         'appName': 'appName',
         'appVersion': 'appVersion',

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/windows_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/windows_device_info_test.dart
@@ -17,14 +17,19 @@ void main() {
         'numberOfCores': 4,
         'systemMemoryInMegabytes': 16,
       });
-      test('toJson should return correct json string', () {
-        final windowsDeviceInfoJson = jsonEncode(windowsDeviceInfo.toMap());
-        expect(
-          windowsDeviceInfo.toJson(),
-          windowsDeviceInfoJson,
-          reason: 'toJson should return correct json string',
-        );
-      });
+    });
+    test('toJson should return correct json string', () {
+      final windowsDeviceInfo = WindowsDeviceInfo(
+        computerName: 'computerName',
+        numberOfCores: 4,
+        systemMemoryInMegabytes: 16,
+      );
+      final windowsDeviceInfoJson = jsonEncode(windowsDeviceInfo.toMap());
+      expect(
+        windowsDeviceInfo.toJson(),
+        windowsDeviceInfoJson,
+        reason: 'toJson should return correct json string',
+      );
     });
   });
 }

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/windows_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/windows_device_info_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:device_info_plus_platform_interface/model/windows_device_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -14,6 +16,14 @@ void main() {
         'computerName': 'computerName',
         'numberOfCores': 4,
         'systemMemoryInMegabytes': 16,
+      });
+      test('toJson should return correct json string', () {
+        final windowsDeviceInfoJson = jsonEncode(windowsDeviceInfo.toMap());
+        expect(
+          windowsDeviceInfo.toJson(),
+          windowsDeviceInfoJson,
+          reason: 'toJson should return correct json string',
+        );
       });
     });
   });


### PR DESCRIPTION
## Description

*Rendered toMap on the models to be jsonCompatible*

## Related Issues

* fix #949 

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
