### PR TITLE
feat(share_plus): remove direct dependence of url_launcher

### DIFF
--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -4,10 +4,13 @@ library share_plus_linux;
 import 'dart:ui';
 
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher_linux/url_launcher_linux.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
 /// The Linux implementation of SharePlatform.
 class SharePlusLinuxPlugin extends SharePlatform {
+  final urlLauncher = UrlLauncherLinux();
+
   /// Register this dart class as the platform implementation for linux
   static void registerWith() {
     SharePlatform.instance = SharePlusLinuxPlugin();
@@ -35,7 +38,11 @@ class SharePlusLinuxPlugin extends SharePlatform {
           .join('&'),
     );
 
-    await launchUrl(uri);
+    if (await urlLauncher.canLaunch(uri.toString())) {
+      await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
+    } else {
+      throw Exception('Unable to share on web');
+    }
   }
 
   /// Share files.

--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -9,11 +9,13 @@ import 'package:url_launcher_platform_interface/url_launcher_platform_interface.
 
 /// The Linux implementation of SharePlatform.
 class SharePlusLinuxPlugin extends SharePlatform {
-  final urlLauncher = UrlLauncherLinux();
+  SharePlusLinuxPlugin(this.urlLauncher);
+
+  final UrlLauncherPlatform urlLauncher;
 
   /// Register this dart class as the platform implementation for linux
   static void registerWith() {
-    SharePlatform.instance = SharePlusLinuxPlugin();
+    SharePlatform.instance = SharePlusLinuxPlugin(UrlLauncherLinux());
   }
 
   /// Share text.

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -5,10 +5,13 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:mime/mime.dart' show lookupMimeType;
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+import 'package:url_launcher_web/url_launcher_web.dart';
 
 /// The web implementation of [SharePlatform].
 class SharePlusWebPlugin extends SharePlatform {
+  final urlLauncher = UrlLauncherPlugin();
+
   /// Registers this class as the default instance of [SharePlatform].
   static void registerWith(Registrar registrar) {
     SharePlatform.instance = SharePlusWebPlugin();
@@ -45,8 +48,8 @@ class SharePlusWebPlugin extends SharePlatform {
             .join('&'),
       );
 
-      if (await canLaunchUrl(uri)) {
-        await launchUrl(uri);
+      if (await urlLauncher.canLaunch(uri.toString())) {
+        await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
       } else {
         throw Exception('Unable to share on web');
       }

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -10,18 +10,20 @@ import 'package:url_launcher_web/url_launcher_web.dart';
 
 /// The web implementation of [SharePlatform].
 class SharePlusWebPlugin extends SharePlatform {
-  final urlLauncher = UrlLauncherPlugin();
+  final UrlLauncherPlatform urlLauncher;
 
   /// Registers this class as the default instance of [SharePlatform].
   static void registerWith(Registrar registrar) {
-    SharePlatform.instance = SharePlusWebPlugin();
+    SharePlatform.instance = SharePlusWebPlugin(UrlLauncherPlugin());
   }
 
   final html.Navigator _navigator;
 
   /// A constructor that allows tests to override the window object used by the plugin.
-  SharePlusWebPlugin({@visibleForTesting html.Navigator? debugNavigator})
-      : _navigator = debugNavigator ?? html.window.navigator;
+  SharePlusWebPlugin(
+    this.urlLauncher, {
+    @visibleForTesting html.Navigator? debugNavigator,
+  }) : _navigator = debugNavigator ?? html.window.navigator;
 
   /// Share text
   @override

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -11,13 +11,15 @@ import 'package:url_launcher_windows/url_launcher_windows.dart';
 /// The fallback Windows implementation of [SharePlatform], for older Windows versions.
 ///
 class SharePlusWindowsPlugin extends SharePlatform {
-  final urlLauncher = UrlLauncherWindows();
+  SharePlusWindowsPlugin(this.urlLauncher);
+
+  final UrlLauncherPlatform urlLauncher;
 
   /// If the modern Share UI i.e. `DataTransferManager` is not available, then use this Dart class instead of platform specific implementation.
   ///
   static void registerWith() {
     if (!VersionHelper.instance.isWindows10RS5OrGreater) {
-      SharePlatform.instance = SharePlusWindowsPlugin();
+      SharePlatform.instance = SharePlusWindowsPlugin(UrlLauncherWindows());
     }
   }
 

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -5,11 +5,14 @@ import 'dart:ui';
 
 import 'package:share_plus/src/windows_version_helper.dart';
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
-import 'package:url_launcher/url_launcher.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+import 'package:url_launcher_windows/url_launcher_windows.dart';
 
 /// The fallback Windows implementation of [SharePlatform], for older Windows versions.
 ///
 class SharePlusWindowsPlugin extends SharePlatform {
+  final urlLauncher = UrlLauncherWindows();
+
   /// If the modern Share UI i.e. `DataTransferManager` is not available, then use this Dart class instead of platform specific implementation.
   ///
   static void registerWith() {
@@ -39,8 +42,8 @@ class SharePlusWindowsPlugin extends SharePlatform {
           .join('&'),
     );
 
-    if (await canLaunchUrl(uri)) {
-      await launchUrl(uri);
+    if (await urlLauncher.canLaunch(uri.toString())) {
+      await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
     } else {
       throw Exception('Unable to share on windows');
     }

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -34,7 +34,10 @@ dependencies:
     sdk: flutter
   share_plus_platform_interface: ^3.1.2
   file: ^6.0.0
-  url_launcher: ^6.1.2
+  url_launcher_web: ^2.0.13
+  url_launcher_windows: ^3.0.1
+  url_launcher_linux: ^3.0.1
+  url_launcher_platform_interface: ^2.1.1
   ffi: ^2.0.1
   win32: ^3.0.0
 
@@ -42,7 +45,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.1
-  url_launcher_platform_interface: ^2.0.2
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/share_plus/share_plus/test/share_plus_linux_test.dart
+++ b/packages/share_plus/share_plus/test/share_plus_linux_test.dart
@@ -11,9 +11,8 @@ void main() {
   });
   test('url encoding is correct for &', () async {
     final mock = MockUrlLauncherPlatform();
-    UrlLauncherPlatform.instance = mock;
 
-    await SharePlusLinuxPlugin().share('foo&bar', subject: 'bar&foo');
+    await SharePlusLinuxPlugin(mock).share('foo&bar', subject: 'bar&foo');
 
     expect(mock.url, 'mailto:?subject=bar%26foo&body=foo%26bar');
   });
@@ -21,9 +20,8 @@ void main() {
   // see https://github.com/dart-lang/sdk/issues/43838#issuecomment-823551891
   test('url encoding is correct for spaces', () async {
     final mock = MockUrlLauncherPlatform();
-    UrlLauncherPlatform.instance = mock;
 
-    await SharePlusLinuxPlugin().share('foo bar', subject: 'bar foo');
+    await SharePlusLinuxPlugin(mock).share('foo bar', subject: 'bar foo');
 
     expect(mock.url, 'mailto:?subject=bar%20foo&body=foo%20bar');
   });
@@ -31,9 +29,8 @@ void main() {
   test('throws when url_launcher can\'t launch uri', () async {
     final mock = MockUrlLauncherPlatform();
     mock.canLaunchMockValue = false;
-    UrlLauncherPlatform.instance = mock;
 
-    expect(() async => await SharePlusLinuxPlugin().share('foo bar'),
+    expect(() async => await SharePlusLinuxPlugin(mock).share('foo bar'),
         throwsException);
   });
 }

--- a/packages/share_plus/share_plus/test/share_plus_windows_test.dart
+++ b/packages/share_plus/share_plus/test/share_plus_windows_test.dart
@@ -31,9 +31,8 @@ void main() {
     'url encoding is correct for &',
     () async {
       final mock = MockUrlLauncherPlatform();
-      UrlLauncherPlatform.instance = mock;
 
-      await SharePlusWindowsPlugin().share('foo&bar', subject: 'bar&foo');
+      await SharePlusWindowsPlugin(mock).share('foo&bar', subject: 'bar&foo');
 
       expect(mock.url, 'mailto:?subject=bar%26foo&body=foo%26bar');
     },
@@ -45,9 +44,8 @@ void main() {
     'url encoding is correct for spaces',
     () async {
       final mock = MockUrlLauncherPlatform();
-      UrlLauncherPlatform.instance = mock;
 
-      await SharePlusWindowsPlugin().share('foo bar', subject: 'bar foo');
+      await SharePlusWindowsPlugin(mock).share('foo bar', subject: 'bar foo');
 
       expect(mock.url, 'mailto:?subject=bar%20foo&body=foo%20bar');
     },
@@ -59,9 +57,8 @@ void main() {
     () async {
       final mock = MockUrlLauncherPlatform();
       mock.canLaunchMockValue = false;
-      UrlLauncherPlatform.instance = mock;
 
-      expect(() async => await SharePlusWindowsPlugin().share('foo bar'),
+      expect(() async => await SharePlusWindowsPlugin(mock).share('foo bar'),
           throwsException);
     },
     skip: VersionHelper.instance.isWindows10RS5OrGreater,


### PR DESCRIPTION
## Description

Remove direct dependence of url_launcher, instead depending on platform specific packages.

## Related Issues

resolves #1070

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

