### PR TITLE
docs(android_alarm_manager_plus): Fix example and docs to explain required annotation

### DIFF
--- a/docs/android_alarm_manager_plus/usage.mdx
+++ b/docs/android_alarm_manager_plus/usage.mdx
@@ -40,6 +40,8 @@ Then in Dart code add:
 ```dart
 import 'package:android_alarm_manager_plus/android_alarm_manager_plus.dart';
 
+// Be sure to annotate your callback function to avoid issues in release mode on Flutter >= 3.3.0
+@pragma('vm:entry-point')
 void printHello() {
   final DateTime now = DateTime.now();
   final int isolateId = Isolate.current.hashCode;

--- a/packages/android_alarm_manager_plus/README.md
+++ b/packages/android_alarm_manager_plus/README.md
@@ -56,6 +56,8 @@ Then in Dart code add:
 ```dart
 import 'package:android_alarm_manager_plus/android_alarm_manager_plus.dart';
 
+// Be sure to annotate your callback function to avoid issues in release mode on Flutter >= 3.3.0
+@pragma('vm:entry-point')
 static void printHello() {
   final DateTime now = DateTime.now();
   final int isolateId = Isolate.current.hashCode;

--- a/packages/android_alarm_manager_plus/example/lib/main.dart
+++ b/packages/android_alarm_manager_plus/example/lib/main.dart
@@ -91,6 +91,7 @@ class _AlarmHomePageState extends State<_AlarmHomePage> {
   static SendPort? uiSendPort;
 
   // The callback for our alarm
+  @pragma('vm:entry-point')
   static Future<void> callback() async {
     developer.log('Alarm fired!');
     // Get the previous cached count and increment it.


### PR DESCRIPTION
## Description

Fix for a problem with `android_alarm_manager_plus` not working in release mode on Flutter 3.3.0 and newer.
It seems that due to recent changes to a tree-shaking quite a few plugins started to have issues with isolates when app is built in release mode.

The main requirement is to annotate the callback function with `@pragma('vm:entry-point')` in the app where the plugin is used. So I have updated the README and docs to mention this requirement.

Here is the list with similar issues or issues on topic:
https://github.com/flutter/flutter/issues/109248
https://github.com/firebase/flutterfire/issues/9446
https://www.reddit.com/r/flutterhelp/comments/x3tq8l/package_not_found_in_release_but_there_in_debug/

And this is the issue about missing documentation update about the change that broke multiple plugins in the community:
https://github.com/flutter/website/issues/7564

## Related Issues

Closes #1077 

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

