### PR TITLE
[share_plus] Remove usage of deprecated UIApplication.keyWindow in iOS 13+

### DIFF
--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.5.0
+
+- iOS: Remove usage of deprecated UIApplication.keyWindow in iOS 13+
+
 ## 4.4.0
 
 - Reverted changes in 4.2.0 due to crash issues. See #1081

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -9,7 +9,22 @@
 static NSString *const PLATFORM_CHANNEL = @"dev.fluttercommunity.plus/share";
 
 static UIViewController *RootViewController() {
-  return [UIApplication sharedApplication].keyWindow.rootViewController;
+  if (@available(iOS 13, *)) { // UIApplication.keyWindow is deprecated
+    NSSet *scenes = [[UIApplication sharedApplication] connectedScenes];
+    for (UIScene *scene in scenes) {
+      if ([scene isKindOfClass:[UIWindowScene class]]) {
+        NSArray *windows = ((UIWindowScene *)scene).windows;
+        for (UIWindow *window in windows) {
+          if (window.isKeyWindow) {
+            return window.rootViewController;
+          }
+        }
+      }
+    }
+    return nil;
+  } else {
+    return [UIApplication sharedApplication].keyWindow.rootViewController;
+  }
 }
 
 static UIViewController *
@@ -259,8 +274,15 @@ TopViewControllerForViewController(UIViewController *viewController) {
             return;
           }
 
+          UIViewController *rootViewController = RootViewController();
+          if (!rootViewController) {
+            result([FlutterError errorWithCode:@"error"
+                                       message:@"No root view controller found"
+                                       details:nil]);
+            return;
+          }
           UIViewController *topViewController =
-              TopViewControllerForViewController(RootViewController());
+              TopViewControllerForViewController(rootViewController);
 
           [self shareText:shareText
                      subject:shareSubject
@@ -293,8 +315,15 @@ TopViewControllerForViewController(UIViewController *viewController) {
             }
           }
 
+          UIViewController *rootViewController = RootViewController();
+          if (!rootViewController) {
+            result([FlutterError errorWithCode:@"error"
+                                       message:@"No root view controller found"
+                                       details:nil]);
+            return;
+          }
           UIViewController *topViewController =
-              TopViewControllerForViewController(RootViewController());
+              TopViewControllerForViewController(rootViewController);
           [self shareFiles:paths
                 withMimeType:mimeTypes
                  withSubject:subject

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 4.4.0
+version: 4.5.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus


### PR DESCRIPTION
## Description

`UIApplication.keyWindow` is deprecated in iOS 13+, leading to iOS 13+ applications built with the `share_plus` plugin to emit deprecation warnings on build. In addition, `UIApplication.keyWindow` is not guaranteed to work in the future.

This PR changes the `RootViewController()` function to check if the iOS version is `>13`, and if so, uses the new approach instead of `UIApplication.keyWindow`.

See https://stackoverflow.com/questions/57134259/how-to-resolve-keywindow-was-deprecated-in-ios-13-0#answer-58031897 for more information.

I have tested this change using the `share_plus` example on the iOS Simulator.

## Related Issues

Fixes #917

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated the version in `pubspec.yaml` and `CHANGELOG.md`.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
