### PR TITLE
fix(connectivity_plus): Does not crash in debug mode of iOS 14+

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/ConnectivityPlusPlugin.m
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/ConnectivityPlusPlugin.m
@@ -10,6 +10,8 @@
 
 @implementation ConnectivityPlusPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
-  [SwiftConnectivityPlusPlugin registerWithRegistrar:registrar];
+    if (registrar) {
+        [SwiftConnectivityPlusPlugin registerWithRegistrar:registrar];
+    }
 }
 @end

--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/ConnectivityPlusPlugin.m
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/ConnectivityPlusPlugin.m
@@ -10,8 +10,8 @@
 
 @implementation ConnectivityPlusPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
-    if (registrar) {
-        [SwiftConnectivityPlusPlugin registerWithRegistrar:registrar];
-    }
+  if (registrar) {
+      [SwiftConnectivityPlusPlugin registerWithRegistrar:registrar];
+  }
 }
 @end

--- a/packages/connectivity_plus/connectivity_plus/ios/Classes/ConnectivityPlusPlugin.m
+++ b/packages/connectivity_plus/connectivity_plus/ios/Classes/ConnectivityPlusPlugin.m
@@ -11,7 +11,7 @@
 @implementation ConnectivityPlusPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   if (registrar) {
-      [SwiftConnectivityPlusPlugin registerWithRegistrar:registrar];
+    [SwiftConnectivityPlusPlugin registerWithRegistrar:registrar];
   }
 }
 @end


### PR DESCRIPTION
## Description

In ios 14+, debug mode Flutter apps can only be launched from Flutter tooling, IDEs with Flutter plugins or from Xcode.
So, registrar will be nil.
However, we can't make it crash in its own plugin.
Determine whether the registrar is null.

## Related Issues


## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

