### PR TITLE
fix(share_plus): return correct share result on android

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/AndroidManifest.xml
+++ b/packages/share_plus/share_plus/android/src/main/AndroidManifest.xml
@@ -1,6 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="dev.fluttercommunity.plus.share">
     <application>
+      <!-- Declares a provider which allows us to store files to share in
+           '.../caches/share_plus' and grant the receiving action access -->
       <provider
         android:name="dev.fluttercommunity.plus.share.ShareFileProvider"
         android:authorities="${applicationId}.flutter.share_provider"
@@ -10,5 +12,12 @@
           android:name="android.support.FILE_PROVIDER_PATHS"
           android:resource="@xml/flutter_share_file_paths"/>
       </provider>
+      <!-- This manifest declared broadcast receiver allows us to use an explicit
+           Intent when creating a PendingItent to be informed of the user's choice -->
+      <receiver android:name=".SharePlusPendingIntent" android:exported="true">
+        <intent-filter>
+          <action android:name="EXTRA_CHOSEN_COMPONENT" />
+        </intent-filter>
+      </receiver>
     </application>
 </manifest>

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -33,7 +33,7 @@ internal class Share(
      */
     private val immutabilityIntentFlags: Int by lazy {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            PendingIntent.FLAG_IMMUTABLE
+            PendingIntent.FLAG_MUTABLE
         } else {
             0
         }
@@ -71,9 +71,9 @@ internal class Share(
                 PendingIntent.getBroadcast(
                     context,
                     0,
-                    Intent(ShareSuccessManager.BROADCAST_CHANNEL),
+                    Intent(context, SharePlusPendingIntent::class.java),
                     PendingIntent.FLAG_UPDATE_CURRENT or immutabilityIntentFlags
-                ).intentSender
+                ).getIntentSender()
             )
         } else {
             Intent.createChooser(shareIntent, null /* dialog title optional */)
@@ -129,9 +129,9 @@ internal class Share(
                 PendingIntent.getBroadcast(
                     context,
                     0,
-                    Intent(ShareSuccessManager.BROADCAST_CHANNEL),
+                    Intent(context, SharePlusPendingIntent::class.java),
                     PendingIntent.FLAG_UPDATE_CURRENT or immutabilityIntentFlags
-                ).intentSender
+                ).getIntentSender()
             )
         } else {
             Intent.createChooser(shareIntent, null /* dialog title optional */)

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -73,7 +73,7 @@ internal class Share(
                     0,
                     Intent(context, SharePlusPendingIntent::class.java),
                     PendingIntent.FLAG_UPDATE_CURRENT or immutabilityIntentFlags
-                ).getIntentSender()
+                ).intentSender
             )
         } else {
             Intent.createChooser(shareIntent, null /* dialog title optional */)
@@ -131,7 +131,7 @@ internal class Share(
                     0,
                     Intent(context, SharePlusPendingIntent::class.java),
                     PendingIntent.FLAG_UPDATE_CURRENT or immutabilityIntentFlags
-                ).getIntentSender()
+                ).intentSender
             )
         } else {
             Intent.createChooser(shareIntent, null /* dialog title optional */)

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/SharePlusPendingIntent.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/SharePlusPendingIntent.kt
@@ -11,13 +11,9 @@ import android.os.Build
  * When the PendingIntent is sent, the system will instantiate this class and call `onReceive` on it.
  */
 internal class SharePlusPendingIntent: BroadcastReceiver() {
-    /**
-     * Companion object to achieve static behaviour.
-     */
     companion object {
-        @JvmField
         /**
-         * Static result to access the result of the system instantiated instance
+         * Static member to access the result of the system instantiated instance
          */
         var result: String = ""
     }

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/SharePlusPendingIntent.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/SharePlusPendingIntent.kt
@@ -1,0 +1,43 @@
+package dev.fluttercommunity.plus.share
+
+import android.content.*
+import android.os.Build
+
+/**
+ * This helper class allows us to use FLAG_MUTABLE on the PendingIntent used in the Share class,
+ * as it allows us to make the underlying Intent explicit, therefore avoiding any risks an implicit
+ * mutable Intent may carry.
+ *
+ * When the PendingIntent is sent, the system will instantiate this class and call `onReceive` on it.
+ */
+internal class SharePlusPendingIntent: BroadcastReceiver() {
+    /**
+     * Companion object to achieve static behaviour.
+     */
+    companion object {
+        @JvmField
+        /**
+         * Static result to access the result of the system instantiated instance
+         */
+        var result: String = ""
+    }
+
+    /**
+     * Handler called after an action was chosen. Called only on success.
+     */
+    override fun onReceive(context: Context, intent: Intent) {
+        // Extract chosen ComponentName
+        val chosenComponent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            // Only available from API level 33 onwards
+            intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT, ComponentName::class.java)
+        } else {
+            // Deprecated in API level 33
+            intent.getParcelableExtra<ComponentName>(Intent.EXTRA_CHOSEN_COMPONENT)
+        }
+
+        // Unambiguously identify the chosen action
+        if (chosenComponent != null) {
+            result = chosenComponent.flattenToString()
+        }
+    }
+}

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/SharePlusPlugin.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/SharePlusPlugin.kt
@@ -15,14 +15,12 @@ class SharePlusPlugin : FlutterPlugin, ActivityAware {
     override fun onAttachedToEngine(binding: FlutterPluginBinding) {
         methodChannel = MethodChannel(binding.binaryMessenger, CHANNEL)
         manager = ShareSuccessManager(binding.applicationContext)
-        manager.register()
         share = Share(context = binding.applicationContext, activity = null, manager = manager)
         val handler = MethodCallHandler(share, manager)
         methodChannel.setMethodCallHandler(handler)
     }
 
     override fun onDetachedFromEngine(binding: FlutterPluginBinding) {
-        manager.discard()
         methodChannel.setMethodCallHandler(null)
     }
 

--- a/packages/share_plus/share_plus/android/src/main/res/xml/flutter_share_file_paths.xml
+++ b/packages/share_plus/share_plus/android/src/main/res/xml/flutter_share_file_paths.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<paths>
-    <cache-path name="cache" path="share_plus/" />
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+  <!-- Used in conjunction with the provider declared in AndroidManifest.xml -->
+  <cache-path name="cache" path="share_plus/" />
 </paths>


### PR DESCRIPTION
## Description

The `share_plus` android `shareWithResult` and `shareFilesWithResult` implementations are broken. The returned `ShareResult.raw` is always `null` on successful share. This PR fixes this by using `FLAG_MUTABLE` instead of `FLAG_IMMUTABLE`, as pointed out by @aakash-pamnani. This issue was not found when initially implementing the `shareWithResult` methods, as the `FLAG_IMMUTABLE` was only required by the highest API versions. Back then, a simple warning was emitted that strongly suggested using `FLAG_IMMUTABLE`, which seemed to break nothing.

This PR now fixes the behavior and ensures that the `FLAG_MUTABLE` `PendingIntent` given out may not be abused by moving from an implicit internal `Intent` to an explicit one. This also reduces mental complexity of the implementation.

I also added some more documentation throughout the android implementation.

As always, I provide [share_plus_example](https://github.com/Coronon/share_plus_example/tree/31ce889c3eae9e1e3de4264870fe3b11f4b829c8) as a pre-setup example project for this PR.

## Related Issues

Fixes #916

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

