### PR TITLE
ci(android_alarm_manager_plus): Add matrix of versions for integration tests

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
-      # Required for Android builds
+          # Required for Android builds
       - uses: actions/setup-java@v1
         with:
           java-version: "11"
@@ -40,15 +40,19 @@ jobs:
   android_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        android-api-level: [21, 26, 32]
+
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Install Flutter"
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
-      # Required for Android builds
+          # Required for Android builds
       - uses: actions/setup-java@v1
         with:
           java-version: "11"
@@ -58,8 +62,10 @@ jobs:
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          arch: x86_64
+          api-level: ${{ matrix.android-api-level }}
+          cores: 3
           target: google_apis
+          arch: x86_64
+          force-avd-creation: false
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android android_alarm_manager_example

--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -23,15 +23,16 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: "Install Flutter"
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
-          # Required for Android builds
-      - uses: actions/setup-java@v1
+        # Required for Android builds
+      - uses: actions/setup-java@v2
         with:
+          distribution: "temurin"
           java-version: "11"
 
       - name: "Build Example"
@@ -52,9 +53,10 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
-          # Required for Android builds
-      - uses: actions/setup-java@v1
+        # Required for Android builds
+      - uses: actions/setup-java@v2
         with:
+          distribution: "temurin"
           java-version: "11"
 
       - name: "Bootstrap Workspace"


### PR DESCRIPTION
## Description

Introduced build matrix so tests run against multiple Android versions. It should help us to be sure that functionality of the plugin isn't broken by some change.

This PR has matrix only for Android alarm manager plus to get initial feedback. If other maintainers agree with suggested strategies in the next PR I will add similar changes for all plugins at once.

Initially I wanted to have 19 as a minimal version, but on 19 I saw such error:
<img width="858" alt="Screenshot 2022-10-09 at 19 43 37" src="https://user-images.githubusercontent.com/13467769/194777702-635e8b33-7630-4c6d-a777-515345831d33.png">

So it seems that `integration_test` doesn't work well with old APIs.
Mid version corresponds to Android O, which is something in the middle of the suggested range.
Max version is 32 as 33 acted strange during my tests on fork.

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

