### PR TITLE
fix(share_plus): Show NSSharingServicePicker asynchronously on main thread

### DIFF
--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -5,13 +5,12 @@
 // ignore_for_file: public_member_api_docs
 
 import 'dart:io';
+import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:image_picker/image_picker.dart';
 
 import 'image_previews.dart';
-import 'utils/file_picker_win.dart'
-    if (dart.library.html) 'utils/file_picker_web.dart';
 
 void main() {
   runApp(const DemoApp());
@@ -71,13 +70,20 @@ class DemoAppState extends State<DemoApp> {
                     title: const Text('Add image'),
                     onTap: () async {
                       // Using `package:image_picker` to get image from gallery.
-                      if (Platform.isWindows) {
-                        // Using `package:filepicker_windows` on Windows, since `package:image_picker` is not supported.
-                        final path = await pickFile();
-                        if (path != null) {
+                      if (Platform.isMacOS ||
+                          Platform.isLinux ||
+                          Platform.isWindows) {
+                        // Using `package:file_selector` on windows, macos & Linux, since `package:image_picker` is not supported.
+                        const XTypeGroup typeGroup = XTypeGroup(
+                          label: 'images',
+                          extensions: <String>['jpg', 'jpeg', 'png', 'gif'],
+                        );
+                        final file = await openFile(
+                            acceptedTypeGroups: <XTypeGroup>[typeGroup]);
+                        if (file != null) {
                           setState(() {
-                            imagePaths.add(path);
-                            imageNames.add(path.split('\\').last);
+                            imagePaths.add(file.path);
+                            imageNames.add(file.name);
                           });
                         }
                       } else {

--- a/packages/share_plus/share_plus/example/lib/utils/file_picker_web.dart
+++ b/packages/share_plus/share_plus/example/lib/utils/file_picker_web.dart
@@ -1,4 +1,0 @@
-/// Dummy implementation for non `dart.library.io` platforms.
-Future<String?> pickFile() async {
-  throw UnimplementedError();
-}

--- a/packages/share_plus/share_plus/example/lib/utils/file_picker_win.dart
+++ b/packages/share_plus/share_plus/example/lib/utils/file_picker_win.dart
@@ -1,9 +1,0 @@
-import 'package:filepicker_windows/filepicker_windows.dart';
-
-/// Picks a file from the file system on Windows & returns it's path as [String].
-Future<String?> pickFile() async {
-  final picker = OpenFilePicker()
-    ..filterSpecification = {'Images': '*.jpg;*.jpeg;*.png;*.gif'};
-  final result = picker.getFile();
-  return result?.path;
-}

--- a/packages/share_plus/share_plus/example/macos/Runner/DebugProfile.entitlements
+++ b/packages/share_plus/share_plus/example/macos/Runner/DebugProfile.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.server</key>
 	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+  <true/>
 </dict>
 </plist>

--- a/packages/share_plus/share_plus/example/macos/Runner/Release.entitlements
+++ b/packages/share_plus/share_plus/example/macos/Runner/Release.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<false/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+  	<true/>
 </dict>
 </plist>

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -7,7 +7,7 @@ dependencies:
   share_plus:
     path: ../
   image_picker: ^0.8.4
-  filepicker_windows: ^2.0.2
+  file_selector: ^0.9.2+1
 
 dependency_overrides:
   share_plus_linux:

--- a/packages/share_plus/share_plus_macos/macos/Classes/SharePlusMacosPlugin.swift
+++ b/packages/share_plus/share_plus_macos/macos/Classes/SharePlusMacosPlugin.swift
@@ -56,7 +56,9 @@ public class SharePlusMacosPlugin: NSObject, FlutterPlugin, NSSharingServicePick
       picker.delegate = self
       self.subject = subject
     }
-    picker.show(relativeTo: origin, of: view, preferredEdge: NSRectEdge.maxY)
+    DispatchQueue.main.async {
+      picker.show(relativeTo: origin, of: view, preferredEdge: NSRectEdge.maxY)
+    }
   }
 
   private func originRect(_ args: [String: Any]) -> NSRect {

--- a/packages/share_plus/share_plus_macos/macos/Classes/SharePlusMacosPlugin.swift
+++ b/packages/share_plus/share_plus_macos/macos/Classes/SharePlusMacosPlugin.swift
@@ -49,14 +49,14 @@ public class SharePlusMacosPlugin: NSObject, FlutterPlugin, NSSharingServicePick
   }
 
   private func shareItems(_ items: [Any], subject: String? = nil, origin: NSRect, view: NSView, callback: FlutterResult? = nil) {
-    let picker = NSSharingServicePicker(items: items)
-    if callback != nil {
-      picker.delegate = SharePlusMacosSuccessDelegate(subject: subject, callback: callback!).keep()
-    } else {
-      picker.delegate = self
-      self.subject = subject
-    }
     DispatchQueue.main.async {
+      let picker = NSSharingServicePicker(items: items)
+      if callback != nil {
+        picker.delegate = SharePlusMacosSuccessDelegate(subject: subject, callback: callback!).keep()
+      } else {
+        picker.delegate = self
+        self.subject = subject
+      }
       picker.show(relativeTo: origin, of: view, preferredEdge: NSRectEdge.maxY)
     }
   }


### PR DESCRIPTION
## Description

In the MacOS implementation of share_plus show the `NSSharingServicePicker` asynchronously.

For testing purpose i've update the corresponding sample app :  
replace filepicker_windows with file_selector, for a working sample in all desktop (MacOS, Windows, Linux).

## Related Issues

- Related #1177

## Checklist

- [X] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.

