### PR TITLE
[android_intent_plus] Fix fallback to implicit intent

### DIFF
--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.2
+
+- Fix explicit intent fallback to implicit
+- Update Android Gradle plugin and Gradle verion
+
 ## 3.1.1+1
 
 - Add issue_tracker link.

--- a/packages/android_intent_plus/android/build.gradle
+++ b/packages/android_intent_plus/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.3.0'
     }
 }
 

--- a/packages/android_intent_plus/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_intent_plus/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
@@ -172,9 +172,6 @@ public final class IntentSender {
         intent.setComponent(componentName);
       }
     }
-    if (intent.resolveActivity(applicationContext.getPackageManager()) == null) {
-      Log.i(TAG, "Cannot resolve explicit intent");
-    }
 
     return intent;
   }

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
@@ -92,11 +92,17 @@ public final class MethodCallHandlerImpl implements MethodCallHandler {
             action, flags, category, data, arguments, packageName, componentName, type);
 
     if ("launch".equalsIgnoreCase(call.method)) {
-      sender.send(intent);
 
+      if (intent != null && !sender.canResolveActivity(intent)) {
+        Log.i(TAG, "Cannot resolve explicit intent, falling back to implicit");
+        intent.setPackage(null);
+      }
+
+      sender.send(intent);
       result.success(null);
     } else if ("launchChooser".equalsIgnoreCase(call.method)) {
       String title = call.argument("chooserTitle");
+
       sender.launchChooser(intent, title);
       result.success(null);
     } else if ("sendBroadcast".equalsIgnoreCase(call.method)) {

--- a/packages/android_intent_plus/example/android/app/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_intent_plus/example/android/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/android_intent_plus/example/android/build.gradle
+++ b/packages/android_intent_plus/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.2'
+        classpath 'com.android.tools.build:gradle:7.3.0'
     }
 }
 

--- a/packages/android_intent_plus/example/android/gradle.properties
+++ b/packages/android_intent_plus/example/android/gradle.properties
@@ -1,3 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
-android.enableJetifier=true
 android.useAndroidX=true

--- a/packages/android_intent_plus/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_intent_plus/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Oct 05 13:40:15 CEST 2021
+#Sun Oct 02 17:46:54 EEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 3.1.1+1
+version: 3.1.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/android_intent_plus


### PR DESCRIPTION
## Description

Fix for #245 broke the functionality of safe fallback from explicit to implicit intent when package can't be resolved. This PR adds such functionality back.

Additionally updated Android Gradle plugin and used Gradle version.

## Related Issues

Closes #919 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
