### PR TITLE
chore(website): Improve dependabot for npm packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    versioning-strategy: increase
 
   # Android Alarm Manager dependencies updates config
 


### PR DESCRIPTION
## Description

This PR changes the [versioning strategy](https://stackoverflow.com/a/66819358) for npm dependabot updates.
We had a couple of [dependabot alerts](https://github.com/fluttercommunity/plus_plugins/security/dependabot?q=is%3Aclosed), that were not updated via dependabot.
Maybe the issue of this [PR](https://github.com/fluttercommunity/plus_plugins/pull/1544) not able to rebase could also be solved.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

