### PR TITLE
docs(connectivity_plus): Documentation added for the missing network interface enums

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -35,6 +35,19 @@ if (connectivityResult == ConnectivityResult.mobile) {
   // I am connected to a mobile network.
 } else if (connectivityResult == ConnectivityResult.wifi) {
   // I am connected to a wifi network.
+} else if (connectivityResult == ConnectivityResult.ethernet) {
+  // I am connected to a ethernet network.
+} else if (connectivityResult == ConnectivityResult.vpn) {
+  // I am connected to a vpn network.
+  // Note for iOS and macOS:
+  // There is no separate network interface type for [vpn].
+  // It returns [other] on any device (also simulator)
+} else if (connectivityResult == ConnectivityResult.bluetooth) {
+  // I am connected to a bluetooth.
+} else if (connectivityResult == ConnectivityResult.other) {
+  // I am connected to a network which is not in the above mentioned networks.
+} else if (connectivityResult == ConnectivityResult.none) {
+  // I am not connected to any network.
 }
 ```
 


### PR DESCRIPTION
## Description

*This PR is for updating the document for missing network interface enums*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

