### PR TITLE
[connectivity_plus] discard unused result warning for method calls

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 2.3.8
 
-- Discard usued warnings for `ensurePathMonitor` & `ensureReachability` call in iOS.
+- Discard unused warnings for `ensurePathMonitor` & `ensureReachability` call in iOS.
 
 ## 2.3.7
 

--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.3.8
+
+- Discard usued warnings for `ensurePathMonitor` & `ensureReachability` call in iOS.
+
 ## 2.3.7
 
 - iOS: Reduce compiler warnings

--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/PathMonitorConnectivityProvider.swift
@@ -28,11 +28,11 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
 
   override init() {
     super.init()
-    ensurePathMonitor()
+    _ = ensurePathMonitor()
   }
 
   public func start() {
-    ensurePathMonitor()
+    _ = ensurePathMonitor()
   }
 
   public func stop() {

--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/ReachabilityConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/ReachabilityConnectivityProvider.swift
@@ -20,7 +20,7 @@ public class ReachabilityConnectivityProvider: NSObject, ConnectivityProvider {
 
   override init() {
     super.init()
-    ensureReachability()
+    _ = ensureReachability()
   }
 
   public func start() {

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 2.3.7
+version: 2.3.8
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/connectivity_plus

--- a/packages/connectivity_plus/connectivity_plus_macos/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.5
+
+- Discard usued warnings for `ensurePathMonitor` & `ensureReachability` call in macOS.
+
 ## 1.2.4
 
 - Stop sending events once flutter engine detached

--- a/packages/connectivity_plus/connectivity_plus_macos/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus_macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.5
 
-- Discard usued warnings for `ensurePathMonitor` & `ensureReachability` call in macOS.
+- Discard unused warnings for `ensurePathMonitor` & `ensureReachability` call in macOS.
 
 ## 1.2.4
 

--- a/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/PathMonitorConnectivityProvider.swift
@@ -26,11 +26,11 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
 
   override init() {
     super.init()
-    ensurePathMonitor()
+    _ = ensurePathMonitor()
   }
 
   public func start() {
-    ensurePathMonitor()
+    _ = ensurePathMonitor()
   }
 
   public func stop() {

--- a/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/ReachabilityConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus_macos/macos/Classes/ReachabilityConnectivityProvider.swift
@@ -20,7 +20,7 @@ public class ReachabilityConnectivityProvider: NSObject, ConnectivityProvider {
 
   override init() {
     super.init()
-    ensureReachability()
+    _ = ensureReachability()
   }
 
   public func start() {

--- a/packages/connectivity_plus/connectivity_plus_macos/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_macos
 description: macOS implementation of the connectivity_plus plugin.
-version: 1.2.4
+version: 1.2.5
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

- Discard usued warnings for `ensurePathMonitor` call in macOS and iOS.
- Discard usued warnings for `ensureReachability` call in macOS and iOS.

## Related Issues

Fixes: #1078

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
