### PR TITLE
docs(device_info_plus): Document toMap deprecation

### DIFF
--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -39,13 +39,22 @@ WebBrowserInfo webBrowserInfo = await deviceInfo.webBrowserInfo;
 print('Running on ${webBrowserInfo.userAgent}');  // e.g. "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0"
 ```
 
-One common use case for this plugin is obtaining device information for telemetry or crash-reporting purposes. In this scenario your app is not interested in specific properties, instead it wants to send all it knows about the device to your backend service for further analysis. You can leverage `deviceInfo` property, which returns platform-specific device information in a generic way. You then use it's `toMap` method to serialize all known properties to a `Map`. Your backend service should be prepared to handle new properties, which can be added to this plugin in the future.
+The plugin provides a `toMap` method that returns platform-specific device
+information in a generic way, which can be used for crash-reporting purposes.
+
+However, the data provided by this `toMap` method is currently not serializable
+(i.e. it is not 100% JSON compatible) and shouldn't be treated as such.
+
+That's why the method is currently marked as deprecated and will be eventually
+replaced, improved, or removed. We recommend you instead to read the actual
+values from each device info platform, or to keep using `toMap` at your own risk.
 
 ```dart
 import 'package:device_info_plus/device_info_plus.dart';
 
 final deviceInfoPlugin = DeviceInfoPlugin();
 final deviceInfo = await deviceInfoPlugin.deviceInfo;
+final allInfo = deviceInfo.toMap();
 ```
 
 You will find links to the API docs on the [pub page](https://pub.dev/documentation/device_info_plus/latest/).


### PR DESCRIPTION
## Description

Documents the deprecation of the `toMap` method, explaining that it is not JSON compatible and shouldn't be used as such.

## Related Issues

- closes  #1291

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

