### PR TITLE
chore(share_plus): Update Kotlin, Gradle and add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
       include: "scope"
 
 # Website dependencies updates config
-     
+
   - package-ecosystem: "npm"
     directory: "/website"
     schedule:
@@ -24,9 +24,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
-      
+
 # Android Alarm Manager dependencies updates config
-      
+
   - package-ecosystem: "pub"
     directory: "/packages/android_alarm_manager_plus"
     schedule:
@@ -44,7 +44,7 @@ updates:
       include: "scope"
 
  # Android Intent Plus dependencies updates config
-      
+
   - package-ecosystem: "pub"
     directory: "/packages/android_intent_plus"
     schedule:
@@ -239,6 +239,22 @@ updates:
     directory: "/packages/share_plus/share_plus_platform_interface"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/share_plus/share_plus/android"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/share_plus/share_plus/example/android"
+    schedule:
+      interval: "monthly"
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/packages/share_plus/share_plus/android/build.gradle
+++ b/packages/share_plus/share_plus/android/build.gradle
@@ -2,14 +2,14 @@ group 'dev.fluttercommunity.plus.share'
 version '1.0-SNAPSHOT'
 
 buildscript {
-  ext.kotlin_version = '1.6.10'
+  ext.kotlin_version = '1.7.20'
   repositories {
     google()
     mavenCentral()
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:7.1.1'
+    classpath 'com.android.tools.build:gradle:7.3.1'
     classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
   }
 }

--- a/packages/share_plus/share_plus/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/share_plus/share_plus/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/share_plus/share_plus/example/android/build.gradle
+++ b/packages/share_plus/share_plus/example/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.1'
+        classpath 'com.android.tools.build:gradle:7.3.1'
     }
 }
 

--- a/packages/share_plus/share_plus/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/share_plus/share_plus/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description

We started to have a few requests to update Kotlin or Gradle in Android part of plugins. So I will do a series of PRs to resolve it. And for future adding a Dependabot config to do such updates automatically.

## Related Issues

#1248 
#1222

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

