### PR TITLE
fix(package_info_plus): Make installerStore an optional argument in mocks

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -78,7 +78,7 @@ class PackageInfo {
     required String version,
     required String buildNumber,
     required String buildSignature,
-    required String? installerStore,
+    String? installerStore,
   }) {
     _fromPlatform = PackageInfo(
       appName: appName,


### PR DESCRIPTION
Making this a required argument unnecessarily broke all calls to setMockInitialValues. This undoes that change but is not itself a breaking change.

## Description

Make installerStore an optional argument in setMockInitialValues.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

