### PR TITLE
test(all): Fix macos integration tests for all packages

### DIFF
--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -126,8 +126,11 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
+      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        run: ./.github/workflows/scripts/install-flutter.sh stable
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.3.10'
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Run Integration Test"

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -125,8 +125,11 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
+      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        run: ./.github/workflows/scripts/install-flutter.sh stable
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.3.10'
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Run Integration Test"

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -126,8 +126,11 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
+      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        run: ./.github/workflows/scripts/install-flutter.sh stable
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.3.10'
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Run Integration Test"

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -126,8 +126,11 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
+      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        run: ./.github/workflows/scripts/install-flutter.sh stable
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.3.10'
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Run Integration Test"

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -125,8 +125,11 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
+      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        run: ./.github/workflows/scripts/install-flutter.sh stable
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.3.10'
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Run Integration Test"

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -125,8 +125,11 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
+      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        run: ./.github/workflows/scripts/install-flutter.sh stable
+        uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.3.10'
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Run Integration Test"


### PR DESCRIPTION
## Description

After some research found out that MacOS integration tests were failing due to this issue https://github.com/flutter/flutter/issues/118469
Older Flutter version is suggested as a solution for this problem. I have tested the change in https://github.com/fluttercommunity/plus_plugins/pull/1596 and saw that it works. Thus, updated all workflows to use older Flutter version and explanation comment on why fixed version is used.

Fixes https://github.com/fluttercommunity/plus_plugins/issues/1591

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

