### PR TITLE
chore(deps): Update Docusaurus dependncies

### DIFF
--- a/.github/workflows/build_preview_website.yaml
+++ b/.github/workflows/build_preview_website.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          ref: refs/pull/${{ github.event.number }}/merge
+          ref: ${{ github.ref }}
       - name: Install Dependencies
         run: npm ci
       - name: Build website
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          ref: refs/pull/${{ github.event.number }}/merge
+          ref: ${{ github.ref }}
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build_preview_website.yaml
+++ b/.github/workflows/build_preview_website.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Install Dependencies
         run: npm ci
       - name: Build website
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build_preview_website.yaml
+++ b/.github/workflows/build_preview_website.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install Dependencies
         run: npm ci
       - name: Build website
@@ -40,6 +42,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build_preview_website.yaml
+++ b/.github/workflows/build_preview_website.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install Dependencies
         run: npm ci
       - name: Build website
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build_preview_website.yaml
+++ b/.github/workflows/build_preview_website.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
+          ref: refs/pull/${{ github.event.number }}/merge
       - name: Install Dependencies
         run: npm ci
       - name: Build website
@@ -43,7 +43,7 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v3
         with:
-          ref: "refs/pull/${{ github.event.number }}/merge"
+          ref: refs/pull/${{ github.event.number }}/merge
       - name: Download Artifact
         uses: actions/download-artifact@v3
         with:

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -56,7 +56,6 @@ module.exports = {
   },
   plugins: [
     require.resolve('docusaurus-plugin-sass'),
-    // require.resolve('@docusaurus/plugin-ideal-image'),
     path.resolve(__dirname, './docusaurus-plugins/favicon-tags'),
     path.resolve(__dirname, './docusaurus-plugins/source-versions'),
   ],

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1,16 +1,16 @@
 {
   "name": "website",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "website",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "@docusaurus/core": "^2.2.0",
         "@docusaurus/plugin-google-gtag": "^2.2.0",
-        "@docusaurus/preset-classic": "^2.1.0",
+        "@docusaurus/preset-classic": "^2.2.0",
         "@types/lodash.get": "^4.4.7",
         "@types/react": "^17.0.50",
         "@types/react-router-dom": "^5.3.3",
@@ -44,29 +44,29 @@
       }
     },
     "node_modules/@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+      "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       }
     },
     "node_modules/@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+      "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
       "dependencies": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       },
       "peerDependencies": {
-        "@algolia/client-search": "^4.9.1",
-        "algoliasearch": "^4.9.1"
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
       }
     },
     "node_modules/@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+      "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
     },
     "node_modules/@algolia/cache-browser-local-storage": {
       "version": "4.14.2",
@@ -1983,18 +1983,18 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.0.tgz",
+      "integrity": "sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg=="
     },
     "node_modules/@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.0.tgz",
