### PR TITLE
docs: Fixed markdown table formatting in README

### DIFF
--- a/packages/package_info_plus/package_info_plus/README.md
+++ b/packages/package_info_plus/package_info_plus/README.md
@@ -14,8 +14,9 @@ This Flutter plugin provides an API for querying information about an applicatio
 
 ## Platform Support
 
-| Android | iOS | MacOS | Web | Linux | Windows | | :-----: | :-: | :---: | :-: | :---: | :-----: |
-| ✔️ | ✔️ | ✔️ | ✔️ | ✔️ | ✔️ |
+| Android |  iOS  | MacOS |  Web  | Linux | Windows |
+| :-----: | :---: | :---: | :---: | :---: | :-----: |
+|✔️|✔️|✔️|✔️|✔️|✔️|
 
 ## Usage
 


### PR DESCRIPTION
Table wasn't rendered properly, since the row with line separators were on the same line as the row of titles.