### PR TITLE
refactor(device_info_plus)!: Change nullability for AndroidDeviceInfo properties

### DIFF
--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
@@ -209,8 +209,8 @@ class AndroidBuildVersion {
   /// Available only on Android M (API 23) and newer
   final String incremental;
 
-  /// The developer preview revision of a prerelease SDK.
-  final int previewSdkInt;
+  /// The developer preview revision of a pre-release SDK.
+  final int? previewSdkInt;
 
   /// The user-visible version string.
   final String release;

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
@@ -12,24 +12,24 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
   /// Android device Info class.
   AndroidDeviceInfo({
     required this.version,
-    this.board,
-    this.bootloader,
-    this.brand,
-    this.device,
-    this.display,
-    this.fingerprint,
-    this.hardware,
-    this.host,
-    this.id,
-    this.manufacturer,
-    this.model,
-    this.product,
+    required this.board,
+    required this.bootloader,
+    required this.brand,
+    required this.device,
+    required this.display,
+    required this.fingerprint,
+    required this.hardware,
+    required this.host,
+    required this.id,
+    required this.manufacturer,
+    required this.model,
+    required this.product,
     required List<String?> supported32BitAbis,
     required List<String?> supported64BitAbis,
     required List<String?> supportedAbis,
-    this.tags,
-    this.type,
-    this.isPhysicalDevice,
+    required this.tags,
+    required this.type,
+    required this.isPhysicalDevice,
     required List<String?> systemFeatures,
     required this.displayMetrics,
   })  : supported32BitAbis = List<String?>.unmodifiable(supported32BitAbis),
@@ -41,40 +41,40 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
   final AndroidBuildVersion version;
 
   /// The name of the underlying board, like "goldfish".
-  final String? board;
+  final String board;
 
   /// The system bootloader version number.
-  final String? bootloader;
+  final String bootloader;
 
   /// The consumer-visible brand with which the product/hardware will be associated, if any.
-  final String? brand;
+  final String brand;
 
   /// The name of the industrial design.
-  final String? device;
+  final String device;
 
   /// A build ID string meant for displaying to the user.
-  final String? display;
+  final String display;
 
   /// A string that uniquely identifies this build.
-  final String? fingerprint;
+  final String fingerprint;
 
   /// The name of the hardware (from the kernel command line or /proc).
-  final String? hardware;
+  final String hardware;
 
   /// Hostname.
-  final String? host;
+  final String host;
 
   /// Either a changelist number, or a label like "M4-rc20".
-  final String? id;
+  final String id;
 
   /// The manufacturer of the product/hardware.
-  final String? manufacturer;
+  final String manufacturer;
 
   /// The end-user-visible name for the end product.
-  final String? model;
+  final String model;
 
   /// The name of the overall product.
-  final String? product;
+  final String product;
 
   /// An ordered list of 32 bit ABIs supported by this device.
   /// Available only on Android L (API 21) and newer
@@ -89,13 +89,13 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
   final List<String?> supportedAbis;
 
   /// Comma-separated tags describing the build, like "unsigned,debug".
-  final String? tags;
+  final String tags;
 
   /// The type of build, like "user" or "eng".
-  final String? type;
+  final String type;
 
   /// `false` if the application is running in an emulator, `true` otherwise.
-  final bool? isPhysicalDevice;
+  final bool isPhysicalDevice;
 
   /// Describes what features are available on the current device.
   ///
@@ -188,11 +188,11 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
 class AndroidBuildVersion {
   const AndroidBuildVersion._({
     this.baseOS,
-    this.codename,
-    this.incremental,
-    this.previewSdkInt,
-    this.release,
-    this.sdkInt,
+    required this.codename,
+    required this.incremental,
+    required this.previewSdkInt,
+    required this.release,
+    required this.sdkInt,
     this.securityPatch,
   });
 
@@ -201,22 +201,22 @@ class AndroidBuildVersion {
   final String? baseOS;
 
   /// The current development codename, or the string "REL" if this is a release build.
-  final String? codename;
+  final String codename;
 
   /// The internal value used by the underlying source control to represent this build.
   /// Available only on Android M (API 23) and newer
-  final String? incremental;
+  final String incremental;
 
   /// The developer preview revision of a prerelease SDK.
-  final int? previewSdkInt;
+  final int previewSdkInt;
 
   /// The user-visible version string.
-  final String? release;
+  final String release;
 
   /// The user-visible SDK version of the framework.
   ///
   /// Possible values are defined in: https://developer.android.com/reference/android/os/Build.VERSION_CODES.html
-  final int? sdkInt;
+  final int sdkInt;
 
   /// The user-visible security patch level.
   /// Available only on Android M (API 23) and newer

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
@@ -24,18 +24,19 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
     required this.manufacturer,
     required this.model,
     required this.product,
-    required List<String?> supported32BitAbis,
-    required List<String?> supported64BitAbis,
-    required List<String?> supportedAbis,
+    required List<String> supported32BitAbis,
+    required List<String> supported64BitAbis,
+    required List<String> supportedAbis,
     required this.tags,
     required this.type,
     required this.isPhysicalDevice,
-    required List<String?> systemFeatures,
+    required List<String> systemFeatures,
     required this.displayMetrics,
-  })  : supported32BitAbis = List<String?>.unmodifiable(supported32BitAbis),
-        supported64BitAbis = List<String?>.unmodifiable(supported64BitAbis),
-        supportedAbis = List<String?>.unmodifiable(supportedAbis),
-        systemFeatures = List<String?>.unmodifiable(systemFeatures);
+  })
+      : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
+        supported64BitAbis = List<String>.unmodifiable(supported64BitAbis),
+        supportedAbis = List<String>.unmodifiable(supportedAbis),
+        systemFeatures = List<String>.unmodifiable(systemFeatures);
 
   /// Android operating system version values derived from `android.os.Build.VERSION`.
   final AndroidBuildVersion version;