+      "integrity": "sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==",
       "dependencies": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@docsearch/css": "3.3.0",
         "algoliasearch": "^4.0.0"
       },
       "peerDependencies": {
@@ -2102,116 +2102,6 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/logger": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
-      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
-      "dependencies": {
-        "chalk": "^4.1.2",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/mdx-loader": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
-      "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
-      "dependencies": {
-        "@babel/parser": "^7.18.8",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "@mdx-js/mdx": "^1.6.22",
-        "escape-html": "^1.0.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "image-size": "^1.0.1",
-        "mdast-util-to-string": "^2.0.0",
-        "remark-emoji": "^2.2.0",
-        "stringify-object": "^3.3.0",
-        "tslib": "^2.4.0",
-        "unified": "^9.2.2",
-        "unist-util-visit": "^2.0.3",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.73.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
-      "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
-      "dependencies": {
-        "@docusaurus/logger": "2.2.0",
-        "@svgr/webpack": "^6.2.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "github-slugger": "^1.4.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.4.0",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.73.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils-common": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
-      "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@docusaurus/core/node_modules/@docusaurus/utils-validation": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
-      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
-      "dependencies": {
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "joi": "^17.6.0",
-        "js-yaml": "^4.1.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
     "node_modules/@docusaurus/core/node_modules/react-router-dom": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.3.tgz",
@@ -2244,9 +2134,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
+      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
@@ -2256,14 +2146,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
+      "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
       "dependencies": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -2290,7 +2180,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
       "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
-      "dev": true,
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
         "@docusaurus/types": "2.2.0",
@@ -2306,38 +2195,18 @@
         "react-dom": "*"
       }
     },
-    "node_modules/@docusaurus/module-type-aliases/node_modules/@docusaurus/types": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-      "dev": true,
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.2.0.tgz",
+      "integrity": "sha512-0mWBinEh0a5J2+8ZJXJXbrCk1tSTNf7Nm4tYAl5h2/xx+PvH/Bnu0V+7mMljYm/1QlDYALNIIaT/JcoZQFUN3w==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -2356,156 +2225,18 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-blog/node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.2.0.tgz",
+      "integrity": "sha512-BOazBR0XjzsHE+2K1wpNxz5QZmrJgmm3+0Re0EVPYFGW8qndCWGNtXW/0lGKhecVPML8yyFeAmnUCIs7xM2wPw==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -2524,173 +2255,16 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-docs/node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.2.0.tgz",
+      "integrity": "sha512-+OTK3FQHk5WMvdelz8v19PbEbx+CNT6VSpx7nVOvMNs5yJCKvmqBJBQ2ZSxROxhVDYn+CZOlmyrC56NSXzHf6g==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
@@ -2703,152 +2277,14 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/plugin-content-pages/node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.2.0.tgz",
+      "integrity": "sha512-p9vOep8+7OVl6r/NREEYxf4HMAjV8JMYJ7Bos5fCFO0Wyi9AZEo0sCTliRd7R8+dlJXZEgcngSdxAUo/Q+CJow==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
@@ -2861,152 +2297,14 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/plugin-debug/node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.2.0.tgz",
+      "integrity": "sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==",
       "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
       },
       "engines": {
@@ -3015,144 +2313,6 @@
       "peerDependencies": {
         "react": "^16.8.4 || ^17.0.0",
         "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/plugin-google-analytics/node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
@@ -3173,19 +2333,213 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/logger": {
+    "node_modules/@docusaurus/plugin-sitemap": {
       "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
-      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.2.0.tgz",
+      "integrity": "sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==",
       "dependencies": {
-        "chalk": "^4.1.2",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
+        "fs-extra": "^10.1.0",
+        "sitemap": "^7.1.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/preset-classic": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.2.0.tgz",
+      "integrity": "sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==",
+      "dependencies": {
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/plugin-debug": "2.2.0",
+        "@docusaurus/plugin-google-analytics": "2.2.0",
+        "@docusaurus/plugin-google-gtag": "2.2.0",
+        "@docusaurus/plugin-sitemap": "2.2.0",
+        "@docusaurus/theme-classic": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-search-algolia": "2.2.0",
+        "@docusaurus/types": "2.2.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/react-loadable": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
+      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
+      "dependencies": {
+        "@types/react": "*",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.2.0.tgz",
+      "integrity": "sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==",
+      "dependencies": {
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
+        "@mdx-js/react": "^1.6.22",
+        "clsx": "^1.2.1",
+        "copy-text-to-clipboard": "^3.0.1",
+        "infima": "0.2.0-alpha.42",
+        "lodash": "^4.17.21",
+        "nprogress": "^0.2.0",
+        "postcss": "^8.4.14",
+        "prism-react-renderer": "^1.3.5",
+        "prismjs": "^1.28.0",
+        "react-router-dom": "^5.3.3",
+        "rtlcss": "^3.5.0",
+        "tslib": "^2.4.0",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic/node_modules/react-router": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=15"
+      }
+    },
+    "node_modules/@docusaurus/theme-classic/node_modules/react-router-dom": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.13",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.3.4",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=15"
+      }
+    },
+    "node_modules/@docusaurus/theme-common": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.2.0.tgz",
+      "integrity": "sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==",
+      "dependencies": {
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "clsx": "^1.2.1",
+        "parse-numeric-range": "^1.3.0",
+        "prism-react-renderer": "^1.3.5",
+        "tslib": "^2.4.0",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-search-algolia": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.2.0.tgz",
+      "integrity": "sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==",
+      "dependencies": {
+        "@docsearch/react": "^3.1.1",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
+        "algoliasearch": "^4.13.1",
+        "algoliasearch-helper": "^3.10.0",
+        "clsx": "^1.2.1",
+        "eta": "^1.12.3",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0",
+        "utility-types": "^3.10.0"
+      },
+      "engines": {
+        "node": ">=16.14"
+      },
+      "peerDependencies": {
+        "react": "^16.8.4 || ^17.0.0",
+        "react-dom": "^16.8.4 || ^17.0.0"
+      }
+    },
+    "node_modules/@docusaurus/theme-translations": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.2.0.tgz",
+      "integrity": "sha512-3T140AG11OjJrtKlY4pMZ5BzbGRDjNs2co5hJ6uYJG1bVWlhcaFGqkaZ5lCgKflaNHD7UHBHU9Ec5f69jTdd6w==",
+      "dependencies": {
+        "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       },
       "engines": {
         "node": ">=16.14"
       }
     },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/types": {
+    "node_modules/@docusaurus/types": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
       "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
@@ -3204,7 +2558,7 @@
         "react-dom": "^16.8.4 || ^17.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils": {
+    "node_modules/@docusaurus/utils": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
       "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
@@ -3237,836 +2591,10 @@
         }
       }
     },
-    "node_modules/@docusaurus/plugin-google-gtag/node_modules/@docusaurus/utils-validation": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
-      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
-      "dependencies": {
-        "@docusaurus/logger": "2.2.0",
-        "@docusaurus/utils": "2.2.0",
-        "joi": "^17.6.0",
-        "js-yaml": "^4.1.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
-      "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "fs-extra": "^10.1.0",
-        "sitemap": "^7.1.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/plugin-sitemap/node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
-      "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-      "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
-      "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/preset-classic/node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/react-loadable": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/react-loadable/-/react-loadable-5.5.2.tgz",
-      "integrity": "sha512-A3dYjdBGuy0IGT+wyLIGIKLRE+sAk1iNk0f1HjNDysO7u8lhL4N3VEm+FAubmJbAztn94F7MxBTPmnixbiyFdQ==",
-      "dependencies": {
-        "@types/react": "*",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
-      "dependencies": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "@mdx-js/react": "^1.6.22",
-        "clsx": "^1.2.1",
-        "copy-text-to-clipboard": "^3.0.1",
-        "infima": "0.2.0-alpha.42",
-        "lodash": "^4.17.21",
-        "nprogress": "^0.2.0",
-        "postcss": "^8.4.14",
-        "prism-react-renderer": "^1.3.5",
-        "prismjs": "^1.28.0",
-        "react-router-dom": "^5.3.3",
-        "rtlcss": "^3.5.0",
-        "tslib": "^2.4.0",
-        "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-classic/node_modules/react-router-dom": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.3.tgz",
-      "integrity": "sha512-Ov0tGPMBgqmbu5CDmN++tv2HQ9HlWDuWIIqn4b88gjlAN5IHI+4ZUZRcpz9Hl0azFIwihbLDYw1OiHGRo7ZIng==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.3",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
-      "dependencies": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "clsx": "^1.2.1",
-        "parse-numeric-range": "^1.3.0",
-        "prism-react-renderer": "^1.3.5",
-        "tslib": "^2.4.0",
-        "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-common/node_modules/@docusaurus/module-type-aliases": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-      "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
-      "dependencies": {
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "2.1.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "@types/react-router-dom": "*",
-        "react-helmet-async": "*",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
-      "dependencies": {
-        "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "algoliasearch": "^4.13.1",
-        "algoliasearch-helper": "^3.10.0",
-        "clsx": "^1.2.1",
-        "eta": "^1.12.3",
-        "fs-extra": "^10.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.4.0",
-        "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/core": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-      "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-      "dependencies": {
-        "@babel/core": "^7.18.6",
-        "@babel/generator": "^7.18.7",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-        "@babel/plugin-transform-runtime": "^7.18.6",
-        "@babel/preset-env": "^7.18.6",
-        "@babel/preset-react": "^7.18.6",
-        "@babel/preset-typescript": "^7.18.6",
-        "@babel/runtime": "^7.18.6",
-        "@babel/runtime-corejs3": "^7.18.6",
-        "@babel/traverse": "^7.18.8",
-        "@docusaurus/cssnano-preset": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-        "@svgr/webpack": "^6.2.1",
-        "autoprefixer": "^10.4.7",
-        "babel-loader": "^8.2.5",
-        "babel-plugin-dynamic-import-node": "^2.3.3",
-        "boxen": "^6.2.1",
-        "chalk": "^4.1.2",
-        "chokidar": "^3.5.3",
-        "clean-css": "^5.3.0",
-        "cli-table3": "^0.6.2",
-        "combine-promises": "^1.1.0",
-        "commander": "^5.1.0",
-        "copy-webpack-plugin": "^11.0.0",
-        "core-js": "^3.23.3",
-        "css-loader": "^6.7.1",
-        "css-minimizer-webpack-plugin": "^4.0.0",
-        "cssnano": "^5.1.12",
-        "del": "^6.1.1",
-        "detect-port": "^1.3.0",
-        "escape-html": "^1.0.3",
-        "eta": "^1.12.3",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "html-minifier-terser": "^6.1.0",
-        "html-tags": "^3.2.0",
-        "html-webpack-plugin": "^5.5.0",
-        "import-fresh": "^3.3.0",
-        "leven": "^3.1.0",
-        "lodash": "^4.17.21",
-        "mini-css-extract-plugin": "^2.6.1",
-        "postcss": "^8.4.14",
-        "postcss-loader": "^7.0.0",
-        "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
-        "react-helmet-async": "^1.3.0",
-        "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-        "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-        "react-router": "^5.3.3",
-        "react-router-config": "^5.1.1",
-        "react-router-dom": "^5.3.3",
-        "rtl-detect": "^1.0.4",
-        "semver": "^7.3.7",
-        "serve-handler": "^6.1.3",
-        "shelljs": "^0.8.5",
-        "terser-webpack-plugin": "^5.3.3",
-        "tslib": "^2.4.0",
-        "update-notifier": "^5.1.0",
-        "url-loader": "^4.1.1",
-        "wait-on": "^6.0.1",
-        "webpack": "^5.73.0",
-        "webpack-bundle-analyzer": "^4.5.0",
-        "webpack-dev-server": "^4.9.3",
-        "webpack-merge": "^5.8.0",
-        "webpackbar": "^5.0.2"
-      },
-      "bin": {
-        "docusaurus": "bin/docusaurus.mjs"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/@docusaurus/cssnano-preset": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-      "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-      "dependencies": {
-        "cssnano-preset-advanced": "^5.3.8",
-        "postcss": "^8.4.14",
-        "postcss-sort-media-queries": "^4.2.1",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/react-router": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-      "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
-        "loose-envify": "^1.3.1",
-        "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/theme-search-algolia/node_modules/react-router-dom": {
-      "version": "5.3.4",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-      "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-      "dependencies": {
-        "@babel/runtime": "^7.12.13",
-        "history": "^4.9.0",
-        "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.3.4",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=15"
-      }
-    },
-    "node_modules/@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
-      "dependencies": {
-        "fs-extra": "^10.1.0",
-        "tslib": "^2.4.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      }
-    },
-    "node_modules/@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
-      "dependencies": {
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "commander": "^5.1.0",
-        "joi": "^17.6.0",
-        "react-helmet-async": "^1.3.0",
-        "utility-types": "^3.10.0",
-        "webpack": "^5.73.0",
-        "webpack-merge": "^5.8.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.4 || ^17.0.0",
-        "react-dom": "^16.8.4 || ^17.0.0"
-      }
-    },
-    "node_modules/@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
-      "dependencies": {
-        "@docusaurus/logger": "2.1.0",
-        "@svgr/webpack": "^6.2.1",
-        "file-loader": "^6.2.0",
-        "fs-extra": "^10.1.0",
-        "github-slugger": "^1.4.0",
-        "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
-        "js-yaml": "^4.1.0",
-        "lodash": "^4.17.21",
-        "micromatch": "^4.0.5",
-        "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
-        "tslib": "^2.4.0",
-        "url-loader": "^4.1.1",
-        "webpack": "^5.73.0"
-      },
-      "engines": {
-        "node": ">=16.14"
-      },
-      "peerDependencies": {
-        "@docusaurus/types": "*"
-      },
-      "peerDependenciesMeta": {
-        "@docusaurus/types": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
+      "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
       "dependencies": {
         "tslib": "^2.4.0"
       },
@@ -4083,12 +2611,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
+      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
       "dependencies": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -12371,9 +10899,9 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "node_modules/parse5": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -13674,9 +12202,9 @@
       }
     },
     "node_modules/react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
+      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
       "dependencies": {
         "@babel/runtime": "^7.10.2",
         "use-composed-ref": "^1.3.0",
@@ -17568,9 +16096,9 @@
       }
     },
     "node_modules/ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==",
+      "version": "0.7.32",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
+      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw==",
       "funding": [
         {
           "type": "opencollective",
@@ -18912,25 +17440,25 @@
   },
   "dependencies": {
     "@algolia/autocomplete-core": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.1.tgz",
-      "integrity": "sha512-eiZw+fxMzNQn01S8dA/hcCpoWCOCwcIIEUtHHdzN5TGB3IpzLbuhqFeTfh2OUhhgkE8Uo17+wH+QJ/wYyQmmzg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.7.2.tgz",
+      "integrity": "sha512-eclwUDC6qfApNnEfu1uWcL/rudQsn59tjEoUYZYE2JSXZrHLRjBUGMxiCoknobU2Pva8ejb0eRxpIYDtVVqdsw==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       }
     },
     "@algolia/autocomplete-preset-algolia": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.1.tgz",
-      "integrity": "sha512-pJwmIxeJCymU1M6cGujnaIYcY3QPOVYZOXhFkWVM7IxKzy272BwCvMFMyc5NpG/QmiObBxjo7myd060OeTNJXg==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.7.2.tgz",
+      "integrity": "sha512-+RYEG6B0QiGGfRb2G3MtPfyrl0dALF3cQNTWBzBX6p5o01vCCGTTinAm2UKG3tfc2CnOMAtnPLkzNZyJUpnVJw==",
       "requires": {
-        "@algolia/autocomplete-shared": "1.7.1"
+        "@algolia/autocomplete-shared": "1.7.2"
       }
     },
     "@algolia/autocomplete-shared": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.1.tgz",
-      "integrity": "sha512-eTmGVqY3GeyBTT8IWiB2K5EuURAqhnumfktAEoHxfDY2o7vg2rSnO16ZtIG0fMgt3py28Vwgq42/bVEuaQV7pg=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.7.2.tgz",
+      "integrity": "sha512-QCckjiC7xXHIUaIL3ektBtjJ0w7tTA3iqKcAE/Hjn1lZ5omp7i3Y4e09rAr9ZybqirL7AbxCLLq0Ra5DDPKeug=="
     },
     "@algolia/cache-browser-local-storage": {
       "version": "4.14.2",
@@ -20269,18 +18797,18 @@
       "optional": true
     },
     "@docsearch/css": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.2.1.tgz",
-      "integrity": "sha512-gaP6TxxwQC+K8D6TRx5WULUWKrcbzECOPA2KCVMuI+6C7dNiGUk5yXXzVhc5sld79XKYLnO9DRTI4mjXDYkh+g=="
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.3.0.tgz",
+      "integrity": "sha512-rODCdDtGyudLj+Va8b6w6Y85KE85bXRsps/R4Yjwt5vueXKXZQKYw0aA9knxLBT6a/bI/GMrAcmCR75KYOM6hg=="
     },
     "@docsearch/react": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.2.1.tgz",
-      "integrity": "sha512-EzTQ/y82s14IQC5XVestiK/kFFMe2aagoYFuTAIfIb/e+4FU7kSMKonRtLwsCiLQHmjvNQq+HO+33giJ5YVtaQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.3.0.tgz",
+      "integrity": "sha512-fhS5adZkae2SSdMYEMVg6pxI5a/cE+tW16ki1V0/ur4Fdok3hBRkmN/H8VvlXnxzggkQIIRIVvYPn00JPjen3A==",
       "requires": {
-        "@algolia/autocomplete-core": "1.7.1",
-        "@algolia/autocomplete-preset-algolia": "1.7.1",
-        "@docsearch/css": "3.2.1",
+        "@algolia/autocomplete-core": "1.7.2",
+        "@algolia/autocomplete-preset-algolia": "1.7.2",
+        "@docsearch/css": "3.3.0",
         "algoliasearch": "^4.0.0"
       }
     },
@@ -20362,81 +18890,6 @@
         "webpackbar": "^5.0.2"
       },
       "dependencies": {
-        "@docusaurus/logger": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
-          "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
-          "requires": {
-            "chalk": "^4.1.2",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@docusaurus/mdx-loader": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
-          "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
-          "requires": {
-            "@babel/parser": "^7.18.8",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/logger": "2.2.0",
-            "@docusaurus/utils": "2.2.0",
-            "@mdx-js/mdx": "^1.6.22",
-            "escape-html": "^1.0.3",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "image-size": "^1.0.1",
-            "mdast-util-to-string": "^2.0.0",
-            "remark-emoji": "^2.2.0",
-            "stringify-object": "^3.3.0",
-            "tslib": "^2.4.0",
-            "unified": "^9.2.2",
-            "unist-util-visit": "^2.0.3",
-            "url-loader": "^4.1.1",
-            "webpack": "^5.73.0"
-          }
-        },
-        "@docusaurus/utils": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
-          "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
-          "requires": {
-            "@docusaurus/logger": "2.2.0",
-            "@svgr/webpack": "^6.2.1",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "github-slugger": "^1.4.0",
-            "globby": "^11.1.0",
-            "gray-matter": "^4.0.3",
-            "js-yaml": "^4.1.0",
-            "lodash": "^4.17.21",
-            "micromatch": "^4.0.5",
-            "resolve-pathname": "^3.0.0",
-            "shelljs": "^0.8.5",
-            "tslib": "^2.4.0",
-            "url-loader": "^4.1.1",
-            "webpack": "^5.73.0"
-          }
-        },
-        "@docusaurus/utils-common": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
-          "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
-          "requires": {
-            "tslib": "^2.4.0"
-          }
-        },
-        "@docusaurus/utils-validation": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
-          "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
-          "requires": {
-            "@docusaurus/logger": "2.2.0",
-            "@docusaurus/utils": "2.2.0",
-            "joi": "^17.6.0",
-            "js-yaml": "^4.1.0",
-            "tslib": "^2.4.0"
-          }
-        },
         "react-router-dom": {
           "version": "5.3.3",
           "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.3.tgz",
@@ -20465,23 +18918,23 @@
       }
     },
     "@docusaurus/logger": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.1.0.tgz",
