### PR TITLE
feat(share_plus): Show destination for share with result in example, update example UI

### DIFF
--- a/packages/share_plus/share_plus/example/lib/image_previews.dart
+++ b/packages/share_plus/share_plus/example/lib/image_previews.dart
@@ -19,7 +19,7 @@ class ImagePreviews extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     if (imagePaths.isEmpty) {
-      return Container();
+      return const SizedBox.shrink();
     }
 
     final imageWidgets = <Widget>[];

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -37,110 +37,118 @@ class DemoAppState extends State<DemoApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Share Plus Plugin Demo',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.indigo),
+      ),
       home: Scaffold(
-          appBar: AppBar(
-            title: const Text('Share Plus Plugin Demo'),
-          ),
-          body: SingleChildScrollView(
-            child: Padding(
-              padding: const EdgeInsets.all(24.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: <Widget>[
-                  TextField(
-                    decoration: const InputDecoration(
-                      labelText: 'Share text:',
-                      hintText: 'Enter some text and/or link to share',
-                    ),
-                    maxLines: 2,
-                    onChanged: (String value) => setState(() {
-                      text = value;
-                    }),
-                  ),
-                  TextField(
-                    decoration: const InputDecoration(
-                      labelText: 'Share subject:',
-                      hintText: 'Enter subject to share (optional)',
-                    ),
-                    maxLines: 2,
-                    onChanged: (String value) => setState(() {
-                      subject = value;
-                    }),
-                  ),
-                  const Padding(padding: EdgeInsets.only(top: 12.0)),
-                  ImagePreviews(imagePaths, onDelete: _onDeleteImage),
-                  ListTile(
-                    leading: const Icon(Icons.add),
-                    title: const Text('Add image'),
-                    onTap: () async {
-                      // Using `package:image_picker` to get image from gallery.
-                      if (Platform.isMacOS ||
-                          Platform.isLinux ||
-                          Platform.isWindows) {
-                        // Using `package:file_selector` on windows, macos & Linux, since `package:image_picker` is not supported.
-                        const XTypeGroup typeGroup = XTypeGroup(
-                          label: 'images',
-                          extensions: <String>['jpg', 'jpeg', 'png', 'gif'],
-                        );
-                        final file = await openFile(
-                            acceptedTypeGroups: <XTypeGroup>[typeGroup]);
-                        if (file != null) {
-                          setState(() {
-                            imagePaths.add(file.path);
-                            imageNames.add(file.name);
-                          });
-                        }
-                      } else {
-                        final imagePicker = ImagePicker();
-                        final pickedFile = await imagePicker.pickImage(
-                          source: ImageSource.gallery,
-                        );
-                        if (pickedFile != null) {
-                          setState(() {
-                            imagePaths.add(pickedFile.path);
-                            imageNames.add(pickedFile.name);
-                          });
-                        }
-                      }
-                    },
-                  ),
-                  const Padding(padding: EdgeInsets.only(top: 12.0)),
-                  Builder(
-                    builder: (BuildContext context) {
-                      return ElevatedButton(
-                        onPressed: text.isEmpty && imagePaths.isEmpty
-                            ? null
-                            : () => _onShare(context),
-                        child: const Text('Share'),
-                      );
-                    },
-                  ),
-                  const Padding(padding: EdgeInsets.only(top: 12.0)),
-                  Builder(
-                    builder: (BuildContext context) {
-                      return ElevatedButton(
-                        onPressed: text.isEmpty && imagePaths.isEmpty
-                            ? null
-                            : () => _onShareWithResult(context),
-                        child: const Text('Share With Result'),
-                      );
-                    },
-                  ),
-                  const Padding(padding: EdgeInsets.only(top: 12.0)),
-                  Builder(
-                    builder: (BuildContext context) {
-                      return ElevatedButton(
-                        onPressed: () {
-                          _onShareXFileFromAssets(context);
-                        },
-                        child: const Text('Share XFile from Assets'),
-                      );
-                    },
-                  ),
-                ],
+        appBar: AppBar(
+          title: const Text('Share Plus Plugin Demo'),
+        ),
+        body: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              TextField(
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Share text',
+                  hintText: 'Enter some text and/or link to share',
+                ),
+                maxLines: null,
+                onChanged: (String value) => setState(() {
+                  text = value;
+                }),
               ),
-            ),
-          )),
+              const SizedBox(height: 16),
+              TextField(
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Share subject',
+                  hintText: 'Enter subject to share (optional)',
+                ),
+                maxLines: null,
+                onChanged: (String value) => setState(() {
+                  subject = value;
+                }),
+              ),
+              const SizedBox(height: 16),
+              ImagePreviews(imagePaths, onDelete: _onDeleteImage),
+              ElevatedButton.icon(
+                style: ElevatedButton.styleFrom(foregroundColor: Colors.red),
+                label: const Text('Add image'),
+                onPressed: () async {
+                  // Using `package:image_picker` to get image from gallery.
+                  if (Platform.isMacOS ||
+                      Platform.isLinux ||
+                      Platform.isWindows) {
+                    // Using `package:file_selector` on windows, macos & Linux, since `package:image_picker` is not supported.
+                    const XTypeGroup typeGroup = XTypeGroup(
+                      label: 'images',
+                      extensions: <String>['jpg', 'jpeg', 'png', 'gif'],
+                    );
+                    final file = await openFile(
+                        acceptedTypeGroups: <XTypeGroup>[typeGroup]);
+                    if (file != null) {
+                      setState(() {
+                        imagePaths.add(file.path);
+                        imageNames.add(file.name);
+                      });
+                    }
+                  } else {
+                    final imagePicker = ImagePicker();
+                    final pickedFile = await imagePicker.pickImage(
+                      source: ImageSource.gallery,
+                    );
+                    if (pickedFile != null) {
+                      setState(() {
+                        imagePaths.add(pickedFile.path);
+                        imageNames.add(pickedFile.name);
+                      });
+                    }
+                  }
+                },
+                icon: const Icon(Icons.add),
+              ),
+              const SizedBox(height: 32),
+              Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    onPressed: text.isEmpty && imagePaths.isEmpty
+                        ? null
+                        : () => _onShare(context),
+                    child: const Text('Share'),
+                  );
+                },
+              ),
+              const SizedBox(height: 16),
+              Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    onPressed: text.isEmpty && imagePaths.isEmpty
+                        ? null
+                        : () => _onShareWithResult(context),
+                    child: const Text('Share With Result'),
+                  );
+                },
+              ),
+              const SizedBox(height: 16),
+              Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    onPressed: () {
+                      _onShareXFileFromAssets(context);
+                    },
+                    child: const Text('Share XFile from Assets'),
+                  );
+                },
+              ),
+            ],
+          ),
+        ),
+      ),
     );
   }
 
