### PR TITLE
docs(sensors_plus): Update website docs and README

### DIFF
--- a/docs/sensors_plus/overview.mdx
+++ b/docs/sensors_plus/overview.mdx
@@ -6,7 +6,7 @@ hide_title: true
 
 ## Sensors Plus Overview
 
-A Flutter plugin to access the accelerometer and gyroscope sensors.
+A Flutter plugin to access the accelerometer, gyroscope and magnetometer sensors.
 
 ### Get started
 

--- a/docs/sensors_plus/usage.mdx
+++ b/docs/sensors_plus/usage.mdx
@@ -21,7 +21,7 @@ This will expose such classes of sensor events through a set of streams:
 - `MagnetometerEvent` describes the ambient magnetic field surrounding the
   device. A compass is an example usage of this data.
 
-Each of these is exposed through a `BroadcastStream`: `accelerometerEvents`,
+These events are exposed through a `BroadcastStream`: `accelerometerEvents`,
 `userAccelerometerEvents`, `gyroscopeEvents`, and `magnetometerEvents`,
 respectively.
 

--- a/docs/sensors_plus/usage.mdx
+++ b/docs/sensors_plus/usage.mdx
@@ -9,19 +9,21 @@ hide_title: true
 To use this plugin, add `sensors_plus` as a [dependency in your pubspec.yaml
 file](https://plus.fluttercommunity.dev/docs/overview).
 
-This will expose three classes of sensor events, through three different
-streams.
+This will expose such classes of sensor events through a set of streams:
 
-- `AccelerometerEvent`s describe the velocity of the device, including the
+- `AccelerometerEvent` describes the velocity of the device, including the
   effects of gravity. Put simply, you can use accelerometer readings to tell if
   the device is moving in a particular direction.
-- `UserAccelerometerEvent`s also describe the velocity of the device, but don't
+- `UserAccelerometerEvent` also describes the velocity of the device, but don't
   include gravity. They can also be thought of as just the user's affect on the
   device.
-- `GyroscopeEvent`s describe the rotation of the device.
+- `GyroscopeEvent` describes the rotation of the device.
+- `MagnetometerEvent` describes the ambient magnetic field surrounding the
+  device. A compass is an example usage of this data.
 
 Each of these is exposed through a `BroadcastStream`: `accelerometerEvents`,
-`userAccelerometerEvents`, and `gyroscopeEvents`, respectively.
+`userAccelerometerEvents`, `gyroscopeEvents`, and `magnetometerEvents`,
+respectively.
 
 ### Example
 
@@ -42,6 +44,11 @@ gyroscopeEvents.listen((GyroscopeEvent event) {
   print(event);
 });
 // [GyroscopeEvent (x: 0.0, y: 0.0, z: 0.0)]
+
+magnetometerEvents.listen((MagnetometerEvent event) {
+  print(event);
+});
+// [MagnetometerEvent (x: -23.6, y: 6.2, z: -34.9)]
 
 ```
 

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -22,17 +22,16 @@ sensors.
 To use this plugin, add `sensors_plus` as a [dependency in your pubspec.yaml
 file](https://plus.fluttercommunity.dev/docs/overview).
 
-This will expose four classes of sensor events through four different
-streams.
+This will expose such classes of sensor events through a set of streams:
 
-- `AccelerometerEvent`s describe the velocity of the device, including the
+- `AccelerometerEvent` describes the velocity of the device, including the
   effects of gravity. Put simply, you can use accelerometer readings to tell if
   the device is moving in a particular direction.
-- `UserAccelerometerEvent`s also describe the velocity of the device, but don't
+- `UserAccelerometerEvent` also describes the velocity of the device, but don't
   include gravity. They can also be thought of as just the user's affect on the
   device.
-- `GyroscopeEvent`s describe the rotation of the device.
-- `MagnetometerEvent`s describe the ambient magnetic field surrounding the
+- `GyroscopeEvent` describes the rotation of the device.
+- `MagnetometerEvent` describes the ambient magnetic field surrounding the
   device. A compass is an example usage of this data.
 
 Each of these is exposed through a `BroadcastStream`: `accelerometerEvents`,

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -34,7 +34,7 @@ This will expose such classes of sensor events through a set of streams:
 - `MagnetometerEvent` describes the ambient magnetic field surrounding the
   device. A compass is an example usage of this data.
 
-Each of these is exposed through a `BroadcastStream`: `accelerometerEvents`,
+These events are exposed through a `BroadcastStream`: `accelerometerEvents`,
 `userAccelerometerEvents`, `gyroscopeEvents`, and `magnetometerEvents`,
 respectively.
 


### PR DESCRIPTION
## Description

Saw that in our current version of website docs there were no info about magnetometer availability in `sensors_plus`. Fixing it. Did some minor corrections to both website docs and README.

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

