### PR TITLE
docs(sensor_plus): improve description of accelerometer

### DIFF
--- a/docs/sensors_plus/usage.mdx
+++ b/docs/sensors_plus/usage.mdx
@@ -12,23 +12,22 @@ file](https://plus.fluttercommunity.dev/docs/overview).
 This will expose such classes of sensor events through a set of streams:
 
 - `UserAccelerometerEvent` describes the acceleration of the device, in m/s<sup>2</sup>.
-If the device is still, or is moving along a straight line at constant speed,
-the reported acceleration is zero.
-If the device is moving e.g. towards north and its speed is increasing, the reported acceleration
-is towards north; if it is slowing down, the reported acceleration is towards south;
-if it is turning right, the reported acceleration is towards east.
-The data of this stream is obtained by filtering out the effect of gravity from `AccelerometerEvent`.
+  If the device is still, or is moving along a straight line at constant speed,
+  the reported acceleration is zero.
+  If the device is moving e.g. towards north and its speed is increasing, the reported acceleration
+  is towards north; if it is slowing down, the reported acceleration is towards south;
+  if it is turning right, the reported acceleration is towards east.
+  The data of this stream is obtained by filtering out the effect of gravity from `AccelerometerEvent`.
 - `AccelerometerEvent` describes the acceleration of the device, in m/s<sup>2</sup>, including the
   effects of gravity. Unlike `UserAccelerometerEvent`, this stream reports raw data from
-	the accelerometer (physical measuring instrument embedded in the mobile device)
-	without any post-processing.
-	The accelerometer is unable to distinguish between the effect of an accelerated movement of the
-	device and the effect of the surrounding gravitational field.
-	This means that, at the surface of Earth, even if the device is completely still,
-	the reading of `AccelerometerEvent` is an acceleration of intensity 9.8 directed upwards
-	(the opposite of the graviational acceleration).
-	This can be used to infer information about the position of the device (horizontal/vertical/tilted).
-	`AccelerometerEvent` reports zero acceleration if the device is free falling.
+  the accelerometer (physical sensor embedded in the mobile device) without any post-processing.
+  The accelerometer is unable to distinguish between the effect of an accelerated movement of the
+  device and the effect of the surrounding gravitational field.
+  This means that, at the surface of Earth, even if the device is completely still,
+  the reading of `AccelerometerEvent` is an acceleration of intensity 9.8 directed upwards
+  (the opposite of the graviational acceleration).
+  This can be used to infer information about the position of the device (horizontal/vertical/tilted).
+  `AccelerometerEvent` reports zero acceleration if the device is free falling.
 - `GyroscopeEvent` describes the rotation of the device.
 - `MagnetometerEvent` describes the ambient magnetic field surrounding the
   device. A compass is an example usage of this data.

--- a/docs/sensors_plus/usage.mdx
+++ b/docs/sensors_plus/usage.mdx
@@ -11,12 +11,24 @@ file](https://plus.fluttercommunity.dev/docs/overview).
 
 This will expose such classes of sensor events through a set of streams:
 
-- `AccelerometerEvent` describes the velocity of the device, including the
-  effects of gravity. Put simply, you can use accelerometer readings to tell if
-  the device is moving in a particular direction.
-- `UserAccelerometerEvent` also describes the velocity of the device, but don't
-  include gravity. They can also be thought of as just the user's affect on the
-  device.
+- `UserAccelerometerEvent` describes the acceleration of the device, in m/s<sup>2</sup>.
+If the device is still, or is moving along a straight line at constant speed,
+the reported acceleration is zero.
+If the device is moving e.g. towards north and its speed is increasing, the reported acceleration
+is towards north; if it is slowing down, the reported acceleration is towards south;
+if it is turning right, the reported acceleration is towards east.
+The data of this stream is obtained by filtering out the effect of gravity from `AccelerometerEvent`.
+- `AccelerometerEvent` describes the acceleration of the device, in m/s<sup>2</sup>, including the
+  effects of gravity. Unlike `UserAccelerometerEvent`, this stream reports raw data from
+	the accelerometer (physical measuring instrument embedded in the mobile device)
+	without any post-processing.
+	The accelerometer is unable to distinguish between the effect of an accelerated movement of the
+	device and the effect of the surrounding gravitational field.
+	This means that, at the surface of Earth, even if the device is completely still,
+	the reading of `AccelerometerEvent` is an acceleration of intensity 9.8 directed upwards
+	(the opposite of the graviational acceleration).
+	This can be used to infer information about the position of the device (horizontal/vertical/tilted).
+	`AccelerometerEvent` reports zero acceleration if the device is free falling.
 - `GyroscopeEvent` describes the rotation of the device.
 - `MagnetometerEvent` describes the ambient magnetic field surrounding the
   device. A compass is an example usage of this data.
@@ -30,15 +42,15 @@ respectively.
 ```dart
 import 'package:sensors_plus/sensors_plus.dart';
 
-accelerometerEvents.listen((AccelerometerEvent event) {
-  print(event);
-});
-// [AccelerometerEvent (x: 0.0, y: 9.8, z: 0.0)]
-
 userAccelerometerEvents.listen((UserAccelerometerEvent event) {
   print(event);
 });
 // [UserAccelerometerEvent (x: 0.0, y: 0.0, z: 0.0)]
+
+accelerometerEvents.listen((AccelerometerEvent event) {
+  print(event);
+});
+// [AccelerometerEvent (x: 0.0, y: 9.8, z: 0.0)]
 
 gyroscopeEvents.listen((GyroscopeEvent event) {
   print(event);

--- a/packages/sensors_plus/sensors_plus/example/lib/main.dart
+++ b/packages/sensors_plus/sensors_plus/example/lib/main.dart
@@ -44,21 +44,21 @@ class _MyHomePageState extends State<MyHomePage> {
   static const int _snakeColumns = 20;
   static const double _snakeCellSize = 10.0;
 
-  List<double>? _accelerometerValues;
   List<double>? _userAccelerometerValues;
+  List<double>? _accelerometerValues;
   List<double>? _gyroscopeValues;
   List<double>? _magnetometerValues;
   final _streamSubscriptions = <StreamSubscription<dynamic>>[];
 
   @override
   Widget build(BuildContext context) {
+    final userAccelerometer = _userAccelerometerValues
+        ?.map((double v) => v.toStringAsFixed(1))
+        .toList();
     final accelerometer =
         _accelerometerValues?.map((double v) => v.toStringAsFixed(1)).toList();
     final gyroscope =
         _gyroscopeValues?.map((double v) => v.toStringAsFixed(1)).toList();
-    final userAccelerometer = _userAccelerometerValues
-        ?.map((double v) => v.toStringAsFixed(1))
-        .toList();
     final magnetometer =
         _magnetometerValues?.map((double v) => v.toStringAsFixed(1)).toList();
 
@@ -90,7 +90,7 @@ class _MyHomePageState extends State<MyHomePage> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
-                Text('Accelerometer: $accelerometer'),
+                Text('UserAccelerometer: $userAccelerometer'),
               ],
             ),
           ),
@@ -99,7 +99,7 @@ class _MyHomePageState extends State<MyHomePage> {
             child: Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: <Widget>[
-                Text('UserAccelerometer: $userAccelerometer'),
+                Text('Accelerometer: $accelerometer'),
               ],
             ),
           ),
@@ -138,6 +138,15 @@ class _MyHomePageState extends State<MyHomePage> {
   void initState() {
     super.initState();
     _streamSubscriptions.add(
+      userAccelerometerEvents.listen(
+        (UserAccelerometerEvent event) {
+          setState(() {
+            _userAccelerometerValues = <double>[event.x, event.y, event.z];
+          });
+        },
+      ),
+    );
+    _streamSubscriptions.add(
       accelerometerEvents.listen(
         (AccelerometerEvent event) {
           setState(() {
@@ -151,15 +160,6 @@ class _MyHomePageState extends State<MyHomePage> {
         (GyroscopeEvent event) {
           setState(() {
             _gyroscopeValues = <double>[event.x, event.y, event.z];
-          });
-        },
-      ),
-    );
-    _streamSubscriptions.add(
-      userAccelerometerEvents.listen(
-        (UserAccelerometerEvent event) {
-          setState(() {
-            _userAccelerometerValues = <double>[event.x, event.y, event.z];
           });
         },
       ),


### PR DESCRIPTION
## Description

I believe the description of the accelerometer in docs/sensors_plus/usage.mdx is not accurate.

I changed the description of AccelerometerEvent and UserAccelerometerEvent. See https://en.wikipedia.org/wiki/Accelerometer

The text is now rather long; I was unable to compress the information I find relevant in a shorter text.

I changed the order of the topics because I feel the presentation is more clear if we explain first the concept of acceleration in itself, and only after that we explain that the gravity is indistinguishable from an accelerated movement. I also changed the order in packages/sensors_plus/sensors_plus/example/lib/main.dart (perhaps this wasn't necessary).

I wonder if the descriptions of GyroscopeEvent and MagnetometerEvent are accurate and complete. I think at least the physical measure units should be mentioned. I suspect the GyroscopeEvent describes the rate of change of the rotation (angular velocity) rather than the rotation of the device. Or perhaps the angular acceleration ? Since I don't have enough knowledge on these topics, I left them unchanged.

## Related Issues

Discussion #1419

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

