### PR TITLE
[device_info_plus] Detect iOS simulator model identifier

### DIFF
--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.3
+
+- Detects iOS simulator device id instead of simulator's underlying architecture.
+
 ## 4.1.2
 
 - Redo changes in 4.1.0

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -69,14 +69,12 @@ void main() {
 
   testWidgets('Can get non-null iOS utsname fields',
       (WidgetTester tester) async {
-    if (Platform.isIOS) {
-      expect(iosInfo.utsname.machine, 'iPhone10,4');
-      expect(iosInfo.utsname.nodename, isNotNull);
-      expect(iosInfo.utsname.release, isNotNull);
-      expect(iosInfo.utsname.sysname, isNotNull);
-      expect(iosInfo.utsname.version, isNotNull);
-    }
-  });
+    expect(iosInfo.utsname.machine, 'iPhone10,4');
+    expect(iosInfo.utsname.nodename, isNotNull);
+    expect(iosInfo.utsname.release, isNotNull);
+    expect(iosInfo.utsname.sysname, isNotNull);
+    expect(iosInfo.utsname.version, isNotNull);
+  }, skip: !Platform.isIOS);
 
   testWidgets('Check all android info values are set',
       (WidgetTester tester) async {

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -67,6 +67,17 @@ void main() {
     }
   });
 
+  testWidgets('Can get non-null iOS utsname fields',
+      (WidgetTester tester) async {
+    if (Platform.isIOS) {
+      expect(iosInfo.utsname.machine, 'iPhone10,4');
+      expect(iosInfo.utsname.nodename, isNotNull);
+      expect(iosInfo.utsname.release, isNotNull);
+      expect(iosInfo.utsname.sysname, isNotNull);
+      expect(iosInfo.utsname.version, isNotNull);
+    }
+  });
+
   testWidgets('Check all android info values are set',
       (WidgetTester tester) async {
     expect(androidInfo.version.baseOS, isNotNull);

--- a/packages/device_info_plus/device_info_plus/ios/Classes/FLTDeviceInfoPlusPlugin.m
+++ b/packages/device_info_plus/device_info_plus/ios/Classes/FLTDeviceInfoPlusPlugin.m
@@ -21,6 +21,13 @@
     struct utsname un;
     uname(&un);
 
+    NSString* machine;
+    if ([[self isDevicePhysical] isEqualToString:@"true"]) {
+      machine = @(un.machine);
+    } else {
+      machine = [[NSProcessInfo processInfo] environment][@"SIMULATOR_MODEL_IDENTIFIER"];
+    }
+
     result(@{
       @"name" : [device name],
       @"systemName" : [device systemName],
@@ -35,7 +42,7 @@
         @"nodename" : @(un.nodename),
         @"release" : @(un.release),
         @"version" : @(un.version),
-        @"machine" : @(un.machine),
+        @"machine" : machine,
       }
     });
   } else {

--- a/packages/device_info_plus/device_info_plus/ios/Classes/FLTDeviceInfoPlusPlugin.m
+++ b/packages/device_info_plus/device_info_plus/ios/Classes/FLTDeviceInfoPlusPlugin.m
@@ -21,11 +21,12 @@
     struct utsname un;
     uname(&un);
 
-    NSString* machine;
+    NSString *machine;
     if ([[self isDevicePhysical] isEqualToString:@"true"]) {
       machine = @(un.machine);
     } else {
-      machine = [[NSProcessInfo processInfo] environment][@"SIMULATOR_MODEL_IDENTIFIER"];
+      machine = [[NSProcessInfo processInfo]
+          environment][@"SIMULATOR_MODEL_IDENTIFIER"];
     }
 
     result(@{

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 4.1.2
+version: 4.1.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus


### PR DESCRIPTION
## Description

Currently, `iosInfo.utsname.machine` returns the underlying architecture of the iOS device when the device is a simulator. This updates the behavior to return the simulator's model identifier instead (e.g. `iPhone 15,2` for an iPhone 14 Pro).

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/273

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
