### PR TITLE
[linux test integration] - run Linux tests in CI 1104

### DIFF
--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
-  macos-integration-test:
+  macos_integration_test:
     if: false # Disabled as battery_plus APIs don't complete in github actions macos VMs.
     runs-on: macos-latest
     timeout-minutes: 30
@@ -131,10 +131,12 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Install UPower"
+        run: sudo apt install upower
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
 
-  linux-integration-test:
+  linux_integration_test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -144,6 +146,8 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Install UPower"
+        run: sudo apt install upower
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh linux battery_plus_example
 

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -134,6 +134,19 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
 
+  linux-integration-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh linux battery_plus_example
+
   windows:
     runs-on: windows-latest
     timeout-minutes: 30

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
-  macos-integration-test:
+  macos_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -133,7 +133,7 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
 
-  linux-integration-test:
+  linux_integration_test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -143,6 +143,8 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Install NetworkManager"
+        run: sudo apt-get install -y network-manager
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh linux connectivity_plus_example
 

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -133,6 +133,19 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
 
+  linux-integration-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh linux connectivity_plus_example
+
   windows:
     runs-on: windows-latest
     timeout-minutes: 30

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -108,7 +108,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
     
-  macos-integration-test:
+  macos_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -134,7 +134,7 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
 
-  linux-integration-test:
+  linux_integration_test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -134,6 +134,19 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
 
+  linux-integration-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh linux device_info_plus_example
+
   windows:
     runs-on: windows-latest
     timeout-minutes: 30

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -108,7 +108,7 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
-  macos-integration-test:
+  macos_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -134,7 +134,7 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
 
-  linux-integration-test:
+  linux_integration_test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -134,6 +134,19 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
 
+  linux-integration-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh linux network_info_plus_example
+
   windows:
     runs-on: windows-latest
     timeout-minutes: 30

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -132,6 +132,19 @@ jobs:
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
+ 
+  linux-integration-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh linux package_info_plus_example
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
-  macos-integration-test:
+  macos_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -133,7 +133,7 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
  
-  linux-integration-test:
+  linux_integration_test:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/scripts/integration-test.sh
+++ b/.github/workflows/scripts/integration-test.sh
@@ -13,9 +13,12 @@ fi
 
 if [ "$ACTION" == "linux" ]
 then
-  sudo apt-get install ninja-build libgtk-3-dev
+  sudo apt-get update
+  sudo apt-get install -y clang cmake ninja-build libgtk-3-dev xvfb
+  export DISPLAY=:99
+  sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
   melos exec -c 1 --scope="$SCOPE" --dir-exists="./integration_test" -- \
-    "flutter test -d linux ./integration_test/MELOS_PARENT_PACKAGE_NAME_test.dart --dart-define=CI=true"
+  "flutter test -d linux ./integration_test/MELOS_PARENT_PACKAGE_NAME_test.dart --dart-define=CI=true"
 fi
 
 if [ "$ACTION" == "windows" ]

--- a/.github/workflows/scripts/integration-test.sh
+++ b/.github/workflows/scripts/integration-test.sh
@@ -14,6 +14,7 @@ fi
 if [ "$ACTION" == "linux" ]
 then
   sudo apt-get install ninja-build libgtk-3-dev
+  # Testrunner is headless. Required create virtual display for the linux tests to run.
   export DISPLAY=:99
   sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
   melos exec -c 1 --scope="$SCOPE" --dir-exists="./integration_test" -- \

--- a/.github/workflows/scripts/integration-test.sh
+++ b/.github/workflows/scripts/integration-test.sh
@@ -13,8 +13,7 @@ fi
 
 if [ "$ACTION" == "linux" ]
 then
-  sudo apt-get update
-  sudo apt-get install -y clang cmake ninja-build libgtk-3-dev xvfb
+  sudo apt-get install ninja-build libgtk-3-dev
   export DISPLAY=:99
   sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
   melos exec -c 1 --scope="$SCOPE" --dir-exists="./integration_test" -- \

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -107,7 +107,7 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
-  macos-integration-test:
+  macos_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -133,7 +133,7 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
      
