### PR TITLE
fix(all): Increase min Flutter version to fix dartPluginClass registration

### DIFF
--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -42,4 +42,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=2.11.0"

--- a/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=2.11.0"
 
 dependencies:
   flutter:

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/connectiv
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  flutter: ">=2.11.0"
 
 flutter:
   plugin:

--- a/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  flutter: ">=2.11.0"
 
 dependencies:
   flutter:

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -44,4 +44,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  flutter: ">=2.11.0"

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -18,4 +18,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.4"
+  flutter: ">=2.11.0"

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/network_i
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=2.11.0"
 
 flutter:
   plugin:

--- a/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=2.11.0"
 
 dependencies:
   flutter:

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -45,4 +45,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  flutter: ">=2.11.0"

--- a/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
@@ -18,4 +18,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.4"
+  flutter: ">=2.11.0"

--- a/packages/sensors_plus/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/example/pubspec.yaml
@@ -25,4 +25,3 @@ flutter:
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.9.1+hotfix.2"

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -33,4 +33,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  flutter: ">=2.11.0"

--- a/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
@@ -18,4 +18,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.4"
+  flutter: ">=2.11.0"

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -27,4 +27,3 @@ flutter:
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
-  flutter: ">=1.20.0"

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -46,4 +46,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=2.11.0"

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -21,4 +21,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  flutter: ">=2.11.0"


### PR DESCRIPTION
## Description

Fixes the issue where the `dart_plugin_registrant.dart` file is not generated correctly.

Tested this locally with packages referenced by path. When I increased the Flutter SDK version to 2.11 then the issue we saw in #1270 was gone.

## Related Issues

- Fix: https://github.com/fluttercommunity/plus_plugins/issues/1270
- Related: https://github.com/flutter/flutter/pull/96610
- Related: https://github.com/flutter/flutter/issues/113720
- Related: https://github.com/fluttercommunity/plus_plugins/issues/1274

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