-      "integrity": "sha512-uuJx2T6hDBg82joFeyobywPjSOIfeq05GfyKGHThVoXuXsu1KAzMDYcjoDxarb9CoHCI/Dor8R2MoL6zII8x1Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
+      "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
       "requires": {
         "chalk": "^4.1.2",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/mdx-loader": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.1.0.tgz",
-      "integrity": "sha512-i97hi7hbQjsD3/8OSFhLy7dbKGH8ryjEzOfyhQIn2CFBYOY3ko0vMVEf3IY9nD3Ld7amYzsZ8153RPkcnXA+Lg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-2.2.0.tgz",
+      "integrity": "sha512-X2bzo3T0jW0VhUU+XdQofcEeozXOTmKQMvc8tUnWRdTnCvj4XEcBVdC3g+/jftceluiwSTNRAX4VBOJdNt18jA==",
       "requires": {
         "@babel/parser": "^7.18.8",
         "@babel/traverse": "^7.18.8",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "@mdx-js/mdx": "^1.6.22",
         "escape-html": "^1.0.3",
         "file-loader": "^6.2.0",
@@ -20501,7 +18954,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.2.0.tgz",
       "integrity": "sha512-wDGW4IHKoOr9YuJgy7uYuKWrDrSpsUSDHLZnWQYM9fN7D5EpSmYHjFruUpKWVyxLpD/Wh0rW8hYZwdjJIQUQCQ==",
-      "dev": true,
       "requires": {
         "@docusaurus/react-loadable": "5.5.2",
         "@docusaurus/types": "2.2.0",
@@ -20511,38 +18963,20 @@
         "@types/react-router-dom": "*",
         "react-helmet-async": "*",
         "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-      },
-      "dependencies": {
-        "@docusaurus/types": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-          "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-          "dev": true,
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-content-blog": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.1.0.tgz",
-      "integrity": "sha512-xEp6jlu92HMNUmyRBEeJ4mCW1s77aAEQO4Keez94cUY/Ap7G/r0Awa6xSLff7HL0Fjg8KK1bEbDy7q9voIavdg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-2.2.0.tgz",
+      "integrity": "sha512-0mWBinEh0a5J2+8ZJXJXbrCk1tSTNf7Nm4tYAl5h2/xx+PvH/Bnu0V+7mMljYm/1QlDYALNIIaT/JcoZQFUN3w==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^10.1.0",
@@ -20552,141 +18986,20 @@
         "unist-util-visit": "^2.0.3",
         "utility-types": "^3.10.0",
         "webpack": "^5.73.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-          "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.1.0",
-            "@docusaurus/logger": "2.1.0",
-            "@docusaurus/mdx-loader": "2.1.0",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.1.0",
-            "@docusaurus/utils-common": "2.1.0",
-            "@docusaurus/utils-validation": "2.1.0",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^1.12.3",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-          "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "react-router": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-          "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "hoist-non-react-statics": "^3.1.0",
-            "loose-envify": "^1.3.1",
-            "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.6.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        },
-        "react-router-dom": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-          "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.6.2",
-            "react-router": "5.3.4",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-content-docs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.1.0.tgz",
-      "integrity": "sha512-Rup5pqXrXlKGIC4VgwvioIhGWF7E/NNSlxv+JAxRYpik8VKlWsk9ysrdHIlpX+KJUCO9irnY21kQh2814mlp/Q==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-2.2.0.tgz",
+      "integrity": "sha512-BOazBR0XjzsHE+2K1wpNxz5QZmrJgmm3+0Re0EVPYFGW8qndCWGNtXW/0lGKhecVPML8yyFeAmnUCIs7xM2wPw==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@types/react-router-config": "^5.0.6",
         "combine-promises": "^1.1.0",
         "fs-extra": "^10.1.0",
@@ -20696,544 +19009,45 @@
         "tslib": "^2.4.0",
         "utility-types": "^3.10.0",
         "webpack": "^5.73.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-          "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.1.0",
-            "@docusaurus/logger": "2.1.0",
-            "@docusaurus/mdx-loader": "2.1.0",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.1.0",
-            "@docusaurus/utils-common": "2.1.0",
-            "@docusaurus/utils-validation": "2.1.0",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^1.12.3",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-          "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@docusaurus/module-type-aliases": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-          "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
-          "requires": {
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/types": "2.1.0",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "@types/react-router-config": "*",
-            "@types/react-router-dom": "*",
-            "react-helmet-async": "*",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-          }
-        },
-        "react-router": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-          "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "hoist-non-react-statics": "^3.1.0",
-            "loose-envify": "^1.3.1",
-            "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.6.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        },
-        "react-router-dom": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-          "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.6.2",
-            "react-router": "5.3.4",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-content-pages": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.1.0.tgz",
-      "integrity": "sha512-SwZdDZRlObHNKXTnFo7W2aF6U5ZqNVI55Nw2GCBryL7oKQSLeI0lsrMlMXdzn+fS7OuBTd3MJBO1T4Zpz0i/+g==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-2.2.0.tgz",
+      "integrity": "sha512-+OTK3FQHk5WMvdelz8v19PbEbx+CNT6VSpx7nVOvMNs5yJCKvmqBJBQ2ZSxROxhVDYn+CZOlmyrC56NSXzHf6g==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0",
         "webpack": "^5.73.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-          "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.1.0",
-            "@docusaurus/logger": "2.1.0",
-            "@docusaurus/mdx-loader": "2.1.0",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.1.0",
-            "@docusaurus/utils-common": "2.1.0",
-            "@docusaurus/utils-validation": "2.1.0",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^1.12.3",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-          "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "react-router": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-          "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "hoist-non-react-statics": "^3.1.0",
-            "loose-envify": "^1.3.1",
-            "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.6.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        },
-        "react-router-dom": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-          "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.6.2",
-            "react-router": "5.3.4",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-debug": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.1.0.tgz",
-      "integrity": "sha512-8wsDq3OIfiy6440KLlp/qT5uk+WRHQXIXklNHEeZcar+Of0TZxCNe2FBpv+bzb/0qcdP45ia5i5WmR5OjN6DPw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-2.2.0.tgz",
+      "integrity": "sha512-p9vOep8+7OVl6r/NREEYxf4HMAjV8JMYJ7Bos5fCFO0Wyi9AZEo0sCTliRd7R8+dlJXZEgcngSdxAUo/Q+CJow==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "fs-extra": "^10.1.0",
         "react-json-view": "^1.21.3",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-          "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.1.0",
-            "@docusaurus/logger": "2.1.0",
-            "@docusaurus/mdx-loader": "2.1.0",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.1.0",
-            "@docusaurus/utils-common": "2.1.0",
-            "@docusaurus/utils-validation": "2.1.0",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^1.12.3",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-          "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "react-router": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-          "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "hoist-non-react-statics": "^3.1.0",
-            "loose-envify": "^1.3.1",
-            "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.6.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        },
-        "react-router-dom": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-          "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.6.2",
-            "react-router": "5.3.4",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-google-analytics": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.1.0.tgz",
-      "integrity": "sha512-4cgeqIly/wcFVbbWP03y1QJJBgH8W+Bv6AVbWnsXNOZa1yB3AO6hf3ZdeQH9x20v9T2pREogVgAH0rSoVnNsgg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-2.2.0.tgz",
+      "integrity": "sha512-+eZVVxVeEnV5nVQJdey9ZsfyEVMls6VyWTIj8SmX0k5EbqGvnIfET+J2pYEuKQnDIHxy+syRMoRM6AHXdHYGIg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-          "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.1.0",
-            "@docusaurus/logger": "2.1.0",
-            "@docusaurus/mdx-loader": "2.1.0",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.1.0",
-            "@docusaurus/utils-common": "2.1.0",
-            "@docusaurus/utils-validation": "2.1.0",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^1.12.3",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-          "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "react-router": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-          "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "hoist-non-react-statics": "^3.1.0",
-            "loose-envify": "^1.3.1",
-            "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.6.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        },
-        "react-router-dom": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-          "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.6.2",
-            "react-router": "5.3.4",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-google-gtag": {
@@ -21245,354 +19059,41 @@
         "@docusaurus/types": "2.2.0",
         "@docusaurus/utils-validation": "2.2.0",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/logger": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-2.2.0.tgz",
-          "integrity": "sha512-DF3j1cA5y2nNsu/vk8AG7xwpZu6f5MKkPPMaaIbgXLnWGfm6+wkOeW7kNrxnM95YOhKUkJUophX69nGUnLsm0A==",
-          "requires": {
-            "chalk": "^4.1.2",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@docusaurus/types": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
-          "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
-          "requires": {
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "commander": "^5.1.0",
-            "joi": "^17.6.0",
-            "react-helmet-async": "^1.3.0",
-            "utility-types": "^3.10.0",
-            "webpack": "^5.73.0",
-            "webpack-merge": "^5.8.0"
-          }
-        },
-        "@docusaurus/utils": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
-          "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
-          "requires": {
-            "@docusaurus/logger": "2.2.0",
-            "@svgr/webpack": "^6.2.1",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "github-slugger": "^1.4.0",
-            "globby": "^11.1.0",
-            "gray-matter": "^4.0.3",
-            "js-yaml": "^4.1.0",
-            "lodash": "^4.17.21",
-            "micromatch": "^4.0.5",
-            "resolve-pathname": "^3.0.0",
-            "shelljs": "^0.8.5",
-            "tslib": "^2.4.0",
-            "url-loader": "^4.1.1",
-            "webpack": "^5.73.0"
-          }
-        },
-        "@docusaurus/utils-validation": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
-          "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
-          "requires": {
-            "@docusaurus/logger": "2.2.0",
-            "@docusaurus/utils": "2.2.0",
-            "joi": "^17.6.0",
-            "js-yaml": "^4.1.0",
-            "tslib": "^2.4.0"
-          }
-        }
       }
     },
     "@docusaurus/plugin-sitemap": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.1.0.tgz",