-  linux-integration-test:
+  linux_integration_test:
     if: false # TODO: enable this if it is possible to register a mailto protocol handler on github hosted runners
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -132,6 +132,20 @@ jobs:
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
+     
+  linux-integration-test:
+    if: false # TODO: enable this if it is possible to register a mailto protocol handler on github hosted runners
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v2
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Run Integration Test"
+        run: ./.github/workflows/scripts/integration-test.sh linux share_plus_example  
 
   windows:
     runs-on: windows-latest

--- a/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
+++ b/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
@@ -17,9 +17,12 @@ void main() {
   final bool batteryStateIsImplemented = Platform.isAndroid ||
       Platform.isIOS ||
       Platform.isMacOS ||
-      Platform.isWindows;
-  final bool isInBatterySaveModeIsImplemented =
-      Platform.isAndroid || Platform.isIOS || Platform.isWindows;
+      Platform.isWindows ||
+      Platform.isLinux;
+  final bool isInBatterySaveModeIsImplemented = Platform.isAndroid ||
+      Platform.isIOS ||
+      Platform.isWindows ||
+      Platform.isLinux;
 
   /// Throws [PlatformException] on iOS simulator and Windows.
   /// Run on Android only.

--- a/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
+++ b/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
@@ -13,16 +13,15 @@ import 'package:integration_test/integration_test.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  final bool batteryLevelIsImplemented = Platform.isAndroid || Platform.isMacOS;
+  final bool batteryLevelIsImplemented =
+      Platform.isAndroid || Platform.isMacOS || Platform.isLinux;
   final bool batteryStateIsImplemented = Platform.isAndroid ||
       Platform.isIOS ||
       Platform.isMacOS ||
       Platform.isWindows ||
       Platform.isLinux;
-  final bool isInBatterySaveModeIsImplemented = Platform.isAndroid ||
-      Platform.isIOS ||
-      Platform.isWindows ||
-      Platform.isLinux;
+  final bool isInBatterySaveModeIsImplemented =
+      Platform.isAndroid || Platform.isIOS || Platform.isWindows;
 
   /// Throws [PlatformException] on iOS simulator and Windows.
   /// Run on Android only.

--- a/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -38,5 +38,12 @@ void main() {
 
       expect(result, ConnectivityResult.ethernet);
     }, skip: !Platform.isMacOS);
+    
+    testWidgets('connectivity on Linux should be ethernet',
+        (WidgetTester tester) async {
+      final result = await _connectivity.checkConnectivity();
+
+      expect(result, ConnectivityResult.ethernet);
+    }, skip: !Platform.isLinux);
   });
 }

--- a/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -39,11 +39,11 @@ void main() {
       expect(result, ConnectivityResult.ethernet);
     }, skip: !Platform.isMacOS);
 
-    testWidgets('connectivity on Linux should be ethernet',
+    testWidgets('connectivity on Linux should be none',
         (WidgetTester tester) async {
       final result = await _connectivity.checkConnectivity();
 
-      expect(result, ConnectivityResult.ethernet);
+      expect(result, ConnectivityResult.none);
     }, skip: !Platform.isLinux);
   });
 }

--- a/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -38,7 +38,7 @@ void main() {
 
       expect(result, ConnectivityResult.ethernet);
     }, skip: !Platform.isMacOS);
-    
+
     testWidgets('connectivity on Linux should be ethernet',
         (WidgetTester tester) async {
       final result = await _connectivity.checkConnectivity();

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -114,4 +114,13 @@ void main() {
     expect(macosInfo.cpuFrequency, isNotNull);
     expect(macosInfo.systemGUID, isNotNull);
   }), skip: !Platform.isMacOS);
