### PR TITLE
fix(connectivity_plus): Add connectivity_plus_web export

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
@@ -10,7 +10,8 @@ import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_
 export 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart'
     show ConnectivityResult;
 
-export 'src/connectivity_plus_linux.dart';
+export 'src/connectivity_plus_linux.dart'
+    if (dart.library.html) 'src/connectivity_plus_web.dart';
 
 /// Discover network connectivity configurations: Distinguish between WI-FI and cellular, check WI-FI status and more.
 class Connectivity {


### PR DESCRIPTION
## Description

This PR adds a missing export.

## Related Issues

https://github.com/fluttercommunity/plus_plugins/pull/1227#discussion_r999845769

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