-      "integrity": "sha512-2Y6Br8drlrZ/jN9MwMBl0aoi9GAjpfyfMBYpaQZXimbK+e9VjYnujXlvQ4SxtM60ASDgtHIAzfVFBkSR/MwRUw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-2.2.0.tgz",
+      "integrity": "sha512-0jAmyRDN/aI265CbWZNZuQpFqiZuo+5otk2MylU9iVrz/4J7gSc+ZJ9cy4EHrEsW7PV8s1w18hIEsmcA1YgkKg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "fs-extra": "^10.1.0",
         "sitemap": "^7.1.1",
         "tslib": "^2.4.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-          "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.1.0",
-            "@docusaurus/logger": "2.1.0",
-            "@docusaurus/mdx-loader": "2.1.0",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.1.0",
-            "@docusaurus/utils-common": "2.1.0",
-            "@docusaurus/utils-validation": "2.1.0",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^1.12.3",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-          "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "react-router": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-          "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "hoist-non-react-statics": "^3.1.0",
-            "loose-envify": "^1.3.1",
-            "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.6.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        },
-        "react-router-dom": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-          "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.6.2",
-            "react-router": "5.3.4",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        }
       }
     },
     "@docusaurus/preset-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.1.0.tgz",
-      "integrity": "sha512-NQMnaq974K4BcSMXFSJBQ5itniw6RSyW+VT+6i90kGZzTwiuKZmsp0r9lC6BYAvvVMQUNJQwrETmlu7y2XKW7w==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-2.2.0.tgz",
+      "integrity": "sha512-yKIWPGNx7BT8v2wjFIWvYrS+nvN04W+UameSFf8lEiJk6pss0kL6SG2MRvyULiI3BDxH+tj6qe02ncpSPGwumg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/plugin-debug": "2.1.0",
-        "@docusaurus/plugin-google-analytics": "2.1.0",
-        "@docusaurus/plugin-google-gtag": "2.1.0",
-        "@docusaurus/plugin-sitemap": "2.1.0",
-        "@docusaurus/theme-classic": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-search-algolia": "2.1.0",
-        "@docusaurus/types": "2.1.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-          "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.1.0",
-            "@docusaurus/logger": "2.1.0",
-            "@docusaurus/mdx-loader": "2.1.0",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.1.0",
-            "@docusaurus/utils-common": "2.1.0",
-            "@docusaurus/utils-validation": "2.1.0",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^1.12.3",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-          "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@docusaurus/plugin-google-gtag": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-2.1.0.tgz",
-          "integrity": "sha512-/3aDlv2dMoCeiX2e+DTGvvrdTA+v3cKQV3DbmfsF4ENhvc5nKV23nth04Z3Vq0Ci1ui6Sn80TkhGk/tiCMW2AA==",
-          "requires": {
-            "@docusaurus/core": "2.1.0",
-            "@docusaurus/types": "2.1.0",
-            "@docusaurus/utils-validation": "2.1.0",
-            "tslib": "^2.4.0"
-          }
-        },
-        "react-router": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
-          "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "hoist-non-react-statics": "^3.1.0",
-            "loose-envify": "^1.3.1",
-            "path-to-regexp": "^1.7.0",
-            "prop-types": "^15.6.2",
-            "react-is": "^16.6.0",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        },
-        "react-router-dom": {
-          "version": "5.3.4",
-          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
-          "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.6.2",
-            "react-router": "5.3.4",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        }
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/plugin-debug": "2.2.0",
+        "@docusaurus/plugin-google-analytics": "2.2.0",
+        "@docusaurus/plugin-google-gtag": "2.2.0",
+        "@docusaurus/plugin-sitemap": "2.2.0",
+        "@docusaurus/theme-classic": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-search-algolia": "2.2.0",
+        "@docusaurus/types": "2.2.0"
       }
     },
     "@docusaurus/react-loadable": {
@@ -21605,22 +19106,22 @@
       }
     },
     "@docusaurus/theme-classic": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.1.0.tgz",
