### PR TITLE
feat(device_info_plus): Add serialNumber property to AndroidDeviceInfo

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
@@ -79,6 +79,16 @@ internal class MethodCallHandlerImpl(
             displayResult["yDpi"] = metrics.ydpi
             build["displayMetrics"] = displayResult
 
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                build["serialNumber"] = try {
+                    Build.getSerial()
+                } catch (ex: SecurityException) {
+                    Build.UNKNOWN
+                }
+            } else {
+                build["serialNumber"] = Build.SERIAL
+            }
+
             result.success(build)
         } else {
             result.notImplemented()

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -115,6 +115,7 @@ void main() {
     expect(androidInfo.type, isNotNull);
     expect(androidInfo.isPhysicalDevice, isNotNull);
     expect(androidInfo.systemFeatures, isNotNull);
+    expect(androidInfo.serialNumber, isNotNull);
   }, skip: !Platform.isAndroid);
 
   testWidgets('Check all macos info values are available',

--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -108,6 +108,7 @@ class _MyAppState extends State<MyApp> {
       'displayHeightInches': build.displayMetrics.heightInches,
       'displayXDpi': build.displayMetrics.xDpi,
       'displayYDpi': build.displayMetrics.yDpi,
+      'serialNumber': build.serialNumber,
     };
   }
 

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -32,6 +32,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
     required this.isPhysicalDevice,
     required List<String> systemFeatures,
     required this.displayMetrics,
+    required this.serialNumber,
   })  : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
         supported64BitAbis = List<String>.unmodifiable(supported64BitAbis),
         supportedAbis = List<String>.unmodifiable(supportedAbis),
@@ -117,6 +118,12 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
   /// Information about the current android display.
   final AndroidDisplayMetrics displayMetrics;
 
+  /// Hardware serial number of the device, if available
+  ///
+  /// There are special restrictions on this identifier, more info here:
+  /// https://developer.android.com/reference/android/os/Build#getSerial()
+  final String serialNumber;
+
   /// Deserializes from the message received from [_kChannel].
   static AndroidDeviceInfo fromMap(Map<String, dynamic> map) {
     return AndroidDeviceInfo._(
@@ -144,6 +151,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
       systemFeatures: _fromList(map['systemFeatures'] ?? []),
       displayMetrics: AndroidDisplayMetrics._fromMap(
           map['displayMetrics']?.cast<String, dynamic>() ?? {}),
+      serialNumber: map['serialNumber'],
     );
   }
 

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
@@ -42,4 +42,5 @@ const fakeAndroidDeviceInfo = <String, dynamic>{
   'supported64BitAbis': fakeSupported64BitAbis,
   'supported32BitAbis': fakeSupported32BitAbis,
   'displayMetrics': fakeDisplayMetrics,
+  'serialNumber': 'SERIAL',
 };

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
@@ -42,6 +42,7 @@ void main() {
         expect(androidDeviceInfo.displayMetrics.heightPx, 2220);
         expect(androidDeviceInfo.displayMetrics.xDpi, 530.0859);
         expect(androidDeviceInfo.displayMetrics.yDpi, 529.4639);
+        expect(androidDeviceInfo.serialNumber, 'SERIAL');
       });
 
       test('toMap should return map with correct key and map', () {


### PR DESCRIPTION
## Description

Add `serialNumber` property to `AndroidDeviceInfo` class

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/840

## Checklist

- [X] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.

