### PR TITLE
fix(share_plus): remove `canLaunch` check

### DIFF
--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -40,11 +40,7 @@ class SharePlusLinuxPlugin extends SharePlatform {
           .join('&'),
     );
 
-    if (await urlLauncher.canLaunch(uri.toString())) {
-      await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
-    } else {
-      throw Exception('Unable to share on web');
-    }
+    await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
   }
 
   /// Share files.

--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -44,7 +44,7 @@ class SharePlusLinuxPlugin extends SharePlatform {
       const LaunchOptions(),
     );
     if (!launchResult) {
-      throw Exception('Failed to launch mailto: URI');
+      throw Exception('Failed to launch $uri');
     }
   }
 

--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -19,7 +19,6 @@ class SharePlusLinuxPlugin extends SharePlatform {
   }
 
   /// Share text.
-  /// Throws a [PlatformException] if `mailto:` scheme cannot be handled.
   @override
   Future<void> share(
     String text, {
@@ -40,7 +39,13 @@ class SharePlusLinuxPlugin extends SharePlatform {
           .join('&'),
     );
 
-    await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
+    final launchResult = await urlLauncher.launchUrl(
+      uri.toString(),
+      const LaunchOptions(),
+    );
+    if (!launchResult) {
+      throw Exception('Failed to launch mailto: URI');
+    }
   }
 
   /// Share files.

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -55,7 +55,7 @@ class SharePlusWebPlugin extends SharePlatform {
         const LaunchOptions(),
       );
       if (!launchResult) {
-        throw Exception('Failed to launch mailto: URI');
+        throw Exception('Failed to launch $uri');
       }
     }
   }

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -50,11 +50,7 @@ class SharePlusWebPlugin extends SharePlatform {
             .join('&'),
       );
 
-      if (await urlLauncher.canLaunch(uri.toString())) {
-        await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
-      } else {
-        throw Exception('Unable to share on web');
-      }
+      await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
     }
   }
 

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -50,7 +50,13 @@ class SharePlusWebPlugin extends SharePlatform {
             .join('&'),
       );
 
-      await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
+      final launchResult = await urlLauncher.launchUrl(
+        uri.toString(),
+        const LaunchOptions(),
+      );
+      if (!launchResult) {
+        throw Exception('Failed to launch mailto: URI');
+      }
     }
   }
 

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -44,11 +44,7 @@ class SharePlusWindowsPlugin extends SharePlatform {
           .join('&'),
     );
 
-    if (await urlLauncher.canLaunch(uri.toString())) {
-      await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
-    } else {
-      throw Exception('Unable to share on windows');
-    }
+    await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
   }
 
   /// Share files.

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -3,6 +3,7 @@ library share_plus_windows;
 
 import 'dart:ui';
 
+import 'package:flutter/services.dart';
 import 'package:share_plus/src/windows_version_helper.dart';
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
@@ -44,7 +45,13 @@ class SharePlusWindowsPlugin extends SharePlatform {
           .join('&'),
     );
 
-    await urlLauncher.launchUrl(uri.toString(), const LaunchOptions());
+    final launchResult = await urlLauncher.launchUrl(
+      uri.toString(),
+      const LaunchOptions(),
+    );
+    if (!launchResult) {
+      throw Exception('Failed to launch mailto: URI');
+    }
   }
 
   /// Share files.

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -3,7 +3,6 @@ library share_plus_windows;
 
 import 'dart:ui';
 
-import 'package:flutter/services.dart';
 import 'package:share_plus/src/windows_version_helper.dart';
 import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -49,7 +49,7 @@ class SharePlusWindowsPlugin extends SharePlatform {
       const LaunchOptions(),
     );
     if (!launchResult) {
-      throw Exception('Failed to launch mailto: URI');
+      throw Exception('Failed to launch $uri');
     }
   }
 

--- a/packages/share_plus/share_plus/test/share_plus_linux_test.dart
+++ b/packages/share_plus/share_plus/test/share_plus_linux_test.dart
@@ -4,6 +4,8 @@ import 'package:share_plus_platform_interface/share_plus_platform_interface.dart
 import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
