### PR TITLE
fix(share_plus): example broken on web

### DIFF
--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'dart:io';
 
 import 'package:file_selector/file_selector.dart'
     hide XFile; // hides to test if share_plus exports XFile
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:image_picker/image_picker.dart'
@@ -80,9 +81,10 @@ class DemoAppState extends State<DemoApp> {
                 label: const Text('Add image'),
                 onPressed: () async {
                   // Using `package:image_picker` to get image from gallery.
-                  if (Platform.isMacOS ||
-                      Platform.isLinux ||
-                      Platform.isWindows) {
+                  if (!kIsWeb &&
+                      (Platform.isMacOS ||
+                          Platform.isLinux ||
+                          Platform.isWindows)) {
                     // Using `package:file_selector` on windows, macos & Linux, since `package:image_picker` is not supported.
                     const XTypeGroup typeGroup = XTypeGroup(
                       label: 'images',


### PR DESCRIPTION
## Description

The example uses `Platform` calls on Web which result in exceptions.

## Related Issues

- Related #1320 

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

