### PR TITLE
fix(share_plus): Set exported=false for BroadcastReceiver on Android

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/AndroidManifest.xml
+++ b/packages/share_plus/share_plus/android/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
       </provider>
       <!-- This manifest declared broadcast receiver allows us to use an explicit
            Intent when creating a PendingItent to be informed of the user's choice -->
-      <receiver android:name=".SharePlusPendingIntent" android:exported="true">
+      <receiver android:name=".SharePlusPendingIntent" android:exported="false">
         <intent-filter>
           <action android:name="EXTRA_CHOSEN_COMPONENT" />
         </intent-filter>


### PR DESCRIPTION
## Description

Addressing an issue reported in #1608. After looking at the documentation and code saw that we indeed don't need to have receiver exposed as only catch the intent that we launch from the app that uses `share_plus`

Docs on topic: 
- https://developer.android.com/guide/topics/manifest/receiver-element
- https://developer.android.com/training/permissions/restrict-interactions#broadcast-receivers

Tested the change - no issues with getting result of share in example app.

## Related Issues

Closes #1608

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

