### PR TITLE
ci(all): Add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,412 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+
+# Github Actions dependencies updates config
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+# Website dependencies updates config
+     
+  - package-ecosystem: "npm"
+    directory: "/website"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+      
+# Android Alarm Manager dependencies updates config
+      
+  - package-ecosystem: "pub"
+    directory: "/packages/android_alarm_manager_plus"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/android_alarm_manager_plus/example"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+ # Android Intent Plus dependencies updates config
+      
+  - package-ecosystem: "pub"
+    directory: "/packages/android_intent_plus"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/android_intent_plus/example"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+# Battery Plus dependencies updates config
+
+  - package-ecosystem: "pub"
+    directory: "/packages/battery_plus/battery_plus"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/battery_plus/battery_plus/example"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/battery_plus/battery_plus_platform_interface"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+# Connectivity Plus dependencies updates config
+
+  - package-ecosystem: "pub"
+    directory: "/packages/connectivity_plus/connectivity_plus"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/connectivity_plus/connectivity_plus/example"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/connectivity_plus/connectivity_plus_linux"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/connectivity_plus/connectivity_plus_macos"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/connectivity_plus/connectivity_plus_platform_interface"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/connectivity_plus/connectivity_plus_web"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+      
+  - package-ecosystem: "pub"
+    directory: "/packages/connectivity_plus/connectivity_plus_windows"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+# Device Info Plus dependencies updates config
+
+  - package-ecosystem: "pub"
+    directory: "/packages/device_info_plus/device_info_plus"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/device_info_plus/device_info_plus/example"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/device_info_plus/device_info_plus_linux"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/device_info_plus/device_info_plus_macos"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/device_info_plus/device_info_plus_platform_interface"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/device_info_plus/device_info_plus_web"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/device_info_plus/device_info_plus_windows"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+# Network Info Plus dependencies updates config
+
+  - package-ecosystem: "pub"
+    directory: "/packages/network_info_plus/network_info_plus"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/network_info_plus/network_info_plus/example"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/network_info_plus/network_info_plus_linux"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/network_info_plus/network_info_plus_macos"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/network_info_plus/network_info_plus_platform_interface"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/network_info_plus/network_info_plus_web"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/network_info_plus/network_info_plus_windows"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+# Package Info Plus dependencies updates config
+
+  - package-ecosystem: "pub"
+    directory: "/packages/package_info_plus/package_info_plus"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/package_info_plus/package_info_plus/example"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/package_info_plus/package_info_plus_linux"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/package_info_plus/package_info_plus_macos"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/package_info_plus/package_info_plus_platform_interface"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/package_info_plus/package_info_plus_web"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/package_info_plus/package_info_plus_windows"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+# Sensors Plus dependencies updates config
+
+  - package-ecosystem: "pub"
+    directory: "/packages/sensors_plus/sensors_plus"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/sensors_plus/sensors_plus/example"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/sensors_plus/sensors_plus_platform_interface"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/sensors_plus/sensors_plus_web"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+# Share Plus dependencies updates config
+
+  - package-ecosystem: "pub"
+    directory: "/packages/share_plus/share_plus"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/share_plus/share_plus/example"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/share_plus/share_plus_linux"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/share_plus/share_plus_macos"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/share_plus/share_plus_platform_interface"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/share_plus/share_plus_web"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "pub"
+    directory: "/packages/share_plus/share_plus_windows"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Description

Introducing Dependabot config to automate dependencies updates for all Github Actions, website and plugins dependencies.

The config is that big because I had to specify exact folder for all `pubspec.yaml` files we have in the repo as Dependabot doesn't support multiple directories search yet: https://github.com/dependabot/dependabot-core/issues/2824

Current setup is basic with once in a week check, but we can customise quite a lot of params if needed:
https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates

Commits will follow a proper conventional commits naming, so it won't be breaking for the newly introduced contribution process:
<img width="912" alt="Screenshot 2022-10-11 at 14 36 17" src="https://user-images.githubusercontent.com/13467769/195079824-6690d1f8-135e-4ac3-bc88-ceb2879e06b0.png">

Be aware that during its first run Dependabot will open lots of PRs. If needed, we can set an upper limit for amounts of PRs as well to not spam our `Pull requests` section first time. But I would leave it as it is for now.

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