-      "integrity": "sha512-xn8ZfNMsf7gaSy9+ClFnUu71o7oKgMo5noYSS1hy3svNifRTkrBp6+MReLDsmIaj3mLf2e7+JCBYKBFbaGzQng==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-2.2.0.tgz",
+      "integrity": "sha512-kjbg/qJPwZ6H1CU/i9d4l/LcFgnuzeiGgMQlt6yPqKo0SOJIBMPuz7Rnu3r/WWbZFPi//o8acclacOzmXdUUEg==",
       "requires": {
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/types": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-common": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/types": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-common": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
         "@mdx-js/react": "^1.6.22",
         "clsx": "^1.2.1",
         "copy-text-to-clipboard": "^3.0.1",
@@ -21636,276 +19137,6 @@
         "utility-types": "^3.10.0"
       },
       "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-          "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.1.0",
-            "@docusaurus/logger": "2.1.0",
-            "@docusaurus/mdx-loader": "2.1.0",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.1.0",
-            "@docusaurus/utils-common": "2.1.0",
-            "@docusaurus/utils-validation": "2.1.0",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^1.12.3",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-          "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        },
-        "@docusaurus/module-type-aliases": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-          "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
-          "requires": {
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/types": "2.1.0",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "@types/react-router-config": "*",
-            "@types/react-router-dom": "*",
-            "react-helmet-async": "*",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-          }
-        },
-        "react-router-dom": {
-          "version": "5.3.3",
-          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.3.tgz",
-          "integrity": "sha512-Ov0tGPMBgqmbu5CDmN++tv2HQ9HlWDuWIIqn4b88gjlAN5IHI+4ZUZRcpz9Hl0azFIwihbLDYw1OiHGRo7ZIng==",
-          "requires": {
-            "@babel/runtime": "^7.12.13",
-            "history": "^4.9.0",
-            "loose-envify": "^1.3.1",
-            "prop-types": "^15.6.2",
-            "react-router": "5.3.3",
-            "tiny-invariant": "^1.0.2",
-            "tiny-warning": "^1.0.0"
-          }
-        }
-      }
-    },
-    "@docusaurus/theme-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.1.0.tgz",
-      "integrity": "sha512-vT1otpVPbKux90YpZUnvknsn5zvpLf+AW1W0EDcpE9up4cDrPqfsh0QoxGHFJnobE2/qftsBFC19BneN4BH8Ag==",
-      "requires": {
-        "@docusaurus/mdx-loader": "2.1.0",
-        "@docusaurus/module-type-aliases": "2.1.0",
-        "@docusaurus/plugin-content-blog": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/plugin-content-pages": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@types/history": "^4.7.11",
-        "@types/react": "*",
-        "@types/react-router-config": "*",
-        "clsx": "^1.2.1",
-        "parse-numeric-range": "^1.3.0",
-        "prism-react-renderer": "^1.3.5",
-        "tslib": "^2.4.0",
-        "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "@docusaurus/module-type-aliases": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-2.1.0.tgz",
-          "integrity": "sha512-Z8WZaK5cis3xEtyfOT817u9xgGUauT0PuuVo85ysnFRX8n7qLN1lTPCkC+aCmFm/UcV8h/W5T4NtIsst94UntQ==",
-          "requires": {
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/types": "2.1.0",
-            "@types/history": "^4.7.11",
-            "@types/react": "*",
-            "@types/react-router-config": "*",
-            "@types/react-router-dom": "*",
-            "react-helmet-async": "*",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2"
-          }
-        }
-      }
-    },
-    "@docusaurus/theme-search-algolia": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.1.0.tgz",
-      "integrity": "sha512-rNBvi35VvENhucslEeVPOtbAzBdZY/9j55gdsweGV5bYoAXy4mHB6zTGjealcB4pJ6lJY4a5g75fXXMOlUqPfg==",
-      "requires": {
-        "@docsearch/react": "^3.1.1",
-        "@docusaurus/core": "2.1.0",
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/plugin-content-docs": "2.1.0",
-        "@docusaurus/theme-common": "2.1.0",
-        "@docusaurus/theme-translations": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
-        "@docusaurus/utils-validation": "2.1.0",
-        "algoliasearch": "^4.13.1",
-        "algoliasearch-helper": "^3.10.0",
-        "clsx": "^1.2.1",
-        "eta": "^1.12.3",
-        "fs-extra": "^10.1.0",
-        "lodash": "^4.17.21",
-        "tslib": "^2.4.0",
-        "utility-types": "^3.10.0"
-      },
-      "dependencies": {
-        "@docusaurus/core": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-2.1.0.tgz",
-          "integrity": "sha512-/ZJ6xmm+VB9Izbn0/s6h6289cbPy2k4iYFwWDhjiLsVqwa/Y0YBBcXvStfaHccudUC3OfP+26hMk7UCjc50J6Q==",
-          "requires": {
-            "@babel/core": "^7.18.6",
-            "@babel/generator": "^7.18.7",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-            "@babel/plugin-transform-runtime": "^7.18.6",
-            "@babel/preset-env": "^7.18.6",
-            "@babel/preset-react": "^7.18.6",
-            "@babel/preset-typescript": "^7.18.6",
-            "@babel/runtime": "^7.18.6",
-            "@babel/runtime-corejs3": "^7.18.6",
-            "@babel/traverse": "^7.18.8",
-            "@docusaurus/cssnano-preset": "2.1.0",
-            "@docusaurus/logger": "2.1.0",
-            "@docusaurus/mdx-loader": "2.1.0",
-            "@docusaurus/react-loadable": "5.5.2",
-            "@docusaurus/utils": "2.1.0",
-            "@docusaurus/utils-common": "2.1.0",
-            "@docusaurus/utils-validation": "2.1.0",
-            "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
-            "@svgr/webpack": "^6.2.1",
-            "autoprefixer": "^10.4.7",
-            "babel-loader": "^8.2.5",
-            "babel-plugin-dynamic-import-node": "^2.3.3",
-            "boxen": "^6.2.1",
-            "chalk": "^4.1.2",
-            "chokidar": "^3.5.3",
-            "clean-css": "^5.3.0",
-            "cli-table3": "^0.6.2",
-            "combine-promises": "^1.1.0",
-            "commander": "^5.1.0",
-            "copy-webpack-plugin": "^11.0.0",
-            "core-js": "^3.23.3",
-            "css-loader": "^6.7.1",
-            "css-minimizer-webpack-plugin": "^4.0.0",
-            "cssnano": "^5.1.12",
-            "del": "^6.1.1",
-            "detect-port": "^1.3.0",
-            "escape-html": "^1.0.3",
-            "eta": "^1.12.3",
-            "file-loader": "^6.2.0",
-            "fs-extra": "^10.1.0",
-            "html-minifier-terser": "^6.1.0",
-            "html-tags": "^3.2.0",
-            "html-webpack-plugin": "^5.5.0",
-            "import-fresh": "^3.3.0",
-            "leven": "^3.1.0",
-            "lodash": "^4.17.21",
-            "mini-css-extract-plugin": "^2.6.1",
-            "postcss": "^8.4.14",
-            "postcss-loader": "^7.0.0",
-            "prompts": "^2.4.2",
-            "react-dev-utils": "^12.0.1",
-            "react-helmet-async": "^1.3.0",
-            "react-loadable": "npm:@docusaurus/react-loadable@5.5.2",
-            "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
-            "react-router": "^5.3.3",
-            "react-router-config": "^5.1.1",
-            "react-router-dom": "^5.3.3",
-            "rtl-detect": "^1.0.4",
-            "semver": "^7.3.7",
-            "serve-handler": "^6.1.3",
-            "shelljs": "^0.8.5",
-            "terser-webpack-plugin": "^5.3.3",
-            "tslib": "^2.4.0",
-            "update-notifier": "^5.1.0",
-            "url-loader": "^4.1.1",
-            "wait-on": "^6.0.1",
-            "webpack": "^5.73.0",
-            "webpack-bundle-analyzer": "^4.5.0",
-            "webpack-dev-server": "^4.9.3",
-            "webpack-merge": "^5.8.0",
-            "webpackbar": "^5.0.2"
-          }
-        },
-        "@docusaurus/cssnano-preset": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-2.1.0.tgz",
-          "integrity": "sha512-pRLewcgGhOies6pzsUROfmPStDRdFw+FgV5sMtLr5+4Luv2rty5+b/eSIMMetqUsmg3A9r9bcxHk9bKAKvx3zQ==",
-          "requires": {
-            "cssnano-preset-advanced": "^5.3.8",
-            "postcss": "^8.4.14",
-            "postcss-sort-media-queries": "^4.2.1",
-            "tslib": "^2.4.0"
-          }
-        },
         "react-router": {
           "version": "5.3.4",
           "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
@@ -21938,19 +19169,63 @@
         }
       }
     },
