### PR TITLE
docs(all): Updates for READMEs and website pages

### DIFF
--- a/docs/android_alarm_manager_plus/usage.mdx
+++ b/docs/android_alarm_manager_plus/usage.mdx
@@ -33,7 +33,6 @@ Next, within the `<application></application>` tags, add:
     </intent-filter>
 </receiver>
 ```
-Check out our documentation website to learn more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/overview)
 
 Then in Dart code add:
 

--- a/docs/android_intent_plus/usage.mdx
+++ b/docs/android_intent_plus/usage.mdx
@@ -57,3 +57,22 @@ of integers or strings.
 > can be used for deep linking. Url launcher can also be used for creating
 > ACTION_VIEW intents for Android, however this intent plugin also allows
 > clients to set extra parameters for the intent.
+
+## Android 11 package visibility
+
+Android 11 introduced new permissions for package visibility.
+If you plan to use `canResolveActivity()` method, you need to specify queries in `AndroidManifest.xml` with specific package names:
+
+https://developer.android.com/training/package-visibility/declaring
+
+you can read more about package visibility on Android on Android Developers blog:
+
+https://medium.com/androiddevelopers/package-visibility-in-android-11-cc857f221cd9
+
+or Official Documentation
+
+https://developer.android.com/training/package-visibility
+
+please note that some packages are visible automatically and you don't have to specify queries:
+
+https://developer.android.com/training/package-visibility/automatic

--- a/docs/battery_plus/overview.mdx
+++ b/docs/battery_plus/overview.mdx
@@ -6,12 +6,7 @@ hide_title: true
 
 ## Battery Plus Overview
 
-Battery plus 🔋 is a Flutter plugin that helps you get information about the current state of the device battery on which the app is running on, for instance, the percentage of the battery and charging status.
-
-:::note
-Battery plus is going to replace the [original Battery plugin](https://pub.dev/packages/battery),
-if you have been using it, it's better to switch to this one.
-:::
+Battery plus is a Flutter plugin that helps you get information about the current state of the device battery on which the app is running on, for instance, the percentage of the battery and charging status.
 
 ### Get started
 
@@ -38,5 +33,4 @@ $ flutter run
 
 ### Next steps
 
-1. Read the [usage page](usage.mdx) to see examples of how to use the package.
-<!-- 2. Go through our [tutorial](tutorial) explaining the example application. -->
+Read the [usage page](usage.mdx) to see examples of how to use the package.

--- a/docs/connectivity_plus/usage.mdx
+++ b/docs/connectivity_plus/usage.mdx
@@ -32,17 +32,17 @@ Using `checkConnectivity()` method, you may get one of 3 network statuses:
 3. **None:** not connected at all.
 
 :::caution
-Note that on **Android**, this does not guarantee connection to internet. 
-For instance, the app might have WiFi access but it might be a VPN or 
+Note that on **Android**, this does not guarantee connection to internet.
+For instance, the app might have WiFi access but it might be a VPN or
 a hotel WiFi with no access to internet.
 :::
 
 ### Get Notified of Network Changes
 
-In most use casses, you will probably use this package to know when your 
-user is connected to the internet or not, and for that you are provided 
-with a method that gives you the realtime status of the connection, 
-therefore enable and disable certain parts of your app that dependss on 
+In most use casses, you will probably use this package to know when your
+user is connected to the internet or not, and for that you are provided
+with a method that gives you the realtime status of the connection,
+therefore enable and disable certain parts of your app that dependss on
 user's connectivity.
 
 #### 1. Declare a StreamSubscription
@@ -53,13 +53,13 @@ StreamSubscription<ConnectivityResult> _connectivitySubscription;
 
 #### 2. Listen to the Stream
 
-Use `onConnectivityChanged` method that has a return type `Stream<ConnectivityResult>`, 
+Use `onConnectivityChanged` method that has a return type `Stream<ConnectivityResult>`,
 to register a listener.
 
 :::note
-Note that connectivity changes are no longer communicated to Android apps 
-in the background starting with **Android 8.0**. 
-*You should always check for connectivity status when your app is resumed.* 
+Note that connectivity changes are no longer communicated to Android apps
+in the background starting with **Android 8.0**.
+*You should always check for connectivity status when your app is resumed.*
 The broadcast is only useful when your application is in the **foreground**.
 :::
 
@@ -71,7 +71,6 @@ ConnectivityResult connectivityResult = ConnectivityResult.none;
 @override
 void initState() {
   super.initState();
-
   _connectivitySubscription =
       _connectivity.onConnectivityChanged.listen(_updateConnectionStatus);
 }
@@ -79,9 +78,8 @@ void initState() {
 // Make sure to cancel subscription after you are done
 @override
 dispose() {
-  super.dispose();
-
   subscription.cancel();
+  super.dispose();
 }
 ```
 
