### PR TITLE
chore(package_info_plus): fix mock formatting

### DIFF
--- a/packages/package_info_plus/package_info_plus/test/package_info_plus_web_test.mocks.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_plus_web_test.mocks.dart
@@ -24,8 +24,8 @@ import 'package:mockito/mockito.dart' as _i1;
 
 class _FakeResponse_0 extends _i1.Fake implements _i2.Response {}
 
-class _FakeStreamedResponse_1 extends _i1.Fake implements _i3.StreamedResponse {
-}
+class _FakeStreamedResponse_1 extends _i1.Fake
+    implements _i3.StreamedResponse {}
 
 /// A class which mocks [Client].
 ///


### PR DESCRIPTION
Fixes the code formatting issue in #1479:
```
These files are not formatted correctly:


-----------------------------------------------------------------
packages/package_info_plus/package_info_plus/test/package_info_plus_web_test.mocks.dart
-----------------------------------------------------------------

diff --git a/packages/package_info_plus/package_info_plus/test/package_info_plus_web_test.mocks.dart b/packages/package_info_plus/package_info_plus/test/package_info_plus_web_test.mocks.dart
index efa5d105..f0b62868 100644
--- a/packages/package_info_plus/package_info_plus/test/package_info_plus_web_test.mocks.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_plus_web_test.mocks.dart
@@ -27,2 +27,2 @@ class _FakeResponse_0 extends _i1.Fake implements _i2.Response {}
-class _FakeStreamedResponse_1 extends _i1.Fake implements _i3.StreamedResponse {
-}
+class _FakeStreamedResponse_1 extends _i1.Fake
+    implements _i3.StreamedResponse {}

-----------------------------------------------------------------



❌ Some files are incorrectly formatted, see above output.

To fix these locally, run: 'melos run format'.
```

https://github.com/fluttercommunity/plus_plugins/actions/runs/4028530903/jobs/6925523935