### PR TITLE
Tb/feature/cancel previous jobs based on github ref

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -1,5 +1,9 @@
 name: all_plugins
 
+concurrency:
+  group: all_plugins_${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths-ignore:

--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -1,7 +1,7 @@
 name: all_plugins
 
 concurrency:
-  group: all_plugins_${{ github.ref }}
+  group: all_plugins_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -1,6 +1,10 @@
 # Build Android Alarm Manager Plus Example
 name: android_alarm_manager_plus
 
+concurrency:
+  group: android_alarm_manager_plus_${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -2,7 +2,7 @@
 name: android_alarm_manager_plus
 
 concurrency:
-  group: android_alarm_manager_plus_${{ github.ref }}
+  group: android_alarm_manager_plus_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -1,6 +1,10 @@
 # Build Android Intent Plus Example
 name: android_intent_plus
 
+concurrency:
+  group: android_intent_plus_${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:
@@ -28,7 +32,7 @@ jobs:
       # Required for Android builds
       - uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: "11"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
@@ -47,7 +51,7 @@ jobs:
       # Required for Android builds
       - uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: "11"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap

--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -2,7 +2,7 @@
 name: android_intent_plus
 
 concurrency:
-  group: android_intent_plus_${{ github.ref }}
+  group: android_intent_plus_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -1,6 +1,10 @@
 # Build Battery Plus Example
 name: battery_plus
 
+concurrency:
+  group: battery_plus_${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash
@@ -32,7 +36,7 @@ jobs:
       # Required for Android builds
       - uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: "11"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
@@ -51,7 +55,7 @@ jobs:
       # Required for Android builds
       - uses: actions/setup-java@v1
         with:
-          java-version: '11'
+          java-version: "11"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap
@@ -90,7 +94,7 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v1
         with:
-          model: 'iPhone 8'
+          model: "iPhone 8"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios battery_plus_example
 

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -2,7 +2,7 @@
 name: battery_plus
 
 concurrency:
-  group: battery_plus_${{ github.ref }}
+  group: battery_plus_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/build_deploy_website.yaml
+++ b/.github/workflows/build_deploy_website.yaml
@@ -1,7 +1,7 @@
 name: Build and deploy website
 
 concurrency:
-  group: build_website_${{ github.ref }}
+  group: build_website_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/build_deploy_website.yaml
+++ b/.github/workflows/build_deploy_website.yaml
@@ -1,4 +1,9 @@
 name: Build and deploy website
+
+concurrency:
+  group: build_website_${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/build_preview_website.yaml
+++ b/.github/workflows/build_preview_website.yaml
@@ -1,4 +1,9 @@
 name: Build website preview
+
+concurrency:
+  group: build_preview_website_${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/build_preview_website.yaml
+++ b/.github/workflows/build_preview_website.yaml
@@ -1,7 +1,7 @@
 name: Build website preview
 
 concurrency:
-  group: build_preview_website_${{ github.ref }}
+  group: build_preview_website_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -2,7 +2,7 @@
 name: connectivity_plus
 
 concurrency:
-  group: connectivity_plus_${{ github.ref }}
+  group: connectivity_plus_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -1,6 +1,10 @@
 # Build Connectivity Info Plus Example
 name: connectivity_plus
 
+concurrency:
+  group: connectivity_plus_${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -2,7 +2,7 @@
 name: device_info_plus
 
 concurrency:
-  group: device_info_plus_${{ github.ref }}
+  group: device_info_plus_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -1,6 +1,10 @@
 # Build Device Info Plus Example
 name: device_info_plus
 
+concurrency:
+  group: device_info_plus_${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -2,7 +2,7 @@
 name: network_info_plus
 
 concurrency:
-  group: network_info_plus_${{ github.ref }}
+  group: network_info_plus_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -1,6 +1,10 @@
 # Build Network Info Plus Example
 name: network_info_plus
 
+concurrency:
+  group: network_info_plus_${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -2,7 +2,7 @@
 name: package_info_plus
 
 concurrency:
-  group: package_info_plus_${{ github.ref }}
+  group: package_info_plus_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -1,6 +1,10 @@
 # Build Package Info Plus Example
 name: package_info_plus
 
+concurrency:
+  group: package_info_plus_${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/scripts/integration-test.sh
+++ b/.github/workflows/scripts/integration-test.sh
@@ -7,7 +7,6 @@ SCOPE=$2
 
 if [ "$ACTION" == "android" ]
 then
-  echo "test"
   melos exec -c 1 --scope="$SCOPE" --dir-exists="./integration_test" -- \
     "flutter test ./integration_test/MELOS_PARENT_PACKAGE_NAME_test.dart --dart-define=CI=true"
 fi

--- a/.github/workflows/scripts/integration-test.sh
+++ b/.github/workflows/scripts/integration-test.sh
@@ -7,6 +7,7 @@ SCOPE=$2
 
 if [ "$ACTION" == "android" ]
 then
+  echo "test"
   melos exec -c 1 --scope="$SCOPE" --dir-exists="./integration_test" -- \
     "flutter test ./integration_test/MELOS_PARENT_PACKAGE_NAME_test.dart --dart-define=CI=true"
 fi

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -2,7 +2,7 @@
 name: sensors_plus
 
 concurrency:
-  group: sensors_plus_${{ github.ref }}
+  group: sensors_plus_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -1,6 +1,10 @@
 # Build Sensors Plus Example
 name: sensors_plus
 
+concurrency:
+  group: sensors_plus_${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths:

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -2,7 +2,7 @@
 name: share_plus
 
 concurrency:
-  group: share_plus_${{ github.ref }}
+  group: share_plus_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 defaults:

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -1,6 +1,10 @@
 # Build Share Plus Example
 name: share_plus
 
+concurrency:
+  group: share_plus_${{ github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: bash

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,7 +1,7 @@
 name: 'Stale issue handler'
 
 concurrency:
-  group: stale_issue_handler_${{ github.ref }}
+  group: stale_issue_handler_${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 on:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,9 @@
 name: 'Stale issue handler'
+
+concurrency:
+  group: stale_issue_handler_${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
## Description

Cancel previous jobs if a new one with a higher priority has been created. The check is done based on the github ref id.

## Related Issues

[Request]: Cancel CI jobs when new commit pushed to PR #1145

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
