### PR TITLE
fix(package_info_plus): adds value equality for PackageInfo

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -89,4 +89,32 @@ class PackageInfo {
       installerStore: installerStore,
     );
   }
+
+  /// Overwrite equals for value equality
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is PackageInfo &&
+          runtimeType == other.runtimeType &&
+          appName == other.appName &&
+          packageName == other.packageName &&
+          version == other.version &&
+          buildNumber == other.buildNumber &&
+          buildSignature == other.buildSignature &&
+          installerStore == other.installerStore;
+
+  /// Overwrite hashCode for value equality
+  @override
+  int get hashCode =>
+      appName.hashCode ^
+      packageName.hashCode ^
+      version.hashCode ^
+      buildNumber.hashCode ^
+      buildSignature.hashCode ^
+      installerStore.hashCode;
+
+  @override
+  String toString() {
+    return 'PackageInfo(appName: $appName, buildNumber: $buildNumber, packageName: $packageName, version: $version, buildSignature: $buildSignature, installerStore: $installerStore)';
+  }
 }

--- a/packages/package_info_plus/package_info_plus/test/package_info_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_test.dart
@@ -68,4 +68,54 @@ void main() {
     expect(info.buildSignature, 'deadbeef');
     expect(info.installerStore, null);
   });
+
+  test('equals checks for value equality', () async {
+    final info1 = PackageInfo(
+        appName: 'package_info_example',
+        buildNumber: '1',
+        packageName: 'io.flutter.plugins.packageinfoexample',
+        version: '1.0',
+        buildSignature: '',
+        installerStore: null);
+    final info2 = PackageInfo(
+        appName: 'package_info_example',
+        buildNumber: '1',
+        packageName: 'io.flutter.plugins.packageinfoexample',
+        version: '1.0',
+        buildSignature: '',
+        installerStore: null);
+    expect(info1, info2);
+  });
+
+  test('hashCode checks for value equality', () async {
+    final info1 = PackageInfo(
+        appName: 'package_info_example',
+        buildNumber: '1',
+        packageName: 'io.flutter.plugins.packageinfoexample',
+        version: '1.0',
+        buildSignature: '',
+        installerStore: null);
+    final info2 = PackageInfo(
+        appName: 'package_info_example',
+        buildNumber: '1',
+        packageName: 'io.flutter.plugins.packageinfoexample',
+        version: '1.0',
+        buildSignature: '',
+        installerStore: null);
+    expect(info1.hashCode, info2.hashCode);
+  });
+
+  test('toString returns a string representation', () async {
+    final info = PackageInfo(
+        appName: 'package_info_example',
+        buildNumber: '1',
+        packageName: 'io.flutter.plugins.packageinfoexample',
+        version: '1.0',
+        buildSignature: '',
+        installerStore: null);
+    expect(
+      info.toString(),
+      'PackageInfo(appName: package_info_example, buildNumber: 1, packageName: io.flutter.plugins.packageinfoexample, version: 1.0, buildSignature: , installerStore: null)',
+    );
+  });
 }


### PR DESCRIPTION
## Description

Overwrites for hashCode and equals for PackageInfo to get value equality, also adds verbose toString method to PackageInfo and adds tests for the changes

## Related Issues
- *Fix #1321*

## Checklist

- [x ] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x ] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x ] All existing and new tests are passing.
- [x ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x ] No, this is *not* a breaking change.

