### PR TITLE
chore(all): Refresh Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,3 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 


### PR DESCRIPTION
## Description

I see that for some reason Dependabot ignores some of packages we have in this repo, so, for example, `share_plus` uses not the most up-to-date dependencies. After some research I found out that it might be a bug in Dependabot: https://github.com/dependabot/dependabot-core/issues/2574

As suggested in that issue any commit to yaml config will make Dependabot re-evaluate it and, hopefully, will resume PRs creation. So trying my luck here.

In case Dependabot continues ignoring packages I would try to swap it to https://github.com/renovatebot/renovate as an experiment.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