+    "@docusaurus/theme-common": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-2.2.0.tgz",
+      "integrity": "sha512-R8BnDjYoN90DCL75gP7qYQfSjyitXuP9TdzgsKDmSFPNyrdE3twtPNa2dIN+h+p/pr+PagfxwWbd6dn722A1Dw==",
+      "requires": {
+        "@docusaurus/mdx-loader": "2.2.0",
+        "@docusaurus/module-type-aliases": "2.2.0",
+        "@docusaurus/plugin-content-blog": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/plugin-content-pages": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router-config": "*",
+        "clsx": "^1.2.1",
+        "parse-numeric-range": "^1.3.0",
+        "prism-react-renderer": "^1.3.5",
+        "tslib": "^2.4.0",
+        "utility-types": "^3.10.0"
+      }
+    },
+    "@docusaurus/theme-search-algolia": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-2.2.0.tgz",
+      "integrity": "sha512-2h38B0tqlxgR2FZ9LpAkGrpDWVdXZ7vltfmTdX+4RsDs3A7khiNsmZB+x/x6sA4+G2V2CvrsPMlsYBy5X+cY1w==",
+      "requires": {
+        "@docsearch/react": "^3.1.1",
+        "@docusaurus/core": "2.2.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/plugin-content-docs": "2.2.0",
+        "@docusaurus/theme-common": "2.2.0",
+        "@docusaurus/theme-translations": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
+        "@docusaurus/utils-validation": "2.2.0",
+        "algoliasearch": "^4.13.1",
+        "algoliasearch-helper": "^3.10.0",
+        "clsx": "^1.2.1",
+        "eta": "^1.12.3",
+        "fs-extra": "^10.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.4.0",
+        "utility-types": "^3.10.0"
+      }
+    },
     "@docusaurus/theme-translations": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.1.0.tgz",
