### PR TITLE
Fix #1162 device_info_plus federated plugin versions

### DIFF
--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.1
+
+- Fixing federated plugin architecture versions.
+
 ## 5.0.0
 
 - Re-introduce: Added more information to `WindowsDeviceInfo`.

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 5.0.0
+version: 5.0.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus
@@ -27,9 +27,9 @@ dependencies:
   flutter:
     sdk: flutter
   device_info_plus_platform_interface: ^4.0.0
-  device_info_plus_macos: ^3.0.0
-  device_info_plus_linux: ^3.0.0
-  device_info_plus_web: ^3.0.0
+  device_info_plus_macos: ^4.0.0
+  device_info_plus_linux: ^4.0.0
+  device_info_plus_web: ^4.0.0
   device_info_plus_windows: ^5.0.0
 
 dev_dependencies:

--- a/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0
+
+- platform interface to 4.0.0
+
 ## 3.0.0
 
 - platform interface to 3.0.0

--- a/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_linux
 description: Linux implementation of the device_info_plus plugin
-version: 3.0.0
+version: 4.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^3.0.0
+  device_info_plus_platform_interface: ^4.0.0
   file: ^6.0.0
   flutter:
     sdk: flutter

--- a/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0
+
+- platform interface to 4.0.0
+
 ## 3.0.0
 
 - platform interface to 3.0.0

--- a/packages/device_info_plus/device_info_plus_macos/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_macos/pubspec.yaml
@@ -2,14 +2,14 @@ name: device_info_plus_macos
 description: Macos implementation of the device_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 3.0.0
+version: 4.0.0
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^3.0.0
+  device_info_plus_platform_interface: ^4.0.0
   flutter:
     sdk: flutter
 

--- a/packages/device_info_plus/device_info_plus_web/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0
+
+- platform interface to 4.0.0
+
 ## 3.0.0
 
 - platform interface to 3.0.0

--- a/packages/device_info_plus/device_info_plus_web/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_web
 description: An implementation for the web platform of the Flutter `device_info_plus` plugin.
-version: 3.0.0
+version: 4.0.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -12,7 +12,7 @@ flutter:
         fileName: device_info_plus_web.dart
 
 dependencies:
-  device_info_plus_platform_interface: ^3.0.0
+  device_info_plus_platform_interface: ^4.0.0
   flutter_web_plugins:
     sdk: flutter
   flutter:


### PR DESCRIPTION
Plugin already published under 5.0.1, this PR is just to save the changes.