+import 'url_launcher_mock.dart';
+
 void main() {
   test('registered instance', () {
     SharePlusLinuxPlugin.registerWith();
@@ -33,35 +35,4 @@ void main() {
     expect(() async => await SharePlusLinuxPlugin(mock).share('foo bar'),
         throwsException);
   });
-}
-
-class MockUrlLauncherPlatform extends UrlLauncherPlatform {
-  String? url;
-  bool canLaunchMockValue = true;
-
-  @override
-  LinkDelegate? get linkDelegate => throw UnimplementedError();
-
-  @override
-  Future<bool> canLaunch(String url) async {
-    return canLaunchMockValue;
-  }
-
-  @override
-  Future<bool> launch(
-    String url, {
-    required bool useSafariVC,
-    required bool useWebView,
-    required bool enableJavaScript,
-    required bool enableDomStorage,
-    required bool universalLinksOnly,
-    required Map<String, String> headers,
-    String? webOnlyWindowName,
-  }) async {
-    this.url = url;
-    if (!canLaunchMockValue) {
-      throw Exception();
-    }
-    return true;
-  }
 }

--- a/packages/share_plus/share_plus/test/share_plus_windows_test.dart
+++ b/packages/share_plus/share_plus/test/share_plus_windows_test.dart
@@ -6,6 +6,8 @@ import 'package:share_plus_platform_interface/share_plus_platform_interface.dart
 import 'package:url_launcher_platform_interface/link.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
+import 'url_launcher_mock.dart';
+
 void main() {
   test(
     'registered instance',
@@ -63,32 +65,4 @@ void main() {
     },
     skip: VersionHelper.instance.isWindows10RS5OrGreater,
   );
-}
-
-class MockUrlLauncherPlatform extends UrlLauncherPlatform {
-  String? url;
-  bool canLaunchMockValue = true;
-
-  @override
-  LinkDelegate? get linkDelegate => throw UnimplementedError();
-
-  @override
-  Future<bool> canLaunch(String url) async {
-    return canLaunchMockValue;
-  }
-
-  @override
-  Future<bool> launch(
-    String url, {
-    required bool useSafariVC,
-    required bool useWebView,
-    required bool enableJavaScript,
-    required bool enableDomStorage,
-    required bool universalLinksOnly,
-    required Map<String, String> headers,
-    String? webOnlyWindowName,
-  }) async {
-    this.url = url;
-    return true;
-  }
 }

--- a/packages/share_plus/share_plus/test/url_launcher_mock.dart
+++ b/packages/share_plus/share_plus/test/url_launcher_mock.dart
@@ -15,15 +15,15 @@ class MockUrlLauncherPlatform extends UrlLauncherPlatform {
 
   @override
   Future<bool> launch(
-      String url, {
-        required bool useSafariVC,
-        required bool useWebView,
-        required bool enableJavaScript,
-        required bool enableDomStorage,
-        required bool universalLinksOnly,
-        required Map<String, String> headers,
-        String? webOnlyWindowName,
-      }) async {
+    String url, {
+    required bool useSafariVC,
+    required bool useWebView,
+    required bool enableJavaScript,
+    required bool enableDomStorage,
+    required bool universalLinksOnly,
+    required Map<String, String> headers,
+    String? webOnlyWindowName,
+  }) async {
     this.url = url;
     return canLaunchMockValue;
   }

--- a/packages/share_plus/share_plus/test/url_launcher_mock.dart
+++ b/packages/share_plus/share_plus/test/url_launcher_mock.dart
@@ -1,0 +1,30 @@
+import 'package:url_launcher_platform_interface/link.dart';
+import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
+
+class MockUrlLauncherPlatform extends UrlLauncherPlatform {
+  String? url;
+  bool canLaunchMockValue = true;
+
+  @override
+  LinkDelegate? get linkDelegate => throw UnimplementedError();
+
+  @override
+  Future<bool> canLaunch(String url) async {
+    return canLaunchMockValue;
+  }
+
+  @override
+  Future<bool> launch(
+      String url, {
+        required bool useSafariVC,
+        required bool useWebView,
+        required bool enableJavaScript,
+        required bool enableDomStorage,
+        required bool universalLinksOnly,
+        required Map<String, String> headers,
+        String? webOnlyWindowName,
+      }) async {
+    this.url = url;
+    return canLaunchMockValue;
+  }
+}


### PR DESCRIPTION
## Description

Reverting back to old construct as @stuartmorgan suggested https://github.com/fluttercommunity/plus_plugins/pull/1295#discussion_r1009240852

Also remove `canLaunch` check.

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

