### PR TITLE
chore(all): Add link to Contributor Guide to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 ## Checklist
 
-- [ ] I read the Contributor Guide and followed the process outlined there for submitting PRs.
+- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
 - [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
 - [ ] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
 - [ ] All existing and new tests are passing.


### PR DESCRIPTION
## Description

The PR template is changed, so that the Contributor Guide can be clicked. It helps people to actually open and read it.

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

