### PR TITLE
test(connectivity_plus): Fix integration test on Android 5

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -25,12 +25,23 @@ void main() {
       expect(result, isNotNull);
     });
 
-    testWidgets('connectivity on Android emulator should be wifi',
+    testWidgets('connectivity on Android newer than 5 (API 21) should be wifi',
         (WidgetTester tester) async {
       final result = await connectivity.checkConnectivity();
 
       expect(result, ConnectivityResult.wifi);
-    }, skip: !Platform.isAndroid);
+    },
+        skip: !Platform.isAndroid ||
+            Platform.operatingSystemVersion.contains('5.0.2'));
+
+    testWidgets('connectivity on Android 5 (API 21) should be mobile',
+        (WidgetTester tester) async {
+      final result = await connectivity.checkConnectivity();
+
+      expect(result, ConnectivityResult.mobile);
+    },
+        skip: !Platform.isAndroid ||
+            !Platform.operatingSystemVersion.contains('5.0.2'));
 
     testWidgets('connectivity on MacOS should be ethernet',
         (WidgetTester tester) async {


### PR DESCRIPTION
## Description

Fixing integration tests which fail for `connectivity_plus` on Android 5 (API 21) since build matrix was introduced. 
Here is an example of such test: https://github.com/fluttercommunity/plus_plugins/actions/runs/3351644055/jobs/5553908690

As it turned out the reason for failing was the fact that Android 5 emulators have mobile internet turned on by default, not wifi. Here is how device config looks on a newly created emulator with Android 5:
<img width="423" alt="Screenshot 2022-10-29 at 23 32 21" src="https://user-images.githubusercontent.com/13467769/198852261-f5bc7110-85f2-4603-84fa-f9fe5bea864b.png">

I have added a check for Android version to check for correct connection type depending on Android version. I could add `device_info_plus` to get Android version, but felt like it is an overkill, so used slightly hacky way.

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

