### PR TITLE
fix(share_plus): Share.shareXFiles resulting in stack-overflow on Windows & Linux

### DIFF
--- a/packages/share_plus/share_plus_linux/lib/share_plus_linux.dart
+++ b/packages/share_plus/share_plus_linux/lib/share_plus_linux.dart
@@ -2,9 +2,10 @@
 library share_plus_linux;
 
 import 'dart:ui';
+import 'package:cross_file/cross_file.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 /// The Linux implementation of SharePlatform.
 class ShareLinux extends SharePlatform {
@@ -48,5 +49,18 @@ class ShareLinux extends SharePlatform {
     Rect? sharePositionOrigin,
   }) {
     throw UnimplementedError('shareFiles() has not been implemented on Linux.');
+  }
+
+  /// Share [XFile] objects with Result.
+  @override
+  Future<ShareResult> shareXFiles(
+    List<XFile> files, {
+    String? subject,
+    String? text,
+    Rect? sharePositionOrigin,
+  }) {
+    throw UnimplementedError(
+      'shareXFiles() has not been implemented on Linux.',
+    );
   }
 }

--- a/packages/share_plus/share_plus_linux/pubspec.yaml
+++ b/packages/share_plus/share_plus_linux/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
+  cross_file: ^0.3.3+2
   share_plus_platform_interface: ^3.0.2
   file: ^6.0.0
   flutter:

--- a/packages/share_plus/share_plus_windows/lib/share_plus_windows.dart
+++ b/packages/share_plus/share_plus_windows/lib/share_plus_windows.dart
@@ -2,9 +2,10 @@
 library share_plus_windows;
 
 import 'dart:ui';
+import 'package:cross_file/cross_file.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:share_plus_windows/src/version_helper.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
 
 /// The fallback Windows implementation of [SharePlatform], for older Windows versions.
@@ -56,6 +57,20 @@ class ShareWindows extends SharePlatform {
     Rect? sharePositionOrigin,
   }) {
     throw UnimplementedError(
-        'shareFiles() has not been implemented on Windows.');
+      'shareFiles() is only available for Windows versions higher than 10.0.${VersionHelper.kWindows10RS5BuildNumber}.',
+    );
+  }
+
+  /// Share [XFile] objects with Result.
+  @override
+  Future<ShareResult> shareXFiles(
+    List<XFile> files, {
+    String? subject,
+    String? text,
+    Rect? sharePositionOrigin,
+  }) {
+    throw UnimplementedError(
+      'shareXFiles() is only available for Windows versions higher than 10.0.${VersionHelper.kWindows10RS5BuildNumber}.',
+    );
   }
 }

--- a/packages/share_plus/share_plus_windows/lib/src/version_helper.dart
+++ b/packages/share_plus/share_plus_windows/lib/src/version_helper.dart
@@ -14,7 +14,7 @@ class VersionHelper {
   ///
   bool isWindows10RS5OrGreater = false;
 
-  static const int _kWindows10RS5BuildNumber = 17763;
+  static const int kWindows10RS5BuildNumber = 17763;
 
   VersionHelper._() {
     if (Platform.isWindows) {
@@ -36,7 +36,7 @@ class VersionHelper {
           void Function(Pointer<OSVERSIONINFOEX>)>('RtlGetVersion');
       rtlGetVersion(pointer);
       isWindows10RS5OrGreater =
-          pointer.ref.dwBuildNumber >= _kWindows10RS5BuildNumber;
+          pointer.ref.dwBuildNumber >= kWindows10RS5BuildNumber;
       calloc.free(pointer);
     }
   }

--- a/packages/share_plus/share_plus_windows/pubspec.yaml
+++ b/packages/share_plus/share_plus_windows/pubspec.yaml
@@ -9,6 +9,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
+  cross_file: ^0.3.3+2
   share_plus_platform_interface: ^3.0.2
   flutter:
     sdk: flutter
@@ -25,6 +26,8 @@ dev_dependencies:
 
 flutter:
   plugin:
+    implements: share_plus
     platforms:
       windows:
+        dartPluginClass: ShareWindows
         pluginClass: SharePlusWindowsPluginCApi


### PR DESCRIPTION
## Description

This pull-request fixes an issue where calling `Share.shareXFiles` caused stack-overflow due to an endless recursion cycle on:
- Windows 10 builds higher than 17763.
- Linux.

Now `shareXFiles` has been overrided in both `ShareLinux` & `ShareWindows` classes, to correctly throw `UnimplementedError` instead. More information may be located at: https://github.com/fluttercommunity/plus_plugins/issues/1180#issuecomment-1272842044.

**NOTE**: This fix should be released for both 4.x.x (currently on pub.dev) & 5.x.x (post #1158 _i.e._ next version).

This pull-request also resolves another issue for older Windows versions (builds lower than 17763), where Dart sided fallback implementation couldn't be registered correctly.

## Related Issues

Closes #1180.

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

