### PR TITLE
chore(release): prepare for release

### DIFF
--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 3.1.3
 
- - **FIX**: fixed a bug! (#585).
- - **FIX**: Remove embedding v1 reference & update dependencies (#507).
+ - **CHORE**: Version tagging using melos.
 
 ## 3.1.2
 

--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.3
+
+ - **FIX**: fixed a bug! (#585).
+ - **FIX**: Remove embedding v1 reference & update dependencies (#507).
+
 ## 3.1.2
 
 - Fix explicit intent fallback to implicit

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 3.1.2
+version: 3.1.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/android_intent_plus

--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 2.3.9
 
- - **FIX**: Reduce compiler warnings (#1068).
- - **FIX**: Reachability.swift ".unavailable" is deprecated (#823).
+ - **CHORE**: Version tagging using melos.
 
 ## 2.3.8
 

--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.9
+
+ - **FIX**: Reduce compiler warnings (#1068).
+ - **FIX**: Reachability.swift ".unavailable" is deprecated (#823).
+
 ## 2.3.8
 
 - Discard unused warnings for `ensurePathMonitor` & `ensureReachability` call in iOS.

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 2.3.8
+version: 2.3.9
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/connectivity_plus
@@ -32,7 +32,7 @@ dependencies:
   connectivity_plus_platform_interface: ^1.2.0
   connectivity_plus_linux: ^1.3.0
   connectivity_plus_macos: ^1.2.4
-  connectivity_plus_web: ^1.2.3
+  connectivity_plus_web: ^1.2.5
   connectivity_plus_windows: ^1.2.2
 
 dev_dependencies:

--- a/packages/connectivity_plus/connectivity_plus_web/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.2.5
 
- - **FIX**: stream fallback for unsupported browsers (#746).
+ - **CHORE**: Version tagging using melos.
 
 ## 1.2.4
 
@@ -18,7 +18,6 @@
 
 - Update flutter_lints to 2.0.1
 - Update dev dependencies
->>>>>>> main
 
 ## 1.2.0
 

--- a/packages/connectivity_plus/connectivity_plus_web/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.5
+
+ - **FIX**: stream fallback for unsupported browsers (#746).
+
 ## 1.2.4
 
 - Fix stream fallback for unsupported browsers

--- a/packages/connectivity_plus/connectivity_plus_web/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus_web
 description: An implementation for the web platform of the Flutter `connectivity_plus` plugin. This uses the NetworkInformation Web API, with a fallback to Navigator.onLine.
-version: 1.2.4
+version: 1.2.5
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 5.1.0
+
+ - **FIX**: Updated the description of getAndroidId method  (#807).
+ - **FIX**: Upgrade gradle, android compile version & implement code improvements (#511).
+ - **FEAT**: more info for Windows (re-land #814) (#1156).
+ - **FEAT**: add toMap method to WebBrowserInfo (#593).
+
 ## 5.0.1
 
 - Fixing federated plugin architecture versions.

--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,9 +1,6 @@
-## 5.1.0
+## 5.0.2
 
- - **FIX**: Updated the description of getAndroidId method  (#807).
- - **FIX**: Upgrade gradle, android compile version & implement code improvements (#511).
- - **FEAT**: more info for Windows (re-land #814) (#1156).
- - **FEAT**: add toMap method to WebBrowserInfo (#593).
+ - **CHORE**: Version tagging using melos.
 
 ## 5.0.1
 

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 5.1.0
+version: 5.0.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 5.0.1
+version: 5.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus
@@ -26,12 +26,11 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus_platform_interface: ^4.0.0
-  device_info_plus_macos: ^4.0.0
-  device_info_plus_linux: ^4.0.0
-  device_info_plus_web: ^4.0.0
-  device_info_plus_windows: ^5.0.0
-
+  device_info_plus_platform_interface: ^4.1.0
+  device_info_plus_macos: ^4.0.1
+  device_info_plus_linux: ^4.0.1
+  device_info_plus_web: ^4.0.1
+  device_info_plus_windows: ^5.1.0
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+ - Update a dependency to the latest release.
+
 ## 4.0.0
 
 - platform interface to 4.0.0

--- a/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_linux/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.0.1
 
- - Update a dependency to the latest release.
+ - **CHORE**: Version tagging using melos.
 
 ## 4.0.0
 

--- a/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_linux/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_linux
 description: Linux implementation of the device_info_plus plugin
-version: 4.0.0
+version: 4.0.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^4.0.0
+  device_info_plus_platform_interface: ^4.1.0
   file: ^6.0.0
   flutter:
     sdk: flutter

--- a/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+ - Update a dependency to the latest release.
+
 ## 4.0.0
 
 - platform interface to 4.0.0

--- a/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_macos/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.0.1
 
- - Update a dependency to the latest release.
+ - **CHORE**: Version tagging using melos.
 
 ## 4.0.0
 

--- a/packages/device_info_plus/device_info_plus_macos/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_macos/pubspec.yaml
@@ -2,14 +2,14 @@ name: device_info_plus_macos
 description: Macos implementation of the device_info_plus plugin
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
-version: 4.0.0
+version: 4.0.1
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
   flutter: ">=1.20.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^4.0.0
+  device_info_plus_platform_interface: ^4.1.0
   flutter:
     sdk: flutter
 

--- a/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 4.1.0
+
+ - **FEAT**: more info for Windows (re-land #814) (#1156).
+ - **FEAT**: add toMap method to WebBrowserInfo (#593).
+
 ## 4.0.0
 
 - Re-introduce Windows: Add userName, majorVersion, minorVersion, buildNumber, platformId, csdVersion, servicePackMajor, servicePackMinor, suitMask, productType, reserved, buildLab, buildLabEx, digitalProductId, displayVersion, editionId, installDate, productId, productName, registeredOwner, releaseId, deviceId to WindowsDeviceInfo.

--- a/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
@@ -1,7 +1,6 @@
-## 4.1.0
+## 4.0.1
 
- - **FEAT**: more info for Windows (re-land #814) (#1156).
- - **FEAT**: add toMap method to WebBrowserInfo (#593).
+ - **CHORE**: Version tagging using melos.
 
 ## 4.0.0
 

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_platform_interface
 description: A common platform interface for the device_info_plus plugin.
-version: 4.1.0
+version: 4.0.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_platform_interface
 description: A common platform interface for the device_info_plus plugin.
-version: 4.0.0
+version: 4.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/device_info_plus/device_info_plus_web/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1
+
+ - Update a dependency to the latest release.
+
 ## 4.0.0
 
 - platform interface to 4.0.0

--- a/packages/device_info_plus/device_info_plus_web/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 4.0.1
 
- - Update a dependency to the latest release.
+ - **CHORE**: Version tagging using melos.
 
 ## 4.0.0
 

--- a/packages/device_info_plus/device_info_plus_web/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_web
 description: An implementation for the web platform of the Flutter `device_info_plus` plugin.
-version: 4.0.0
+version: 4.0.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -12,7 +12,7 @@ flutter:
         fileName: device_info_plus_web.dart
 
 dependencies:
-  device_info_plus_platform_interface: ^4.0.0
+  device_info_plus_platform_interface: ^4.1.0
   flutter_web_plugins:
     sdk: flutter
   flutter:

--- a/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
@@ -1,6 +1,6 @@
-## 5.1.0
+## 5.0.1
 
- - **FEAT**: more info for Windows (re-land #814) (#1156).
+ - **CHORE**: Version tagging using melos.
 
 ## 5.0.0
 

--- a/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.0
+
+ - **FEAT**: more info for Windows (re-land #814) (#1156).
+
 ## 5.0.0
 
 - Re-introduce: Add more information to WindowsDeviceInfo

--- a/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_windows
 description: Windows implementation of the device_info_plus plugin
-version: 5.0.0
+version: 5.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  device_info_plus_platform_interface: ^4.0.0
+  device_info_plus_platform_interface: ^4.1.0
   ffi: ^2.0.1
   flutter:
     sdk: flutter

--- a/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_windows/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_windows
 description: Windows implementation of the device_info_plus plugin
-version: 5.1.0
+version: 5.0.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 2.3.1
 
- - **FIX**: fixed a bug! (#1004).
- - **FIX**: Upgrade gradle, android compile version & implement code improvements (#512).
+ - **CHORE**: Version tagging using melos.
 
 ## 2.3.0
 

--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.3.1
+
+ - **FIX**: fixed a bug! (#1004).
+ - **FIX**: Upgrade gradle, android compile version & implement code improvements (#512).
+
 ## 2.3.0
 
 - Android: Use new APIs to get network info on devices with with Android 12 (SDK 31) and newer. Due

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 2.3.0
+version: 2.3.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/network_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/network_info_plus

--- a/packages/sensors_plus/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.4.1
+
+ - **FIX**: iOS calibrated magnetometer (#812).
+ - **FIX**: Upgrade gradle, android compile version & implement code improvements (#513).
+
 ## 1.4.0
 
 - iOS: Corrects magnetometer implementation, returning calibrated values from

--- a/packages/sensors_plus/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## 1.4.1
 
- - **FIX**: iOS calibrated magnetometer (#812).
- - **FIX**: Upgrade gradle, android compile version & implement code improvements (#513).
+ - **CHORE**: Version tagging using melos.
 
 ## 1.4.0
 

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sensors_plus
 description: Flutter plugin for accessing accelerometer, gyroscope, and
   magnetometer sensors.
-version: 1.4.0
+version: 1.4.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/sensors_plus
@@ -20,9 +20,8 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  sensors_plus_web: ^1.1.0
-  sensors_plus_platform_interface: ^1.1.0
-
+  sensors_plus_web: ^1.1.2
+  sensors_plus_platform_interface: ^1.1.2
 dev_dependencies:
   test: ^1.16.4
   flutter_test:

--- a/packages/sensors_plus/sensors_plus_platform_interface/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.2
 
- - **FIX**: iOS calibrated magnetometer (#812).
+ - **CHORE**: Version tagging using melos.
 
 ## 1.1.1
 

--- a/packages/sensors_plus/sensors_plus_platform_interface/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+ - **FIX**: iOS calibrated magnetometer (#812).
+
 ## 1.1.1
 
 - Update flutter_lints to 2.0.1

--- a/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sensors_plus_platform_interface
 description: A common platform interface for the sensors_plus plugin.
-version: 1.1.1
+version: 1.1.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/sensors_plus/sensors_plus_web/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+ - Update a dependency to the latest release.
+
 ## 1.1.1
 
 - Update flutter_lints to 2.0.1

--- a/packages/sensors_plus/sensors_plus_web/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus_web/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.2
 
- - Update a dependency to the latest release.
+ - **CHORE**: Version tagging using melos.
 
 ## 1.1.1
 

--- a/packages/sensors_plus/sensors_plus_web/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sensors_plus_web
 description: The web implementation of sensors_plus
-version: 1.1.1
+version: 1.1.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
@@ -18,7 +18,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  sensors_plus_platform_interface: ^1.1.0
+  sensors_plus_platform_interface: ^1.1.2
   flutter_web_plugins:
     sdk: flutter
 

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.5.3
+
+ - **FIX**: Throw error if sharePositionOrigin not in sourceView (#1038).
+ - **FIX**: Fix 'share text' not showing when share files (#907).
+ - **FIX**: activityViewControllerPlaceholderItem impl (#906).
+ - **FIX**: Upgrade gradle & implement code improvements (#522).
+
 ## 4.5.2
 
 - Update internal dependencies

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,9 +1,6 @@
 ## 4.5.3
 
- - **FIX**: Throw error if sharePositionOrigin not in sourceView (#1038).
- - **FIX**: Fix 'share text' not showing when share files (#907).
- - **FIX**: activityViewControllerPlaceholderItem impl (#906).
- - **FIX**: Upgrade gradle & implement code improvements (#522).
+ - **CHORE**: Version tagging using melos.
 
 ## 4.5.2
 

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 4.5.2
+version: 4.5.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus


### PR DESCRIPTION
## Description

This is the result of running `melos version --no-git-tag-version`.

I'd like to do a patch release using melos following the instructions in the CONTRIBUTING guide.

All packages have the same release message:

```
 - **CHORE**: Version tagging using melos.
 ```

After this gets merged, it will be published and tags created.