### PR TITLE
docs(device_info_plus): Add info about Android properties availability, update API docs links

### DIFF
--- a/docs/device_info_plus/overview.mdx
+++ b/docs/device_info_plus/overview.mdx
@@ -7,6 +7,7 @@ hide_title: true
 ## Device Info Plus Overview
 
 Get current device information from within the Flutter application.
+Full list of properties returned for every platform can be found in [the API docs](https://pub.dev/packages/device_info_plus).
 
 ### Get started
 

--- a/docs/device_info_plus/overview.mdx
+++ b/docs/device_info_plus/overview.mdx
@@ -7,7 +7,8 @@ hide_title: true
 ## Device Info Plus Overview
 
 Get current device information from within the Flutter application.
-Full list of properties returned for every platform can be found in [the API docs](https://pub.dev/packages/device_info_plus).
+
+Full list of properties returned for every platform can be found in [the API docs](https://pub.dev/documentation/device_info_plus/latest/).
 
 ### Get started
 

--- a/docs/device_info_plus/usage.mdx
+++ b/docs/device_info_plus/usage.mdx
@@ -25,5 +25,3 @@ print('Running on ${iosInfo.utsname.machine}');  // e.g. "iPod7,1"
 WebBrowserInfo webBrowserInfo = await deviceInfo.webBrowserInfo;
 print('Running on ${webBrowserInfo.userAgent}');  // e.g. "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0"
 ```
-
-You will find links to the API docs on the [pub page](https://pub.dev/packages/device_info_plus).

--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -48,6 +48,6 @@ final deviceInfoPlugin = DeviceInfoPlugin();
 final deviceInfo = await deviceInfoPlugin.deviceInfo;
 ```
 
-You will find links to the API docs on the [pub page](https://pub.dev/packages/device_info_plus).
+You will find links to the API docs on the [pub page](https://pub.dev/documentation/device_info_plus/latest/).
 
 Check out our documentation website to learn more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/overview)

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
@@ -77,12 +77,15 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
   final String? product;
 
   /// An ordered list of 32 bit ABIs supported by this device.
+  /// Available only on Android L (API 21) and newer
   final List<String?> supported32BitAbis;
 
   /// An ordered list of 64 bit ABIs supported by this device.
+  /// Available only on Android L (API 21) and newer
   final List<String?> supported64BitAbis;
 
   /// An ordered list of ABIs supported by this device.
+  /// Available only on Android L (API 21) and newer
   final List<String?> supportedAbis;
 
   /// Comma-separated tags describing the build, like "unsigned,debug".
@@ -194,12 +197,14 @@ class AndroidBuildVersion {
   });
 
   /// The base OS build the product is based on.
+  /// Available only on Android M (API 23) and newer
   final String? baseOS;
 
   /// The current development codename, or the string "REL" if this is a release build.
   final String? codename;
 
   /// The internal value used by the underlying source control to represent this build.
+  /// Available only on Android M (API 23) and newer
   final String? incremental;
 
   /// The developer preview revision of a prerelease SDK.
@@ -214,6 +219,7 @@ class AndroidBuildVersion {
   final int? sdkInt;
 
   /// The user-visible security patch level.
+  /// Available only on Android M (API 23) and newer
   final String? securityPatch;
 
   /// Serializes [ AndroidBuildVersion ] to map.


### PR DESCRIPTION
## Description

Adding more info to some of `AndroidDeviceInfo` properties, so it is clear which properties might be null on some older platforms.

Saw that links to API documentation on the website and README redirected users just to pub.dev page of the `device_info_plus`, so updated the link. Also added the same link to the `Overview` page explaining to users that they can find the full list of properties there.

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

