### PR TITLE
fix(network_info_plus): Get SSID on Android 12 and newer

### DIFF
--- a/packages/network_info_plus/network_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/network_info/NetworkInfo.kt
+++ b/packages/network_info_plus/network_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/network_info/NetworkInfo.kt
@@ -7,19 +7,12 @@ import android.os.Build
 import java.net.*
 
 /** Reports network info such as wifi name and address. */
-internal class NetworkInfo(private val wifiManager: WifiManager?,
+internal class NetworkInfo(private val wifiManager: WifiManager,
                            private val connectivityManager: ConnectivityManager? = null
 ) {
 
     private val wifiInfo: WifiInfo?
-        get() =
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                val currentNetwork = connectivityManager?.activeNetwork
-                connectivityManager?.getNetworkCapabilities(currentNetwork)?.transportInfo as WifiInfo?
-            } else {
-                @Suppress("DEPRECATION")
-                wifiManager?.connectionInfo
-            }
+        get() = wifiManager.connectionInfo
 
     // Android returns "SSID"
     fun getWifiName(): String? = wifiInfo?.ssid
@@ -103,7 +96,7 @@ internal class NetworkInfo(private val wifiManager: WifiManager?,
             dhcpServer
         } else {
             @Suppress("DEPRECATION")
-            val dhcpInfo = wifiManager?.dhcpInfo
+            val dhcpInfo = wifiManager.dhcpInfo
             val gatewayIPInt = dhcpInfo?.gateway
 
             gatewayIPInt?.let { formatIPAddress(it) }

--- a/packages/network_info_plus/network_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/network_info/NetworkInfo.kt
+++ b/packages/network_info_plus/network_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/network_info/NetworkInfo.kt
@@ -11,13 +11,15 @@ internal class NetworkInfo(private val wifiManager: WifiManager,
                            private val connectivityManager: ConnectivityManager? = null
 ) {
 
-    private val wifiInfo: WifiInfo?
+    // Using deprecated `connectionInfo` call here to be able to get info on demand
+    @Suppress("DEPRECATION")
+    private val wifiInfo: WifiInfo
         get() = wifiManager.connectionInfo
 
     // Android returns "SSID"
-    fun getWifiName(): String? = wifiInfo?.ssid
+    fun getWifiName(): String? = wifiInfo.ssid
 
-    fun getWifiBSSID(): String? = wifiInfo?.bssid
+    fun getWifiBSSID(): String? = wifiInfo.bssid
 
     fun getWifiIPAddress(): String? {
         var ipAddress: String? = null
@@ -82,7 +84,7 @@ internal class NetworkInfo(private val wifiManager: WifiManager,
                     }
                 }
             }
-        } catch (socketException: SocketException) {
+        } catch (ignored: SocketException) {
 
         }
         return null


### PR DESCRIPTION
## Description

As it turned out in Android 12 and newer `SSID` and `BSSID` are considered a location sensitive info, thus the new API to get WifiInfo via `getNetworkCapabilities()` returned all info except these 2 values. And it doesn't matter that app has required permissions. Explanation is provided in the official docs:
https://developer.android.com/reference/android/net/ConnectivityManager#getNetworkCapabilities(android.net.Network)

The suggested way to register a callback with [required flag](https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback#FLAG_INCLUDE_LOCATION_INFO) seems not the best option for the `network_info_plus` as we want to get info on demand, not wait till something changes in network configuration. 

It seems we are not the only ones, who issue this problem: https://stackoverflow.com/questions/71281724/getting-wifi-ssid-from-connectivitymanager-networkcapabilities-synchronously

Based on the info above I decided to revert one of changes I made in #1151 and rely on deprecated function to get needed required info. I think we are safe to live till time comes to kill this deprecated API in next Android releases. However, hope that Google introduces some better API to not have only callbacks way.

## Related Issues

Closes #1181 

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

