### PR TITLE
fix(workflows): run apt-get update before install

### DIFF
--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -156,7 +156,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Install NetworkManager"
-        run: sudo apt-get install -y network-manager
+        run: sudo apt-get update && sudo apt-get install -y network-manager
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh linux connectivity_plus_example
 

--- a/.github/workflows/scripts/build-examples.sh
+++ b/.github/workflows/scripts/build-examples.sh
@@ -37,6 +37,7 @@ fi
 if [ "$ACTION" == "linux" ]
 then
   melos bootstrap --scope="$PLUGIN_SCOPE"
+  sudo apt-get update
   sudo apt-get install ninja-build libgtk-3-dev
   flutter doctor -v
   melos exec -c 1 --scope="$PLUGIN_EXAMPLE_SCOPE" \

--- a/.github/workflows/scripts/integration-test.sh
+++ b/.github/workflows/scripts/integration-test.sh
@@ -13,6 +13,7 @@ fi
 
 if [ "$ACTION" == "linux" ]
 then
+  sudo apt-get update
   sudo apt-get install ninja-build libgtk-3-dev
   # Testrunner is headless. Required create virtual display for the linux tests to run.
   export DISPLAY=:99


### PR DESCRIPTION
## Description

The Linux build tests always failed because the `apt-get install` command errored.
This PR runs `apt-get update` before any `install`.

#### Examples:
- [Failing test](https://github.com/fluttercommunity/plus_plugins/actions/runs/3351525648/jobs/5553032279)
- [Successful test](https://github.com/Coronon/plus_plugins/actions/runs/3351625509/jobs/5553203086)

## Related Issues

No issue yet

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

