### PR TITLE
[network_info_plus] Use new Android APIs

### DIFF
--- a/docs/network_info_plus/usage.mdx
+++ b/docs/network_info_plus/usage.mdx
@@ -27,6 +27,8 @@ To successfully get WiFi Name or Wi-Fi BSSID starting with Android O, ensure all
 
  * Location services are enabled on the device (under Settings > Location).
 
+ * If you use device with Android 12 (API level 31) and newer be sure that your app has ACCESS_NETWORK_STATE permission.
+
 **This package does not provide the ACCESS_FINE_LOCATION nor the ACCESS_COARSE_LOCATION permission by default**
 
 ### iOS 12

--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.3.0
+
+- Android: Use new APIs to get network info on devices with with Android 12 (SDK 31) and newer. Due
+  to this change on such devices be sure to add `ACCESS_NETWORK_STATE` permission into your
+  `AndroidManifest.xml` file.
+
 ## 2.2.0
 
 - Android: Migrate to Kotlin
@@ -13,7 +19,6 @@
 ## 2.1.4
 
 - Android: Plugin no longer removes `"` from SSID name.
-
 
 ## 2.1.3
 
@@ -58,7 +63,6 @@
 
 - migrate integration_test to flutter sdk
 
-
 ## 1.1.0
 
 - Android, IOS: Adding IPv6 information
@@ -88,8 +92,8 @@
 
 ## 0.1.1
 
-- Added a stub plugin for Web that throws unsupported exceptions, because
-  the functionality is not supported on Web.
+- Added a stub plugin for Web that throws unsupported exceptions, because the functionality is not
+  supported on Web.
 
 ## 0.1.0
 

--- a/packages/network_info_plus/network_info_plus/README.md
+++ b/packages/network_info_plus/network_info_plus/README.md
@@ -30,7 +30,7 @@ import 'package:network_info_plus/network_info_plus.dart';
 
 final info = NetworkInfo();
 
-var wifiName = await info.getWifiName(); // FooNetwork
+var wifiName = await info.getWifiName(); // "FooNetwork"
 var wifiBSSID = await info.getWifiBSSID(); // 11:22:33:44:55:66
 var wifiIP = await info.getWifiIP(); // 192.168.1.43
 var wifiIPv6 = await info.getWifiIPv6(); // 2001:0db8:85a3:0000:0000:8a2e:0370:7334
@@ -48,6 +48,8 @@ To successfully get WiFi Name or Wi-Fi BSSID starting with Android 1O, ensure al
 - If your app is targeting SDK lower than Android 10 (API level 29), your app needs to have the ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION permission.
 
 - Location services are enabled on the device (under Settings > Location).
+
+- If you use device with Android 12 (API level 31) and newer be sure that your app has ACCESS_NETWORK_STATE permission.
 
 **This package does not provide the ACCESS_FINE_LOCATION nor the ACCESS_COARSE_LOCATION permission by default**
 

--- a/packages/network_info_plus/network_info_plus/android/src/main/AndroidManifest.xml
+++ b/packages/network_info_plus/network_info_plus/android/src/main/AndroidManifest.xml
@@ -2,4 +2,5 @@
   package="dev.fluttercommunity.plus.network_info">
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 </manifest>

--- a/packages/network_info_plus/network_info_plus/android/src/main/AndroidManifest.xml
+++ b/packages/network_info_plus/network_info_plus/android/src/main/AndroidManifest.xml
@@ -2,5 +2,4 @@
   package="dev.fluttercommunity.plus.network_info">
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
   <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
-  <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 </manifest>

--- a/packages/network_info_plus/network_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/network_info/NetworkInfoPlusPlugin.kt
+++ b/packages/network_info_plus/network_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/network_info/NetworkInfoPlusPlugin.kt
@@ -1,7 +1,9 @@
 package dev.fluttercommunity.plus.network_info
 
 import android.content.Context
+import android.net.ConnectivityManager
 import android.net.wifi.WifiManager
+import android.os.Build
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.FlutterPlugin.FlutterPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
@@ -24,7 +26,13 @@ class NetworkInfoPlusPlugin : FlutterPlugin {
         methodChannel = MethodChannel(messenger, CHANNEL)
         val wifiManager =
             context.applicationContext.getSystemService(Context.WIFI_SERVICE) as WifiManager
-        val networkInfo = NetworkInfo(wifiManager)
+
+        var connectivityManager: ConnectivityManager? = null
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            connectivityManager = context.applicationContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+        }
+
+        val networkInfo = NetworkInfo(wifiManager, connectivityManager)
         val methodChannelHandler = NetworkInfoMethodChannelHandler(networkInfo)
         methodChannel.setMethodCallHandler(methodChannelHandler)
     }

--- a/packages/network_info_plus/network_info_plus/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/network_info_plus/network_info_plus/example/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
     package="dev.fluttercommunity.plus.network_info_plus_example">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application
         android:name="${applicationName}"

--- a/packages/network_info_plus/network_info_plus/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/network_info_plus/network_info_plus/example/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 
     <application
         android:name="${applicationName}"

--- a/packages/network_info_plus/network_info_plus/example/lib/main.dart
+++ b/packages/network_info_plus/network_info_plus/example/lib/main.dart
@@ -65,9 +65,23 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('NetworkInfo example app'),
+        title: const Text('NetworkInfoPlus example'),
       ),
-      body: Center(child: Text('Connection Status: $_connectionStatus')),
+      body: Center(
+          child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Text(
+            'Network info',
+            style: TextStyle(
+              fontSize: 16,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 16),
+          Text(_connectionStatus),
+        ],
+      )),
     );
   }
 

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,8 +1,8 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 2.2.0
+version: 2.3.0
 homepage: https://plus.fluttercommunity.dev/
-repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
+repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/network_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/network_info_plus
 
 environment:


### PR DESCRIPTION
## Description

While working on #1090 saw that plugin uses some deprecated APIs.
Namely, there were usages of:
- [WifiManager.connectionInfo()](https://developer.android.com/reference/android/net/wifi/WifiManager#getConnectionInfo())
- [WifiInfo.getIpAddress()](https://developer.android.com/reference/android/net/wifi/WifiInfo#getIpAddress())
- [WifiManager.getDhcpInfo()](https://developer.android.com/reference/android/net/wifi/WifiManager#getDhcpInfo())

I modified the code, so on devices with Android 12 (S) and newer plugin uses new recommended way of getting the same information. Now plugin relies on [ConnectivityManager.getLinkProperties()](https://developer.android.com/reference/android/net/ConnectivityManager#getLinkProperties(android.net.Network)) and [ConnectivityManager.getNetworkCapabilities()](https://developer.android.com/reference/android/net/ConnectivityManager#getLinkProperties(android.net.Network)) for such devices. 
Both functions mention that they require `Manifest.permission.ACCESS_NETWORK_STATE`, but during testing on emulators code worked fine for me even without this permission being added into AndroidManifest. Nevertheless, add info about this permission to docs and README, since don't trust emulator much.

Additionally did a minor update to `example` app to show info in more pretty form:

Before:
<img width="286" alt="Screenshot 2022-10-03 at 10 25 00" src="https://user-images.githubusercontent.com/13467769/193532756-40428680-f975-4e35-b712-d6762b29cc5e.png">

After:
<img width="302" alt="Screenshot 2022-10-03 at 11 25 17" src="https://user-images.githubusercontent.com/13467769/193532863-01b7a201-0be5-47b5-b638-b2965d7d4f4a.png">

## Related Issues

-

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