@@ -78,15 +79,15 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
 
   /// An ordered list of 32 bit ABIs supported by this device.
   /// Available only on Android L (API 21) and newer
-  final List<String?> supported32BitAbis;
+  final List<String> supported32BitAbis;
 
   /// An ordered list of 64 bit ABIs supported by this device.
   /// Available only on Android L (API 21) and newer
-  final List<String?> supported64BitAbis;
+  final List<String> supported64BitAbis;
 
   /// An ordered list of ABIs supported by this device.
   /// Available only on Android L (API 21) and newer
-  final List<String?> supportedAbis;
+  final List<String> supportedAbis;
 
   /// Comma-separated tags describing the build, like "unsigned,debug".
   final String tags;
@@ -111,7 +112,7 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
   /// and many of the common feature strings to look for are available in
   /// PackageManager's public documentation:
   /// https://developer.android.com/reference/android/content/pm/PackageManager
-  final List<String?> systemFeatures;
+  final List<String> systemFeatures;
 
   /// Information about the current android display.
   final AndroidDisplayMetrics displayMetrics;
@@ -162,8 +163,8 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
       manufacturer: map['manufacturer'],
       model: map['model'],
       product: map['product'],
-      supported32BitAbis: _fromList(map['supported32BitAbis'] ?? []),
-      supported64BitAbis: _fromList(map['supported64BitAbis'] ?? []),
+      supported32BitAbis: _fromList(map['supported32BitAbis'] ?? <String>[]),
+      supported64BitAbis: _fromList(map['supported64BitAbis'] ?? <String>[]),
       supportedAbis: _fromList(map['supportedAbis'] ?? []),
       tags: map['tags'],
       type: map['type'],
@@ -175,9 +176,10 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
   }
 
   /// Deserializes message as List<String>
-  static List<String?> _fromList(dynamic message) {
-    final List<dynamic> list = message;
-    return List<String?>.from(list);
+  static List<String> _fromList(List<dynamic> message) {
+    final list = message.takeWhile((item) => item != null)
+        .toList();
+    return List<String>.from(list);
   }
 }
 

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/android_device_info.dart
@@ -32,8 +32,7 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
     required this.isPhysicalDevice,
     required List<String> systemFeatures,
     required this.displayMetrics,
