### PR TITLE
refactor: Remove nullable struct fields

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
@@ -10,10 +10,10 @@ part of package_info_plus_windows;
 
 class _LANGANDCODEPAGE extends Struct {
   @Uint16()
-  external int? wLanguage;
+  external int wLanguage;
 
   @Uint16()
-  external int? wCodePage;
+  external int wCodePage;
 }
 
 final _kernel32 = DynamicLibrary.open('kernel32.dll');
@@ -65,8 +65,8 @@ class _FileVersionInfo {
     String toHex4(int val) => val.toRadixString(16).padLeft(4, '0');
 
     for (final langCodepage in langCodepages) {
-      final lang = toHex4(langCodepage[0]!);
-      final codepage = toHex4(langCodepage[1]!);
+      final lang = toHex4(langCodepage[0]);
+      final codepage = toHex4(langCodepage[1]);
       final lpSubBlock = TEXT('\\StringFileInfo\\$lang$codepage\\$name');
       final res =
           VerQueryValue(_data.lpBlock!, lpSubBlock, lplpBuffer.cast(), puLen);


### PR DESCRIPTION
## Description

Struct fields should not be nullable, removing nullability modifier.

## Related Issues

* https://github.com/fluttercommunity/plus_plugins/issues/1525

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

