### PR TITLE
feat(battery_plus): Added new isPlugged method in battery_plus

### DIFF
--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -71,6 +71,14 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
                     result.error("UNAVAILABLE", "Battery save mode not available.", null)
                 }
             }
+            "isPlugged" -> {
+                val isPlugged = isPlugged()
+                if (isPlugged != null) {
+                    result.success(isPlugged)
+                } else {
+                    result.error("UNAVAILABLE", "IsPlugged not available.", null)
+                }
+            }
             else -> result.notImplemented()
         }
     }
@@ -106,6 +114,12 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
             val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, -1)
             (level * 100 / scale)
         }
+    }
+
+    private fun isPlugged(): Boolean?{
+        val intent = ContextWrapper(applicationContext).registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        val plugged = intent!!.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
+        return plugged == BatteryManager.BATTERY_PLUGGED_AC || plugged == BatteryManager.BATTERY_PLUGGED_USB || plugged == BatteryManager.BATTERY_PLUGGED_WIRELESS
     }
 
     private fun isInPowerSaveMode(): Boolean? {

--- a/packages/battery_plus/battery_plus/lib/battery_plus.dart
+++ b/packages/battery_plus/battery_plus/lib/battery_plus.dart
@@ -53,4 +53,9 @@ class Battery {
   Stream<BatteryState> get onBatteryStateChanged {
     return _platform.onBatteryStateChanged;
   }
+
+  /// Get if battery is plugged or not
+  Future<bool> get isPlugged {
+    return _platform.isPlugged;
+  }
 }

--- a/packages/battery_plus/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
@@ -57,4 +57,9 @@ abstract class BatteryPlatform extends PlatformInterface {
     throw UnimplementedError(
         'get onBatteryStateChanged has not been implemented.');
   }
+
+    /// Returns the current battery state in percent.
+  Future<bool> get isPlugged {
+    throw UnimplementedError('isPlugged() has not been implemented.');
+  }
 }

--- a/packages/battery_plus/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
@@ -58,7 +58,7 @@ abstract class BatteryPlatform extends PlatformInterface {
         'get onBatteryStateChanged has not been implemented.');
   }
 
-    /// Returns the current battery state in percent.
+  /// Returns the current battery state in percent.
   Future<bool> get isPlugged {
     throw UnimplementedError('isPlugged() has not been implemented.');
   }

--- a/packages/battery_plus/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
@@ -50,4 +50,11 @@ class MethodChannelBattery extends BatteryPlatform {
         .map((dynamic event) => parseBatteryState(event));
     return _onBatteryStateChanged!;
   }
+
+   /// Returns if battery is Plugged or not
+  @override
+  Future<bool> get isPlugged => methodChannel
+      .invokeMethod<bool>('isPlugged')
+      .then<bool>((dynamic result) => result);
+
 }

--- a/packages/battery_plus/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
@@ -51,10 +51,9 @@ class MethodChannelBattery extends BatteryPlatform {
     return _onBatteryStateChanged!;
   }
 
-   /// Returns if battery is Plugged or not
+  /// Returns if battery is Plugged or not
   @override
   Future<bool> get isPlugged => methodChannel
       .invokeMethod<bool>('isPlugged')
       .then<bool>((dynamic result) => result);
-
 }


### PR DESCRIPTION
## Description

Added a new isPlugged method to check if device is charging or not because we cant get this information when the device is full and also plugged.
Only implemented on android.

## Related Issues

- *Related #1039*
- *Related #1049*

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

