### PR TITLE
ci(all): Add Android build matrix for all plugins

### DIFF
--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -41,6 +41,10 @@ jobs:
   android_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        android-api-level: [ 21, 26, 32 ]
+
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
@@ -61,8 +65,10 @@ jobs:
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          arch: x86_64
+          api-level: ${{ matrix.android-api-level }}
+          cores: 3
           target: google_apis
+          arch: x86_64
+          force-avd-creation: false
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android android_intent_example

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -45,6 +45,10 @@ jobs:
   android_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        android-api-level: [ 21, 26, 32 ]
+
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
@@ -64,9 +68,11 @@ jobs:
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          arch: x86_64
+          api-level: ${{ matrix.android-api-level }}
+          cores: 3
           target: google_apis
+          arch: x86_64
+          force-avd-creation: false
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android battery_plus_example
 

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
@@ -45,6 +45,10 @@ jobs:
   android_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        android-api-level: [ 21, 26, 32 ]
+
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
@@ -57,16 +61,18 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          arch: x86_64
+          api-level: ${{ matrix.android-api-level }}
+          cores: 3
           target: google_apis
+          arch: x86_64
+          force-avd-creation: false
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android connectivity_plus_example
 

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
@@ -57,16 +57,18 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          arch: x86_64
+          api-level: ${{ matrix.android-api-level }}
+          cores: 3
           target: google_apis
+          arch: x86_64
+          force-avd-creation: false
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android device_info_plus_example
 
@@ -113,7 +115,7 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
-    
+
   macos_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -45,6 +45,10 @@ jobs:
   android_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        android-api-level: [ 21, 26, 32 ]
+
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
@@ -45,6 +45,10 @@ jobs:
   android_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        android-api-level: [ 21, 26, 32 ]
+
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
@@ -57,7 +61,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap
@@ -65,9 +69,11 @@ jobs:
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          arch: x86_64
+          api-level: ${{ matrix.android-api-level }}
+          cores: 3
           target: google_apis
+          arch: x86_64
+          force-avd-creation: false
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android network_info_plus_example
 

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
@@ -45,6 +45,10 @@ jobs:
   android_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        android-api-level: [ 21, 26, 32 ]
+
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
@@ -57,16 +61,18 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          arch: x86_64
+          api-level: ${{ matrix.android-api-level }}
+          cores: 3
           target: google_apis
+          arch: x86_64
+          force-avd-creation: false
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android package_info_plus_example
 
@@ -138,7 +144,7 @@ jobs:
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
- 
+
   linux_integration_test:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
@@ -41,6 +41,10 @@ jobs:
   android_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        android-api-level: [ 21, 26, 32 ]
+
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
@@ -53,16 +57,18 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          arch: x86_64
+          api-level: ${{ matrix.android-api-level }}
+          cores: 3
           target: google_apis
+          arch: x86_64
+          force-avd-creation: false
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android sensors_plus_example
 

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
@@ -45,6 +45,10 @@ jobs:
   android_integration_test:
     runs-on: macos-latest
     timeout-minutes: 30
+    strategy:
+      matrix:
+        android-api-level: [ 21, 26, 32 ]
+
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
@@ -57,16 +61,18 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: '11'
+          java-version: "11"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 30
-          arch: x86_64
+          api-level: ${{ matrix.android-api-level }}
+          cores: 3
           target: google_apis
+          arch: x86_64
+          force-avd-creation: false
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android share_plus_example
 
@@ -138,7 +144,7 @@ jobs:
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh linux ./lib/main.dart
-     
+
   linux_integration_test:
     if: false # TODO: enable this if it is possible to register a mailto protocol handler on github hosted runners
     runs-on: ubuntu-latest
@@ -151,7 +157,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Run Integration Test"
-        run: ./.github/workflows/scripts/integration-test.sh linux share_plus_example  
+        run: ./.github/workflows/scripts/integration-test.sh linux share_plus_example
 
   windows:
     runs-on: windows-latest


### PR DESCRIPTION
## Description

Updating workflows to run Android integration tests on different API levels for all plugins, like I recently did in #1184

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

