### PR TITLE
fix: Data type issue - type 'String' is not a subtype of type 'bool'

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:developer';
 import 'dart:math' as math show sqrt;
 import 'package:device_info_plus_platform_interface/model/base_device_info.dart';
 

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:developer';
 import 'dart:math' as math show sqrt;
 import 'package:device_info_plus_platform_interface/model/base_device_info.dart';
 
@@ -140,7 +141,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
       supportedAbis: _fromList(map['supportedAbis'] ?? []),
       tags: map['tags'],
       type: map['type'],
-      isPhysicalDevice: map['isPhysicalDevice'],
+      isPhysicalDevice: map['isPhysicalDevice'] == 'true',
       systemFeatures: _fromList(map['systemFeatures'] ?? []),
       displayMetrics: AndroidDisplayMetrics._fromMap(
           map['displayMetrics']?.cast<String, dynamic>() ?? {}),

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
@@ -32,7 +32,7 @@ const fakeAndroidDeviceInfo = <String, dynamic>{
   'product': 'product',
   'display': 'display',
   'hardware': 'hardware',
-  'isPhysicalDevice': true,
+  'isPhysicalDevice': 'true',
   'bootloader': 'bootloader',
   'fingerprint': 'fingerprint',
   'manufacturer': 'manufacturer',


### PR DESCRIPTION
type 'String' is not a subtype of type 'bool'

<img width="502" alt="Screenshot 2022-12-04 at 9 20 45 PM" src="https://user-images.githubusercontent.com/55572605/205501442-bdc689f6-f25a-4889-a20a-4c2877fd791f.png">

Changes:
packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart

Line number 143

<img width="425" alt="Screenshot 2022-12-04 at 9 29 29 PM" src="https://user-images.githubusercontent.com/55572605/205501519-16a833b5-b2ef-4b3c-b7e3-17fbd830c128.png">
