### PR TITLE
fix(share_plus): Fix the error of requestCode value range.

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
@@ -69,7 +69,11 @@ internal class ShareSuccessManager(private val context: Context) : ActivityResul
      * the share result.
      */
     companion object {
-        const val ACTIVITY_CODE = 17062003
+        /**
+         * When the application's activity is [androidx.fragment.app.FragmentActivity], requestCode can only use the lower 16 bits.
+         * @see androidx.fragment.app.FragmentActivity.validateRequestPermissionsRequestCode
+         */
+        const val ACTIVITY_CODE = 0x5873
         const val RESULT_UNAVAILABLE = "dev.fluttercommunity.plus/share/unavailable"
     }
 }

--- a/packages/share_plus/share_plus/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/share_plus/share_plus/example/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:icon="@mipmap/ic_launcher"
         android:label="share_example">
         <activity
-            android:name="io.flutter.embedding.android.FlutterActivity"
+            android:name="io.flutter.embedding.android.FlutterFragmentActivity"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|layoutDirection"
             android:exported="true"
             android:hardwareAccelerated="true"


### PR DESCRIPTION
## Description

When the application's activity is `FragmentActivity`, requestCode can only use the lower 16 bits.

## Related Issues

- *Related https://github.com/juliansteenbakker/mobile_scanner/pull/279*

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