-      "integrity": "sha512-07n2akf2nqWvtJeMy3A+7oSGMuu5F673AovXVwY0aGAux1afzGCiqIFlYW3EP0CujvDJAEFSQi/Tetfh+95JNg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-2.2.0.tgz",
+      "integrity": "sha512-3T140AG11OjJrtKlY4pMZ5BzbGRDjNs2co5hJ6uYJG1bVWlhcaFGqkaZ5lCgKflaNHD7UHBHU9Ec5f69jTdd6w==",
       "requires": {
         "fs-extra": "^10.1.0",
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/types": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.1.0.tgz",
-      "integrity": "sha512-BS1ebpJZnGG6esKqsjtEC9U9qSaPylPwlO7cQ1GaIE7J/kMZI3FITnNn0otXXu7c7ZTqhb6+8dOrG6fZn6fqzQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-2.2.0.tgz",
+      "integrity": "sha512-b6xxyoexfbRNRI8gjblzVOnLr4peCJhGbYGPpJ3LFqpi5nsFfoK4mmDLvWdeah0B7gmJeXabN7nQkFoqeSdmOw==",
       "requires": {
         "@types/history": "^4.7.11",
         "@types/react": "*",
@@ -21963,11 +19238,11 @@
       }
     },
     "@docusaurus/utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.1.0.tgz",