@@ -195,9 +203,19 @@ class DemoAppState extends State<DemoApp> {
           subject: subject,
           sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
     }
-    scaffoldMessenger.showSnackBar(SnackBar(
-      content: Text("Share result: ${result.status}"),
-    ));
+    scaffoldMessenger.showSnackBar(
+      SnackBar(
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text("Share result: ${result.status}"),
+            if (result.status == ShareResultStatus.success)
+              Text("Shared to: ${result.raw}")
+          ],
+        ),
+      ),
+    );
   }
 
   void _onShareXFileFromAssets(BuildContext context) async {
@@ -208,15 +226,18 @@ class DemoAppState extends State<DemoApp> {
     final result = await Share.shareXFiles(
       [
         XFile.fromData(
-            buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
-            name: 'flutter_logo.png',
-            mimeType: 'image/png'),
+          buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+          name: 'flutter_logo.png',
+          mimeType: 'image/png',
+        ),
       ],
       sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
     );
 
-    scaffoldMessenger.showSnackBar(SnackBar(
-      content: Text("Share result: ${result.status}"),
-    ));
+    scaffoldMessenger.showSnackBar(
+      SnackBar(
+        content: Text("Share result: ${result.status}"),
+      ),
+    );
   }
 }

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -39,7 +39,7 @@ class DemoAppState extends State<DemoApp> {
       title: 'Share Plus Plugin Demo',
       theme: ThemeData(
         useMaterial3: true,
-        colorScheme: ColorScheme.fromSwatch(primarySwatch: Colors.indigo),
+        colorSchemeSeed: const Color(0x9f4376f8),
       ),
       home: Scaffold(
         appBar: AppBar(
@@ -77,7 +77,6 @@ class DemoAppState extends State<DemoApp> {
               const SizedBox(height: 16),
               ImagePreviews(imagePaths, onDelete: _onDeleteImage),
               ElevatedButton.icon(
-                style: ElevatedButton.styleFrom(foregroundColor: Colors.red),
                 label: const Text('Add image'),
                 onPressed: () async {
                   // Using `package:image_picker` to get image from gallery.
@@ -116,6 +115,10 @@ class DemoAppState extends State<DemoApp> {
               Builder(
                 builder: (BuildContext context) {
                   return ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                    ),
                     onPressed: text.isEmpty && imagePaths.isEmpty
                         ? null
                         : () => _onShare(context),
@@ -127,6 +130,10 @@ class DemoAppState extends State<DemoApp> {
               Builder(
                 builder: (BuildContext context) {
                   return ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                    ),
                     onPressed: text.isEmpty && imagePaths.isEmpty
                         ? null
                         : () => _onShareWithResult(context),
@@ -138,6 +145,10 @@ class DemoAppState extends State<DemoApp> {
               Builder(
                 builder: (BuildContext context) {
                   return ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                    ),
                     onPressed: () {
                       _onShareXFileFromAssets(context);
                     },


### PR DESCRIPTION
## Description

Saw that example app for `share_plus` shows only type of result in case with `shareWithResult` call, but not the destination. So adding a destination info as well to showcase the feature better for package users.

Additionally decided to give the example app UI a little visual improvement, so made it to use Material 3 and did small changes to make it look more modern and clean to use:

<img src="https://user-images.githubusercontent.com/13467769/199116465-3b1bc3c2-1da1-4f99-8d15-0eac2aed1749.jpeg" height="600" />

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

