### PR TITLE
docs(device_info_plus): Explain how to get serial number on Android

### DIFF
--- a/docs/device_info_plus/usage.mdx
+++ b/docs/device_info_plus/usage.mdx
@@ -28,5 +28,5 @@ print('Running on ${webBrowserInfo.userAgent}');  // e.g. "Mozilla/5.0 (X11; Ubu
 
 :::caution
 To get serial number on Android your app needs to meet one of official [requirements](https://developer.android.com/reference/android/os/Build#getSerial())
-In case the app doesn't meet any of requirements plugin will return `unknown` instead of serial.
+In case the app doesn't meet any of requirements plugin will return `unknown`.
 :::

--- a/docs/device_info_plus/usage.mdx
+++ b/docs/device_info_plus/usage.mdx
@@ -25,3 +25,8 @@ print('Running on ${iosInfo.utsname.machine}');  // e.g. "iPod7,1"
 WebBrowserInfo webBrowserInfo = await deviceInfo.webBrowserInfo;
 print('Running on ${webBrowserInfo.userAgent}');  // e.g. "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0"
 ```
+
+:::caution
+To get serial number on Android your app needs to meet one of official [requirements](https://developer.android.com/reference/android/os/Build#getSerial())
+In case the app doesn't meet any of requirements plugin will return `unknown` instead of serial.
+:::

--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -56,7 +56,7 @@ final allInfo = deviceInfo.data;
 > **Note**
 >
 > To get serial number on Android your app needs to meet one of official [requirements](https://developer.android.com/reference/android/os/Build#getSerial())
-> In case the app doesn't meet any of requirements plugin will return `unknown` instead of serial.
+> In case the app doesn't meet any of requirements plugin will return `unknown`.
 
 You will find links to the API docs on the [pub page](https://pub.dev/documentation/device_info_plus/latest/).
 

--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -53,6 +53,11 @@ final deviceInfo = await deviceInfoPlugin.deviceInfo;
 final allInfo = deviceInfo.data;
 ```
 
+> **Note**
+>
+> To get serial number on Android your app needs to meet one of official [requirements](https://developer.android.com/reference/android/os/Build#getSerial())
+> In case the app doesn't meet any of requirements plugin will return `unknown` instead of serial.
+
 You will find links to the API docs on the [pub page](https://pub.dev/documentation/device_info_plus/latest/).
 
 Check out our documentation website to learn more. [Plus plugins documentation](https://plus.fluttercommunity.dev/docs/overview)


### PR DESCRIPTION
## Description

Adding a note about getting serial number on Android after merging #840 

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

