### PR TITLE
fix(connectivity_plus): add onCapabilitiesChanged callback

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -45,6 +46,12 @@ public class ConnectivityBroadcastReceiver extends BroadcastReceiver
           new ConnectivityManager.NetworkCallback() {
             @Override
             public void onAvailable(Network network) {
+              sendEvent();
+            }
+
+            @Override
+            public void onCapabilitiesChanged(
+                Network network, NetworkCapabilities networkCapabilities) {
               sendEvent();
             }
 


### PR DESCRIPTION
## Description

The android implementation for the onconnectivitychanged stream uses a network callback to emit new values every time onAvailable is Called. From Android M on, it determines which type of network is active by calling `connectivityManager.getNetworkCapabilities(network)`, from `connectivity.getNetworkType` but in the [documentation for the onAvailable callback](https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback#onAvailable(android.net.Network)), It says:
```
Do NOT call ConnectivityManager.getNetworkCapabilities(android.net.Network) or ConnectivityManager.getLinkProperties(android.net.Network) or other synchronous ConnectivityManager methods in this callback as this is prone to race conditions (there is no guarantee the objects returned by these methods will be current).
Instead, wait for a call to onCapabilitiesChanged(android.net.Network, android.net.NetworkCapabilities) and onLinkPropertiesChanged(android.net.Network, android.net.LinkProperties) whose arguments are guaranteed to be well-ordered with respect to other callbacks.
```

So, it seems getNetworkType should be called from onCapabilitiesChanged instead of from onAvailable. Since I'm not sure how that would affect Platforms prior to Android M, I left the onAvailable Callback in.

The motivation for this is that we have discovered a bug where sometimes after our phone has been in standby for some time, onConnectivityChanged wouldn't update correctly, still reporting no connectivity even though a wifi connection was active and we're hoping this might fix that.

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

