### PR TITLE
fix(battery_plus_linux): broadcast stream

### DIFF
--- a/packages/battery_plus/battery_plus/lib/src/battery_plus_linux.dart
+++ b/packages/battery_plus/battery_plus/lib/src/battery_plus_linux.dart
@@ -53,7 +53,7 @@ class BatteryPlusLinuxPlugin extends BatteryPlatform {
   /// Fires whenever the battery state changes.
   @override
   Stream<BatteryState> get onBatteryStateChanged {
-    _stateController ??= StreamController<BatteryState>(
+    _stateController ??= StreamController<BatteryState>.broadcast(
       onListen: _startListenState,
       onCancel: _stopListenState,
     );

--- a/packages/battery_plus/battery_plus/test/battery_plus_linux_test.dart
+++ b/packages/battery_plus/battery_plus/test/battery_plus_linux_test.dart
@@ -40,6 +40,7 @@ void main() {
       });
       return client;
     };
+    expect(battery.onBatteryStateChanged.isBroadcast, isTrue);
     expect(battery.onBatteryStateChanged,
         emitsInOrder([BatteryState.charging, BatteryState.full]));
   });


### PR DESCRIPTION
## Description

Use a broadcast stream to allow multiple listeners.

> A single-subscription stream allows only a single listener during the whole lifetime of the stream.
...
> Listening twice on a single-subscription stream is not allowed, even after the first subscription has been canceled.

https://api.dart.dev/stable/2.19.0/dart-async/Stream-class.html

## Related Issues

Fixes: #1478

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