@@ -96,18 +94,18 @@ Future<void> _updateConnectionStatus(ConnectivityResult result) async {
 ```
 
 :::caution
-You should not be using the current network status for deciding 
-whether you can reliably make a network connection. 
-Always guard your app code against timeouts and errors that might come 
+You should not be using the current network status for deciding
+whether you can reliably make a network connection.
+Always guard your app code against timeouts and errors that might come
 from the network layer with `try/catch`.
 :::
 
 ### [Web Only] Limitations
 
-In order to retrieve information about the quality/speed of a browser's connection, 
-the web implementation of the `connectivity` plugin uses the browser's 
-[**NetworkInformation** Web API](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation), 
-which as of this writing (Feburary 2021) is still "experimental", and not available in 
+In order to retrieve information about the quality/speed of a browser's connection,
+the web implementation of the `connectivity` plugin uses the browser's
+[**NetworkInformation** Web API](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation),
+which as of this writing (Feburary 2021) is still "experimental", and not available in
 all browsers:
 
 ![Data on support for the netinfo feature across the major browsers from caniuse.com](https://caniuse.bitsofco.de/image/netinfo.png)
@@ -116,10 +114,10 @@ On desktop browsers, this API only returns a very broad set of connectivity stat
 
 **Fallback to `navigator.onLine`**
 
-For those browsers where the NetworkInformation Web API is not available, the plugin falls back to the [**NavigatorOnLine** Web API](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine), which is more broadly supported: 
+For those browsers where the NetworkInformation Web API is not available, the plugin falls back to the [**NavigatorOnLine** Web API](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorOnLine), which is more broadly supported:
 
 ![Data on support for the online-status feature across the major browsers from caniuse.com](https://caniuse.bitsofco.de/image/online-status.png)
 
-The NavigatorOnLine API is [provided by `dart:html`](https://api.dart.dev/stable/2.7.2/dart-html/Navigator/onLine.html), 
-and only supports a boolean connectivity status (either online or offline), with no network speed information. 
+The NavigatorOnLine API is [provided by `dart:html`](https://api.dart.dev/stable/2.7.2/dart-html/Navigator/onLine.html),
+and only supports a boolean connectivity status (either online or offline), with no network speed information.
 In those cases the plugin will return either `wifi` (when the browser is online) or `none` (when it's not).

--- a/docs/package_info_plus/usage.mdx
+++ b/docs/package_info_plus/usage.mdx
@@ -12,6 +12,13 @@ application package. This works both on iOS and Android.
 ```dart
 import 'package:package_info_plus/package_info_plus.dart';
 
+...
+
+// Be sure to add this line if `PackageInfo.fromPlatform()` is called before runApp()
+WidgetsFlutterBinding.ensureInitialized();
+
+...
+
 PackageInfo packageInfo = await PackageInfo.fromPlatform();
 
 String appName = packageInfo.appName;
@@ -20,9 +27,26 @@ String version = packageInfo.version;
 String buildNumber = packageInfo.buildNumber;
 ```
 
-## Known Issue
+## Known Issues
+
+### iOS
+
+#### Plugin returns incorrect app version
+
+Flutter build tools allow only digits and `.` (dot) symbols to be used in `version`
+of `pubspec.yaml` on iOS/MacOS to comply with official version format from Apple.
+
+More info available
+in [this comment](https://github.com/fluttercommunity/plus_plugins/issues/389#issuecomment-1106764429)
+
+#### I have changed version in pubspec.yaml and plugin returns wrong info
 
 As noted on [issue 20761](https://github.com/flutter/flutter/issues/20761#issuecomment-493434578), package_info on iOS
 requires the Xcode build folder to be rebuilt after changes to the version string in `pubspec.yaml`.
 Clean the Xcode build folder with:
 `XCode Menu -> Product -> (Holding Option Key) Clean build folder`.
+
+### Android (and potentially all platforms)
+
+Calling to `PackageInfo.fromPlatform()` before the `runApp()` call will cause an exception.
+See https://github.com/fluttercommunity/plus_plugins/issues/309

--- a/packages/android_alarm_manager_plus/README.md
+++ b/packages/android_alarm_manager_plus/README.md
@@ -142,5 +142,5 @@ flutter driver test_driver/android_alarm_manager_plus_e2e.dart
 
 ## Learn more
 
-- [API Documentation](https://pub.dev/documentation/android_alarm_manager_plus/latest/android_alarm_manager_plus/android_alarm_manager_plus-library.html).
+- [API Documentation](https://pub.dev/documentation/android_alarm_manager_plus/latest/android_alarm_manager_plus/android_alarm_manager_plus-library.html)
 - [Plugin documentation website](https://plus.fluttercommunity.dev/docs/android_alarm_manager_plus/overview/)

--- a/packages/android_alarm_manager_plus/README.md
+++ b/packages/android_alarm_manager_plus/README.md
@@ -142,5 +142,5 @@ flutter driver test_driver/android_alarm_manager_plus_e2e.dart
 
 ## Learn more
 
-[API Documentation](https://pub.dev/documentation/android_alarm_manager_plus/latest/android_alarm_manager_plus/android_alarm_manager_plus-library.html).
-[Plugin documentation website](https://plus.fluttercommunity.dev/docs/android_alarm_manager_plus/overview/)
+- [API Documentation](https://pub.dev/documentation/android_alarm_manager_plus/latest/android_alarm_manager_plus/android_alarm_manager_plus-library.html).
+- [Plugin documentation website](https://plus.fluttercommunity.dev/docs/android_alarm_manager_plus/overview/)

--- a/packages/android_alarm_manager_plus/README.md
+++ b/packages/android_alarm_manager_plus/README.md
@@ -49,7 +49,6 @@ Next, within the `<application></application>` tags, add:
 </receiver>
 
 ```
-Check out our documentation website to learn more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/overview)
 
 Then in Dart code add:
 