-  })
-      : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
+  })  : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
         supported64BitAbis = List<String>.unmodifiable(supported64BitAbis),
         supportedAbis = List<String>.unmodifiable(supportedAbis),
         systemFeatures = List<String>.unmodifiable(systemFeatures);
@@ -177,8 +176,7 @@ class AndroidDeviceInfo implements BaseDeviceInfo {
 
   /// Deserializes message as List<String>
   static List<String> _fromList(List<dynamic> message) {
-    final list = message.takeWhile((item) => item != null)
-        .toList();
+    final list = message.takeWhile((item) => item != null).toList();
     return List<String>.from(list);
   }
 }

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/model/web_browser_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/model/web_browser_info.dart
@@ -152,30 +152,30 @@ class WebBrowserInfo implements BaseDeviceInfo {
   }
 
   BrowserName _parseUserAgentToBrowserName() {
-    final _userAgent = userAgent;
-    if (_userAgent == null) {
+    final userAgent = this.userAgent;
+    if (userAgent == null) {
       return BrowserName.unknown;
-    } else if (_userAgent.contains('Firefox')) {
+    } else if (userAgent.contains('Firefox')) {
       return BrowserName.firefox;
       // "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0"
-    } else if (_userAgent.contains('SamsungBrowser')) {
+    } else if (userAgent.contains('SamsungBrowser')) {
       return BrowserName.samsungInternet;
       // "Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G955F Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36
-    } else if (_userAgent.contains('Opera') || _userAgent.contains('OPR')) {
+    } else if (userAgent.contains('Opera') || userAgent.contains('OPR')) {
       return BrowserName.opera;
       // "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 OPR/57.0.3098.106"
-    } else if (_userAgent.contains('Trident')) {
+    } else if (userAgent.contains('Trident')) {
       return BrowserName.msie;
       // "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; .NET4.0C; .NET4.0E; Zoom 3.6.0; wbx 1.0.0; rv:11.0) like Gecko"
-    } else if (_userAgent.contains('Edg')) {
+    } else if (userAgent.contains('Edg')) {
       return BrowserName.edge;
       // https://docs.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-string
       // "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43"
       // "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36 Edge/16.16299"
-    } else if (_userAgent.contains('Chrome')) {
+    } else if (userAgent.contains('Chrome')) {
       return BrowserName.chrome;
       // "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/66.0.3359.181 Chrome/66.0.3359.181 Safari/537.36"
-    } else if (_userAgent.contains('Safari')) {
+    } else if (userAgent.contains('Safari')) {
       return BrowserName.safari;
       // "Mozilla/5.0 (iPhone; CPU iPhone OS 11_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1 980x1306"
     } else {

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/method_channel_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/method_channel_device_info_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:device_info_plus_platform_interface/method_channel/method_channel_device_info.dart';
 
-import 'model/android_device_info_fake.dart' show fakeAndroidDeviceInfo;
+import 'model/android_device_info_fake.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/method_channel_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/method_channel_device_info_test.dart
@@ -7,7 +7,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:device_info_plus_platform_interface/method_channel/method_channel_device_info.dart';
 
-import 'model/android_device_info_fake.dart';
+import 'model/android_device_info_fake.dart' show fakeAndroidDeviceInfo;
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/method_channel_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/method_channel_device_info_test.dart
@@ -7,6 +7,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:device_info_plus_platform_interface/method_channel/method_channel_device_info.dart';
 
+import 'model/android_device_info_fake.dart';
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -20,15 +22,7 @@ void main() {
           .setMockMethodCallHandler((MethodCall methodCall) async {
         switch (methodCall.method) {
           case 'getAndroidDeviceInfo':
-            return ({
-              'brand': 'Google',
-              'displayMetrics': {
-                'widthPx': 1080.0,
-                'heightPx': 2220.0,
-                'xDpi': 530.0859,
-                'yDpi': 529.4639,
-              }
-            });
+            return fakeAndroidDeviceInfo;
           case 'getIosDeviceInfo':
             return ({
               'name': 'iPhone 10',

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_fake.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_fake.dart
@@ -1,0 +1,45 @@
+const fakeAndroidBuildVersion = <String, dynamic>{
+  'sdkInt': 16,
+  'baseOS': 'baseOS',
+  'previewSdkInt': 30,
+  'release': 'release',
+  'codename': 'codename',
+  'incremental': 'incremental',
+  'securityPatch': 'securityPatch',
+};
+
+const fakeDisplayMetrics = <String, dynamic>{
+  'widthPx': 1080.0,
+  'heightPx': 2220.0,
+  'xDpi': 530.0859,
+  'yDpi': 529.4639,
+};
+
+const fakeSupportedAbis = <String>['arm64-v8a', 'x86', 'x86_64'];
+const fakeSupported32BitAbis = <String?>['x86 (IA-32)', 'MMX'];
+const fakeSupported64BitAbis = <String?>['x86-64', 'MMX', 'SSSE3'];
+const fakeSystemFeatures = ['FEATURE_AUDIO_PRO', 'FEATURE_AUDIO_OUTPUT'];
+
+const fakeAndroidDeviceInfo = <String, dynamic>{
+  'id': 'id',
+  'host': 'host',
+  'tags': 'tags',
+  'type': 'type',
+  'model': 'model',
+  'board': 'board',
+  'brand': 'Google',
+  'device': 'device',
+  'product': 'product',
+  'display': 'display',
+  'hardware': 'hardware',
+  'isPhysicalDevice': true,
+  'bootloader': 'bootloader',
+  'fingerprint': 'fingerprint',
+  'manufacturer': 'manufacturer',
+  'supportedAbis': fakeSupportedAbis,
+  'systemFeatures': fakeSystemFeatures,
+  'version': fakeAndroidBuildVersion,
+  'supported64BitAbis': fakeSupported64BitAbis,
+  'supported32BitAbis': fakeSupported32BitAbis,
+  'displayMetrics': fakeDisplayMetrics,
+};

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
@@ -3,7 +3,13 @@
 import 'package:device_info_plus_platform_interface/model/android_device_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'android_device_info_fake.dart';
+import 'android_device_info_fake.dart'
+    show
+        fakeAndroidDeviceInfo,
+        fakeSupported32BitAbis,
+        fakeSupported64BitAbis,
+        fakeSupportedAbis,
+        fakeSystemFeatures;
 
 void main() {
   group('$AndroidDeviceInfo', () {

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
@@ -3,13 +3,7 @@
 import 'package:device_info_plus_platform_interface/model/android_device_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'android_device_info_fake.dart'
-    show
-        fakeAndroidDeviceInfo,
-        fakeSupported32BitAbis,
-        fakeSupported64BitAbis,
-        fakeSupportedAbis,
-        fakeSystemFeatures;
+import 'android_device_info_fake.dart';
 
 void main() {
   group('$AndroidDeviceInfo', () {

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/model/android_device_info_test.dart
@@ -3,57 +3,14 @@
 import 'package:device_info_plus_platform_interface/model/android_device_info.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'android_device_info_fake.dart';
+
 void main() {
   group('$AndroidDeviceInfo', () {
     group('fromMap | toMap', () {
-      const androidBuildVersionMap = <String, dynamic>{
-        'sdkInt': 16,
-        'baseOS': 'baseOS',
-        'previewSdkInt': 30,
-        'release': 'release',
-        'codename': 'codename',
-        'incremental': 'incremental',
-        'securityPatch': 'securityPatch',
-      };
-
-      const displayMetrics = <String, dynamic>{
-        'widthPx': 1080.0,
-        'heightPx': 2220.0,
-        'xDpi': 530.0859,
-        'yDpi': 529.4639,
-      };
-
-      const supportedAbis = <String>['arm64-v8a', 'x86', 'x86_64'];
-      const supported32BitAbis = <String?>['x86 (IA-32)', 'MMX'];
-      const supported64BitAbis = <String?>['x86-64', 'MMX', 'SSSE3'];
-      const systemFeatures = ['FEATURE_AUDIO_PRO', 'FEATURE_AUDIO_OUTPUT'];
-      final androidDeviceInfoMap = <String, dynamic>{
-        'id': 'id',
-        'host': 'host',
-        'tags': 'tags',
-        'type': 'type',
-        'model': 'model',
-        'board': 'board',
-        'brand': 'brand',
-        'device': 'device',
-        'product': 'product',
-        'display': 'display',
-        'hardware': 'hardware',
-        'isPhysicalDevice': true,
-        'bootloader': 'bootloader',
-        'fingerprint': 'fingerprint',
-        'manufacturer': 'manufacturer',
-        'supportedAbis': supportedAbis,
-        'systemFeatures': systemFeatures,
-        'version': androidBuildVersionMap,
-        'supported64BitAbis': supported64BitAbis,
-        'supported32BitAbis': supported32BitAbis,
-        'displayMetrics': displayMetrics,
-      };
-
       test('fromMap should return $AndroidDeviceInfo with correct values', () {
         final androidDeviceInfo =
-            AndroidDeviceInfo.fromMap(androidDeviceInfoMap);
+            AndroidDeviceInfo.fromMap(fakeAndroidDeviceInfo);
 
         expect(androidDeviceInfo.id, 'id');
         expect(androidDeviceInfo.host, 'host');
@@ -61,7 +18,7 @@ void main() {
         expect(androidDeviceInfo.type, 'type');
         expect(androidDeviceInfo.model, 'model');
         expect(androidDeviceInfo.board, 'board');
-        expect(androidDeviceInfo.brand, 'brand');
+        expect(androidDeviceInfo.brand, 'Google');
         expect(androidDeviceInfo.device, 'device');
         expect(androidDeviceInfo.product, 'product');
         expect(androidDeviceInfo.display, 'display');
@@ -70,10 +27,10 @@ void main() {
         expect(androidDeviceInfo.isPhysicalDevice, isTrue);
         expect(androidDeviceInfo.fingerprint, 'fingerprint');
         expect(androidDeviceInfo.manufacturer, 'manufacturer');
-        expect(androidDeviceInfo.supportedAbis, supportedAbis);
-        expect(androidDeviceInfo.systemFeatures, systemFeatures);
-        expect(androidDeviceInfo.supported32BitAbis, supported32BitAbis);
-        expect(androidDeviceInfo.supported64BitAbis, supported64BitAbis);
+        expect(androidDeviceInfo.supportedAbis, fakeSupportedAbis);
+        expect(androidDeviceInfo.systemFeatures, fakeSystemFeatures);
+        expect(androidDeviceInfo.supported32BitAbis, fakeSupported32BitAbis);
+        expect(androidDeviceInfo.supported64BitAbis, fakeSupported64BitAbis);
         expect(androidDeviceInfo.version.sdkInt, 16);
         expect(androidDeviceInfo.version.baseOS, 'baseOS');
         expect(androidDeviceInfo.version.previewSdkInt, 30);
@@ -89,9 +46,9 @@ void main() {
 
       test('toMap should return map with correct key and map', () {
         final androidDeviceInfo =
-            AndroidDeviceInfo.fromMap(androidDeviceInfoMap);
+            AndroidDeviceInfo.fromMap(fakeAndroidDeviceInfo);
 
-        expect(androidDeviceInfo.toMap(), androidDeviceInfoMap);
+        expect(androidDeviceInfo.toMap(), fakeAndroidDeviceInfo);
       });
     });
   });


### PR DESCRIPTION
## Description

It seems that during migration to null safety all properties for Android platform were just marked as nullable, while in reality almost all properties are not nullable. Thus, we had issues like #706 with users not really understanding why something is nullable now.

I refactored the plugin interface to have only a few properties which really can be null declared as nullable, while the rest if non-nullable anymore.

## Related Issues

#706 

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