-      "integrity": "sha512-fPvrfmAuC54n8MjZuG4IysaMdmvN5A/qr7iFLbSGSyDrsbP4fnui6KdZZIa/YOLIPLec8vjZ8RIITJqF18mx4A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-2.2.0.tgz",
+      "integrity": "sha512-oNk3cjvx7Tt1Lgh/aeZAmFpGV2pDr5nHKrBVx6hTkzGhrnMuQqLt6UPlQjdYQ3QHXwyF/ZtZMO1D5Pfi0lu7SA==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
         "@svgr/webpack": "^6.2.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^10.1.0",
@@ -21985,20 +19260,20 @@
       }
     },
     "@docusaurus/utils-common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.1.0.tgz",
-      "integrity": "sha512-F2vgmt4yRFgRQR2vyEFGTWeyAdmgKbtmu3sjHObF0tjjx/pN0Iw/c6eCopaH34E6tc9nO0nvp01pwW+/86d1fg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-2.2.0.tgz",
+      "integrity": "sha512-qebnerHp+cyovdUseDQyYFvMW1n1nv61zGe5JJfoNQUnjKuApch3IVsz+/lZ9a38pId8kqehC1Ao2bW/s0ntDA==",
       "requires": {
         "tslib": "^2.4.0"
       }
     },
     "@docusaurus/utils-validation": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.1.0.tgz",
-      "integrity": "sha512-AMJzWYKL3b7FLltKtDXNLO9Y649V2BXvrnRdnW2AA+PpBnYV78zKLSCz135cuWwRj1ajNtP4onbXdlnyvCijGQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-2.2.0.tgz",
+      "integrity": "sha512-I1hcsG3yoCkasOL5qQAYAfnmVoLei7apugT6m4crQjmDGxq+UkiRrq55UqmDDyZlac/6ax/JC0p+usZ6W4nVyg==",
       "requires": {
-        "@docusaurus/logger": "2.1.0",
-        "@docusaurus/utils": "2.1.0",
+        "@docusaurus/logger": "2.2.0",
+        "@docusaurus/utils": "2.2.0",
         "joi": "^17.6.0",
         "js-yaml": "^4.1.0",
         "tslib": "^2.4.0"
@@ -27918,9 +25193,9 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ=="
     },
     "parse5": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.1.tgz",
-      "integrity": "sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "requires": {
         "entities": "^4.4.0"
       }
@@ -28804,9 +26079,9 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.3.4.tgz",
-      "integrity": "sha512-CdtmP8Dc19xL8/R6sWvtknD/eCXkQr30dtvC4VmGInhRsfF8X/ihXCq6+9l9qbxmKRiq407/7z5fxE7cVWQNgQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-8.4.0.tgz",
+      "integrity": "sha512-YrTFaEHLgJsi8sJVYHBzYn+mkP3prGkmP2DKb/tm0t7CLJY5t1Rxix8070LAKb0wby7bl/lf2EeHkuMihMZMwQ==",
       "requires": {
         "@babel/runtime": "^7.10.2",
         "use-composed-ref": "^1.3.0",
@@ -31650,9 +28925,9 @@
       "dev": true
     },
     "ua-parser-js": {
-      "version": "0.7.31",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.31.tgz",
-      "integrity": "sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ=="
+      "version": "0.7.32",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.32.tgz",
+      "integrity": "sha512-f9BESNVhzlhEFf2CHMSj40NWOjYPl1YKYbrvIr/hFTDEmLq7SRbWvm7FcdcpCYT95zrOhC7gZSxjdnnTpBcwVw=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -1,6 +1,6 @@
 {
   "name": "website",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": true,
   "scripts": {
     "start": "docusaurus start",
@@ -23,7 +23,7 @@
   "dependencies": {
     "@docusaurus/core": "^2.2.0",
     "@docusaurus/plugin-google-gtag": "^2.2.0",
-    "@docusaurus/preset-classic": "^2.1.0",
+    "@docusaurus/preset-classic": "^2.2.0",
     "@types/lodash.get": "^4.4.7",
     "@types/react": "^17.0.50",
     "@types/react-router-dom": "^5.3.3",


### PR DESCRIPTION
## Description

Was looking through logs of preview build and saw that there are some errors due to Docusaurus components having different versions:
<img width="873" alt="Screenshot 2022-12-11 at 15 00 48" src="https://user-images.githubusercontent.com/13467769/206929069-498fa455-5a80-4dc1-9caf-5edcaef32954.png">

This PR addresses these issues.

## Related Issues

-

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

