### PR TITLE
test(device_info_plus): Add Android display metrics check, fix Android version check

### DIFF
--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -78,14 +78,16 @@ void main() {
 
   testWidgets('Check all android info values are available',
       (WidgetTester tester) async {
-    expect(androidInfo.version.baseOS, isNotNull);
+    if (androidInfo.version.sdkInt >= 23) {
+      expect(androidInfo.version.baseOS, isNotNull);
+      expect(androidInfo.version.previewSdkInt, isNotNull);
+      expect(androidInfo.version.securityPatch, isNotNull);
+    }
+
     expect(androidInfo.version.codename, isNotNull);
     expect(androidInfo.version.incremental, isNotNull);
-    expect(androidInfo.version.previewSdkInt, isNotNull);
     expect(androidInfo.version.release, isNotNull);
     expect(androidInfo.version.sdkInt, isNotNull);
-    expect(androidInfo.version.securityPatch, isNotNull);
-
     expect(androidInfo.board, isNotNull);
     expect(androidInfo.bootloader, isNotNull);
     expect(androidInfo.brand, isNotNull);

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -83,7 +83,7 @@ void main() {
     expect(androidInfo.version.incremental, isNotNull);
     expect(androidInfo.version.previewSdkInt, isNotNull);
     expect(androidInfo.version.release, isNotNull);
-    expect(androidInfo.version.sdkInt, equals(30));
+    expect(androidInfo.version.sdkInt, isNotNull);
     expect(androidInfo.version.securityPatch, isNotNull);
 
     expect(androidInfo.board, isNotNull);

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -94,6 +94,11 @@ void main() {
     expect(androidInfo.fingerprint, isNotNull);
     expect(androidInfo.hardware, isNotNull);
 
+    expect(androidInfo.displayMetrics.heightPx, isNotNull);
+    expect(androidInfo.displayMetrics.widthPx, isNotNull);
+    expect(androidInfo.displayMetrics.yDpi, isNotNull);
+    expect(androidInfo.displayMetrics.xDpi, isNotNull);
+
     expect(androidInfo.host, isNotNull);
     expect(androidInfo.id, isNotNull);
     expect(androidInfo.manufacturer, isNotNull);


### PR DESCRIPTION
## Description

After adding an Android build matrix saw that [integration tests fail ](https://github.com/fluttercommunity/plus_plugins/actions/runs/3244740493/jobs/5321314320)for `device_info_plus` on newly added Andoid APIs. As it turned out there was a hardcoded version of Android (30), which caused test to fail on all other versions.
Also, saw that same test was missing check for a newly added device metrics data, so added it as well.

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