+
+  testWidgets('Check all Linux info values are available',
+      ((WidgetTester tester) async {
+    expect(linuxInfo.name, equals('Linux'));
+    expect(linuxInfo.idLike, isNull);
+    expect(linuxInfo.buildId, isNull);
+    expect(linuxInfo.variant, isNull);
+    expect(linuxInfo.variantId, isNull);
+  }), skip: !Platform.Linux);
 }

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -117,16 +117,15 @@ void main() {
 
   testWidgets('Check all Linux info values are available',
       ((WidgetTester tester) async {
-    expect(linuxInfo.name, equals('Linux'));
-    expect(linuxInfo.version, isNull);
-    expect(linuxInfo.id, equals('linux'));
-    expect(linuxInfo.idLike, isNull);
-    expect(linuxInfo.versionCodename, isNull);
-    expect(linuxInfo.versionId, isNull);
-    expect(linuxInfo.prettyName, 'Linux');
+    expect(linuxInfo.name, isNotNull);
+    expect(linuxInfo.version, isNotNull);
+    expect(linuxInfo.id, isNotNull);
+    expect(linuxInfo.idLike, isNotNull);
+    expect(linuxInfo.versionCodename, isNotNull);
+    expect(linuxInfo.versionId, isNotNull);
+    expect(linuxInfo.prettyName, isNotNull);
     expect(linuxInfo.buildId, isNull);
     expect(linuxInfo.variant, isNull);
     expect(linuxInfo.variantId, isNull);
-    expect(linuxInfo.machineId, isNull);
   }), skip: !Platform.isLinux);
 }

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -118,9 +118,15 @@ void main() {
   testWidgets('Check all Linux info values are available',
       ((WidgetTester tester) async {
     expect(linuxInfo.name, equals('Linux'));
+    expect(linuxInfo.version, isNull);
+    expect(linuxInfo.id, equals('linux'));
     expect(linuxInfo.idLike, isNull);
+    expect(linuxInfo.versionCodename, isNull);
+    expect(linuxInfo.versionId, isNull);
+    expect(linuxInfo.prettyName, 'Linux');
     expect(linuxInfo.buildId, isNull);
     expect(linuxInfo.variant, isNull);
     expect(linuxInfo.variantId, isNull);
-  }), skip: !Platform.Linux);
+    expect(linuxInfo.machineId, isNull);
+  }), skip: !Platform.isLinux);
 }

--- a/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_test.dart
+++ b/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_test.dart
@@ -42,10 +42,10 @@ void main() {
         expect(info.packageName, 'io.flutter.plugins.packageInfoExample');
         expect(info.version, '1.2.3');
       } else if (Platform.isLinux) {
-        expect(info.appName, 'package_info_example');
+        expect(info.appName, 'package_info_plus_example');
         expect(info.buildNumber, '4');
         expect(info.buildSignature, isEmpty);
-        expect(info.packageName, 'package_info_example');
+        expect(info.packageName, 'package_info_plus_example');
         expect(info.version, '1.2.3');
       } else if (Platform.isWindows) {
         expect(info.appName, 'example');
@@ -90,7 +90,7 @@ void main() {
         expect(find.text('1.2.3'), findsOneWidget);
         expect(find.text('Not set'), findsOneWidget);
       } else if (Platform.isLinux) {
-        expect(find.text('package_info_example'), findsNWidgets(2));
+        expect(find.text('package_info_plus_example'), findsNWidgets(2));
         expect(find.text('1.2.3'), findsOneWidget);
         expect(find.text('4'), findsOneWidget);
         expect(find.text('Not set'), findsOneWidget);


### PR DESCRIPTION
## Description
* Runs integration_test on Linux.
* Ignores the share_plus integration test on Linux -> it works for me locally but it seems that the github runners do not implement mailto. If we consider this part of this issue, please comment about it and I will start working on it.

The solution is to create a virtual device using Xvfb and have that as the display that flutter is expecting.

## Related Issues
[Request]: Integration tests for Linux #1104 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