@@ -140,3 +139,8 @@ To run the Flutter Driver tests, cd into `example` and run:
 ```
 flutter driver test_driver/android_alarm_manager_plus_e2e.dart
 ```
+
+## Learn more
+
+[API Documentation](https://pub.dev/documentation/android_alarm_manager_plus/latest/android_alarm_manager_plus/android_alarm_manager_plus-library.html).
+[Plugin documentation website](https://plus.fluttercommunity.dev/docs/android_alarm_manager_plus/overview/)

--- a/packages/android_intent_plus/README.md
+++ b/packages/android_intent_plus/README.md
@@ -95,5 +95,5 @@ https://developer.android.com/training/package-visibility/automatic
 
 ## Learn more
 
-[API Documentation](https://pub.dev/documentation/android_intent_plus/latest/).
-[Plugin documentation website](https://plus.fluttercommunity.dev/docs/android_intent_plus/overview)
+- [API Documentation](https://pub.dev/documentation/android_intent_plus/latest/).
+- [Plugin documentation website](https://plus.fluttercommunity.dev/docs/android_intent_plus/overview)

--- a/packages/android_intent_plus/README.md
+++ b/packages/android_intent_plus/README.md
@@ -8,9 +8,11 @@
 
 <center><a href="https://flutter.dev/docs/development/packages-and-plugins/favorites" target="_blank" rel="noreferrer noopener"><img src="../../website/static/img/flutter-favorite-badge.png" width="100" alt="build"></a></center>
 
-This plugin allows Flutter apps to launch arbitrary intents when the platform
-is Android. If the plugin is invoked on iOS, it will crash your app. In checked
-mode, we assert that the platform should be Android.
+This plugin allows Flutter apps to launch arbitrary intents when the platform is Android.
+
+> **Warning**
+>
+> If the plugin is invoked on iOS, it will crash your app. In checked mode, we assert that the platform should be Android.
 
 Use it by specifying action, category, data and extra arguments for the intent.
 It does not support returning the result of the launched activity. Sample usage:
@@ -58,7 +60,9 @@ On the Android side, the arguments are used to populate an Android `Bundle`
 instance. This process currently restricts the use of lists to homogeneous lists
 of integers or strings.
 
-> Note that a similar method does not currently exist for iOS. Instead, the
+> **Note**
+>
+> There is no similar method for iOS. Instead, the
 > [url_launcher](https://pub.dartlang.org/packages/url_launcher) plugin
 > can be used for deep linking. Url launcher can also be used for creating
 > ACTION_VIEW intents for Android, however this intent plugin also allows
@@ -91,4 +95,5 @@ https://developer.android.com/training/package-visibility/automatic
 
 ## Learn more
 
-Check out our documentation website to learn more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/overview)
+[API Documentation](https://pub.dev/documentation/android_intent_plus/latest/).
+[Plugin documentation website](https://plus.fluttercommunity.dev/docs/android_intent_plus/overview)

--- a/packages/android_intent_plus/README.md
+++ b/packages/android_intent_plus/README.md
@@ -95,5 +95,5 @@ https://developer.android.com/training/package-visibility/automatic
 
 ## Learn more
 
-- [API Documentation](https://pub.dev/documentation/android_intent_plus/latest/).
+- [API Documentation](https://pub.dev/documentation/android_intent_plus/latest/)
 - [Plugin documentation website](https://plus.fluttercommunity.dev/docs/android_intent_plus/overview)

--- a/packages/battery_plus/battery_plus/README.md
+++ b/packages/battery_plus/battery_plus/README.md
@@ -42,5 +42,5 @@ battery.onBatteryStateChanged.listen((BatteryState state) {
 
 ## Learn more
 
-- [API Documentation](https://pub.dev/documentation/battery_plus/latest/battery_plus/battery_plus-library.html).
+- [API Documentation](https://pub.dev/documentation/battery_plus/latest/battery_plus/battery_plus-library.html)
 - [Plugin documentation website](https://plus.fluttercommunity.dev/docs/battery_plus/overview)

--- a/packages/battery_plus/battery_plus/README.md
+++ b/packages/battery_plus/battery_plus/README.md
@@ -42,5 +42,5 @@ battery.onBatteryStateChanged.listen((BatteryState state) {
 
 ## Learn more
 
-[API Documentation](https://pub.dev/documentation/battery_plus/latest/battery_plus/battery_plus-library.html).
-[Plugin documentation website](https://plus.fluttercommunity.dev/docs/battery_plus/overview)
+- [API Documentation](https://pub.dev/documentation/battery_plus/latest/battery_plus/battery_plus-library.html).
+- [Plugin documentation website](https://plus.fluttercommunity.dev/docs/battery_plus/overview)

--- a/packages/battery_plus/battery_plus/README.md
+++ b/packages/battery_plus/battery_plus/README.md
@@ -20,7 +20,7 @@ A Flutter plugin to access various information about the battery of the device t
 
 ## Usage
 
-To use this plugin, add `battery_plus` as a [dependency in your pubspec.yaml file](https://plus.fluttercommunity.dev/docs/overview).
+Add `battery_plus` as a dependency in your pubspec.yaml file.
 
 ### Example
 
@@ -39,3 +39,8 @@ battery.onBatteryStateChanged.listen((BatteryState state) {
   // Do something with new state
 });
 ```
+
+## Learn more
+
+[API Documentation](https://pub.dev/documentation/battery_plus/latest/battery_plus/battery_plus-library.html).
+[Plugin documentation website](https://plus.fluttercommunity.dev/docs/battery_plus/overview)

--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -89,5 +89,5 @@ Other than the approximate "downlink" speed, where available, and due to securit
 
 ## Learn more
 
-- [API Documentation](https://pub.dev/documentation/connectivity_plus/latest/connectivity_plus/connectivity_plus-library.html).
+- [API Documentation](https://pub.dev/documentation/connectivity_plus/latest/connectivity_plus/connectivity_plus-library.html)
 - [Plugin documentation website](https://plus.fluttercommunity.dev/docs/connectivity_plus/overview)

--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -89,5 +89,5 @@ Other than the approximate "downlink" speed, where available, and due to securit
 
 ## Learn more
 
-[API Documentation](https://pub.dev/documentation/connectivity_plus/latest/connectivity_plus/connectivity_plus-library.html).
-[Plugin documentation website](https://plus.fluttercommunity.dev/docs/connectivity_plus/overview)
+- [API Documentation](https://pub.dev/documentation/connectivity_plus/latest/connectivity_plus/connectivity_plus-library.html).
+- [Plugin documentation website](https://plus.fluttercommunity.dev/docs/connectivity_plus/overview)

--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -13,7 +13,9 @@
 This plugin allows Flutter apps to discover network connectivity and configure
 themselves accordingly. It can distinguish between cellular vs WiFi connection.
 
-> Note that on Android, this does not guarantee connection to Internet. For instance, the app might have wifi access but it might be a VPN or a hotel WiFi with no access.
+> **Note**
+>
+> On Android, this does not guarantee connection to Internet. For instance, the app might have wifi access but it might be a VPN or a hotel WiFi > with no access.
 
 ## Platform Support
 
@@ -28,7 +30,7 @@ Sample usage to check current status:
 ```dart
 import 'package:connectivity_plus/connectivity_plus.dart';
 
-var connectivityResult = await (Connectivity().checkConnectivity());
+final connectivityResult = await (Connectivity().checkConnectivity());
 if (connectivityResult == ConnectivityResult.mobile) {
   // I am connected to a mobile network.
 } else if (connectivityResult == ConnectivityResult.wifi) {
@@ -36,9 +38,9 @@ if (connectivityResult == ConnectivityResult.mobile) {
 }
 ```
 
-Check out our documentation website to learn more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/overview)
-
-> Note that you should not be using the current network status for deciding whether you can reliably make a network connection. Always guard your app code against timeouts and errors that might come from the network layer.
+> **Note**
+>
+> You should not be using the current network status for deciding whether you can reliably make a network connection. Always guard your app code against timeouts and errors that might come from the network layer.
 
 You can also listen for network state changes by subscribing to the stream
 exposed by connectivity plugin:
@@ -52,19 +54,20 @@ initState() {
 
   subscription = Connectivity().onConnectivityChanged.listen((ConnectivityResult result) {
     // Got a new connectivity status!
-  })
+  });
 }
 
 // Be sure to cancel subscription after you are done
 @override
 dispose() {
-  super.dispose();
-
   subscription.cancel();
+  super.dispose();
 }
 ```
 
-Note that connectivity changes are no longer communicated to Android apps in the background starting with Android O. _You should always check for connectivity status when your app is resumed._ The broadcast is only useful when your application is in the foreground.
+> **Note**
+>
+> Connectivity changes are no longer communicated to Android apps in the background starting with Android O (8.0). _You should always check for connectivity status when your app is resumed._ The broadcast is only useful when your application is in the foreground.
 
 ## Limitations on the web platform
 
@@ -84,9 +87,7 @@ The NavigatorOnLine API is [provided by `dart:html`](https://api.dart.dev/stable
 
 Other than the approximate "downlink" speed, where available, and due to security and privacy concerns, **no Web browser will provide** any specific information about the actual network your users' device is connected to, like **the SSID on a Wi-Fi, or the MAC address of their device.**
 
-## Getting Started
+## Learn more
 
-For help getting started with Flutter, view our online
-[documentation](https://flutter.dev/).
-
-For help on editing plugin code, view the [documentation](https://flutter.dev/platform-plugins/#edit-code).
+[API Documentation](https://pub.dev/documentation/connectivity_plus/latest/connectivity_plus/connectivity_plus-library.html).
+[Plugin documentation website](https://plus.fluttercommunity.dev/docs/connectivity_plus/overview)

--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -53,6 +53,7 @@ final deviceInfo = await deviceInfoPlugin.deviceInfo;
 final allInfo = deviceInfo.data;
 ```
 
-You will find links to the API docs on the [pub page](https://pub.dev/documentation/device_info_plus/latest/).
+## Learn more
 
-Check out our documentation website to learn more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/overview)
+[API Documentation](https://pub.dev/documentation/device_info_plus/latest/device_info_plus/device_info_plus-library.html).
+[Plugin documentation website](https://plus.fluttercommunity.dev/docs/device_info_plus/overview)

--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -55,5 +55,5 @@ final allInfo = deviceInfo.data;
 
 ## Learn more
 
-- [API Documentation](https://pub.dev/documentation/device_info_plus/latest/device_info_plus/device_info_plus-library.html).
+- [API Documentation](https://pub.dev/documentation/device_info_plus/latest/device_info_plus/device_info_plus-library.html)
 - [Plugin documentation website](https://plus.fluttercommunity.dev/docs/device_info_plus/overview)

--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -55,5 +55,5 @@ final allInfo = deviceInfo.data;
 
 ## Learn more
 
-[API Documentation](https://pub.dev/documentation/device_info_plus/latest/device_info_plus/device_info_plus-library.html).
-[Plugin documentation website](https://plus.fluttercommunity.dev/docs/device_info_plus/overview)
+- [API Documentation](https://pub.dev/documentation/device_info_plus/latest/device_info_plus/device_info_plus-library.html).
+- [Plugin documentation website](https://plus.fluttercommunity.dev/docs/device_info_plus/overview)

--- a/packages/network_info_plus/network_info_plus/README.md
+++ b/packages/network_info_plus/network_info_plus/README.md
@@ -23,20 +23,20 @@ The functionality is not supported on Web.
 
 ## Usage
 
-You can get wi-fi related information using:
+You can get Wi-Fi related information using:
 
 ```dart
 import 'package:network_info_plus/network_info_plus.dart';
 
 final info = NetworkInfo();
 
-var wifiName = await info.getWifiName(); // "FooNetwork"
-var wifiBSSID = await info.getWifiBSSID(); // 11:22:33:44:55:66
-var wifiIP = await info.getWifiIP(); // 192.168.1.43
-var wifiIPv6 = await info.getWifiIPv6(); // 2001:0db8:85a3:0000:0000:8a2e:0370:7334
-var wifiSubmask = await info.getWifiSubmask(); // 255.255.255.0
-var wifiBroadcast = await info.getWifiBroadcast(); // 192.168.1.255
-var wifiGateway = await info.getWifiGatewayIP(); // 192.168.1.1
+final wifiName = await info.getWifiName(); // "FooNetwork"
+final wifiBSSID = await info.getWifiBSSID(); // 11:22:33:44:55:66
+final wifiIP = await info.getWifiIP(); // 192.168.1.43
+final wifiIPv6 = await info.getWifiIPv6(); // 2001:0db8:85a3:0000:0000:8a2e:0370:7334
+final wifiSubmask = await info.getWifiSubmask(); // 255.255.255.0
+final wifiBroadcast = await info.getWifiBroadcast(); // 192.168.1.255
+final wifiGateway = await info.getWifiGatewayIP(); // 192.168.1.1
 ```
 
 ### Device permissions
@@ -57,7 +57,9 @@ To successfully get WiFi Name or Wi-Fi BSSID starting with Android 1O, ensure al
 
 - If you use device with Android 12 (API level 31) and newer be sure that your app has ACCESS_NETWORK_STATE permission.
 
-**This package does not provide the ACCESS_FINE_LOCATION nor the ACCESS_COARSE_LOCATION permission by default**
+> **Note**
+>
+> This package does not provide the ACCESS_FINE_LOCATION nor the ACCESS_COARSE_LOCATION permission by default
 
 #### iOS 12
 
@@ -92,4 +94,7 @@ Make sure to add the following keys to your _Info.plist_ file, located in `<proj
 - `NSLocationAlwaysAndWhenInUseUsageDescription` - describe why the app needs access to the user’s location information all the time (foreground and background). This is called _Privacy - Location Always and When In Use Usage Description_ in the visual editor.
 - `NSLocationWhenInUseUsageDescription` - describe why the app needs access to the user’s location information when the app is running in the foreground. This is called _Privacy - Location When In Use Usage Description_ in the visual editor.
 
-Check out our documentation website to learn more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/overview)
+## Learn more
+
+[API Documentation](https://pub.dev/documentation/network_info_plus/latest/network_info_plus/network_info_plus-library.html).
+[Plugin documentation website](https://plus.fluttercommunity.dev/docs/network_info_plus/overview)

--- a/packages/network_info_plus/network_info_plus/README.md
+++ b/packages/network_info_plus/network_info_plus/README.md
@@ -96,5 +96,5 @@ Make sure to add the following keys to your _Info.plist_ file, located in `<proj
 
 ## Learn more
 
-- [API Documentation](https://pub.dev/documentation/network_info_plus/latest/network_info_plus/network_info_plus-library.html).
+- [API Documentation](https://pub.dev/documentation/network_info_plus/latest/network_info_plus/network_info_plus-library.html)
 - [Plugin documentation website](https://plus.fluttercommunity.dev/docs/network_info_plus/overview)

--- a/packages/network_info_plus/network_info_plus/README.md
+++ b/packages/network_info_plus/network_info_plus/README.md
@@ -96,5 +96,5 @@ Make sure to add the following keys to your _Info.plist_ file, located in `<proj
 
 ## Learn more
 
-[API Documentation](https://pub.dev/documentation/network_info_plus/latest/network_info_plus/network_info_plus-library.html).
-[Plugin documentation website](https://plus.fluttercommunity.dev/docs/network_info_plus/overview)
+- [API Documentation](https://pub.dev/documentation/network_info_plus/latest/network_info_plus/network_info_plus-library.html).
+- [Plugin documentation website](https://plus.fluttercommunity.dev/docs/network_info_plus/overview)

--- a/packages/package_info_plus/package_info_plus/README.md
+++ b/packages/package_info_plus/package_info_plus/README.md
@@ -49,8 +49,7 @@ String buildNumber = packageInfo.buildNumber;
 Flutter build tools allow only digits and `.` (dot) symbols to be used in `version`
 of `pubspec.yaml` on iOS/MacOS to comply with official version format from Apple.
 
-More info available
-in [this comment](https://github.com/fluttercommunity/plus_plugins/issues/389#issuecomment-1106764429)
+More info available in [this comment](https://github.com/fluttercommunity/plus_plugins/issues/389#issuecomment-1106764429)
 
 #### I have changed version in pubspec.yaml and plugin returns wrong info
 
@@ -64,6 +63,8 @@ string in `pubspec.yaml`. Clean the Xcode build folder with:
 Calling to `PackageInfo.fromPlatform()` before the `runApp()` call will cause an exception.
 See https://github.com/fluttercommunity/plus_plugins/issues/309
 
-Check out our documentation website to learn
-more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/package_info_plus/overview/)
+## Learn more
+
+[API Documentation](https://pub.dev/documentation/package_info_plus/latest/package_info_plus/package_info_plus-library.html).
+[Plugin documentation website](https://plus.fluttercommunity.dev/docs/package_info_plus/overview/)
 

--- a/packages/package_info_plus/package_info_plus/README.md
+++ b/packages/package_info_plus/package_info_plus/README.md
@@ -65,6 +65,6 @@ See https://github.com/fluttercommunity/plus_plugins/issues/309
 
 ## Learn more
 
-- [API Documentation](https://pub.dev/documentation/package_info_plus/latest/package_info_plus/package_info_plus-library.html).
+- [API Documentation](https://pub.dev/documentation/package_info_plus/latest/package_info_plus/package_info_plus-library.html)
 - [Plugin documentation website](https://plus.fluttercommunity.dev/docs/package_info_plus/overview/)
 

--- a/packages/package_info_plus/package_info_plus/README.md
+++ b/packages/package_info_plus/package_info_plus/README.md
@@ -65,6 +65,6 @@ See https://github.com/fluttercommunity/plus_plugins/issues/309
 
 ## Learn more
 
-[API Documentation](https://pub.dev/documentation/package_info_plus/latest/package_info_plus/package_info_plus-library.html).
-[Plugin documentation website](https://plus.fluttercommunity.dev/docs/package_info_plus/overview/)
+- [API Documentation](https://pub.dev/documentation/package_info_plus/latest/package_info_plus/package_info_plus-library.html).
+- [Plugin documentation website](https://plus.fluttercommunity.dev/docs/package_info_plus/overview/)
 

--- a/packages/package_info_plus/package_info_plus/README.md
+++ b/packages/package_info_plus/package_info_plus/README.md
@@ -10,19 +10,17 @@
 <center><a href="https://flutter.dev/docs/development/packages-and-plugins/favorites" target="_blank" rel="noreferrer noopener"><img src="../../../website/static/img/flutter-favorite-badge.png" width="100" alt="build"></a></center>
 </p>
 
-This Flutter plugin provides an API for querying information about an
-application package.
+This Flutter plugin provides an API for querying information about an application package.
 
 ## Platform Support
 
-| Android | iOS | MacOS | Web | Linux | Windows |
-| :-----: | :-: | :---: | :-: | :---: | :-----: |
-|   ✔️    | ✔️  |  ✔️   | ✔️  |  ✔️   |   ✔️    |
+| Android | iOS | MacOS | Web | Linux | Windows | | :-----: | :-: | :---: | :-: | :---: | :-----: |
+| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
 
 ## Usage
 
-You can use the PackageInfo to query information about the
-application package. This works both on iOS and Android.
+You can use the PackageInfo to query information about the application package. This works both on
+iOS and Android.
 
 ```dart
 import 'package:package_info_plus/package_info_plus.dart';
@@ -46,14 +44,26 @@ String buildNumber = packageInfo.buildNumber;
 
 ### iOS
 
-As noted on [issue 20761](https://github.com/flutter/flutter/issues/20761#issuecomment-493434578), package_info on iOS
-requires the Xcode build folder to be rebuilt after changes to the version string in `pubspec.yaml`.
-Clean the Xcode build folder with:
-`XCode Menu -> Product -> (Holding Option Key) Clean build folder`.
+#### Plugin returns incorrect app version
 
-Check out our documentation website to learn more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/overview)
+Flutter build tools allow only digits and `.` (dot) symbols to be used in `version`
+of `pubspec.yaml` on iOS/MacOS to comply with official version format from Apple.
+
+More info available
+in [this comment](https://github.com/fluttercommunity/plus_plugins/issues/389#issuecomment-1106764429)
+
+#### I have changed version in pubspec.yaml and plugin returns wrong info
+
+As noted on [issue 20761](https://github.com/flutter/flutter/issues/20761#issuecomment-493434578),
+package_info_plus on iOS requires the Xcode build folder to be rebuilt after changes to the version
+string in `pubspec.yaml`. Clean the Xcode build folder with:
+`XCode Menu -> Product -> (Holding Option Key) Clean build folder`.
 
 ### Android (and potentially all platforms)
 
 Calling to `PackageInfo.fromPlatform()` before the `runApp()` call will cause an exception.
 See https://github.com/fluttercommunity/plus_plugins/issues/309
+
+Check out our documentation website to learn
+more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/package_info_plus/overview/)
+

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -69,5 +69,5 @@ sensor data.
 
 ## Learn more
 
-- [API Documentation](https://pub.dev/documentation/sensors_plus/latest/sensors_plus/sensors_plus-library.html).
+- [API Documentation](https://pub.dev/documentation/sensors_plus/latest/sensors_plus/sensors_plus-library.html)
 - [Plugin documentation website](https://plus.fluttercommunity.dev/docs/sensors_plus/overview)

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -19,8 +19,7 @@ sensors.
 
 ## Usage
 
-To use this plugin, add `sensors_plus` as a [dependency in your pubspec.yaml
-file](https://plus.fluttercommunity.dev/docs/overview).
+Add `sensors_plus` as a dependency in your pubspec.yaml file.
 
 This will expose such classes of sensor events through a set of streams:
 
@@ -68,4 +67,7 @@ magnetometerEvents.listen((MagnetometerEvent event) {
 Also see the `example` subdirectory for an example application that uses the
 sensor data.
 
-Check out our website to learn more: [Plus Plugins documentation](https://plus.fluttercommunity.dev/docs/overview)
+## Learn more
+
+- [API Documentation](https://pub.dev/documentation/sensors_plus/latest/sensors_plus/sensors_plus-library.html).
+- [Plugin documentation website](https://plus.fluttercommunity.dev/docs/sensors_plus/overview)

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -121,6 +121,6 @@ See the `main.dart` in the `example` for a complete example.
 
 ## Learn more
 
-- [API Documentation](https://pub.dev/documentation/share_plus/latest/share_plus/share_plus-library.html).
+- [API Documentation](https://pub.dev/documentation/share_plus/latest/share_plus/share_plus-library.html)
 - [Plugin documentation website](https://plus.fluttercommunity.dev/docs/share_plus/overview)
 

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -121,6 +121,6 @@ See the `main.dart` in the `example` for a complete example.
 
 ## Learn more
 
-[API Documentation](https://pub.dev/documentation/share_plus/latest/share_plus/share_plus-library.html).
-[Plugin documentation website](https://plus.fluttercommunity.dev/docs/share_plus/overview)
+- [API Documentation](https://pub.dev/documentation/share_plus/latest/share_plus/share_plus-library.html).
+- [Plugin documentation website](https://plus.fluttercommunity.dev/docs/share_plus/overview)
 

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -67,15 +67,13 @@ package.
 Share.shareXFiles([XFile('assets/hello.txt')], text: 'Great picture');
 ```
 
-Check out our documentation website to learn more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/overview)
-
 ## Known Issues
 
 ### Sharing data created with XFile.fromData
 
 When sharing data created with `XFile.fromData`, the plugin will write a temporal file inside the cache directory of the app, so it can be shared.
 
-Althouth the OS should take care of deleting those files, it is advised, that you clean up this data once in a while (e.g. on app start).
+Although the OS should take care of deleting those files, it is advised, that you clean up this data once in a while (e.g. on app start).
 
 You can access this directory using [path_provider](https://pub.dev/packages/path_provider) [getTemporaryDirectory](https://pub.dev/documentation/path_provider/latest/path_provider/getTemporaryDirectory.html).
 
@@ -120,4 +118,9 @@ await Share.share(
 ```
 
 See the `main.dart` in the `example` for a complete example.
+
+## Learn more
+
+[API Documentation](https://pub.dev/documentation/share_plus/latest/share_plus/share_plus-library.html).
+[Plugin documentation website](https://plus.fluttercommunity.dev/docs/share_plus/overview)
 


### PR DESCRIPTION
## Description

Updating docs to cleanup them a little bit and add missing info on either website or in README files (for example, added info from #389 about package_info_plus).

Also, started to use fresh Github features for admonitions in README files for better visualisation:
<img width="334" alt="Screenshot 2022-12-11 at 00 43 17" src="https://user-images.githubusercontent.com/13467769/206878155-04617f47-a145-48b4-ae5c-a445a7be7d41.png">

Will do some more docs updates in further PRs.

## Related Issues

Closes #389 

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

