### PR TITLE
fix(package_info_plus): Make example app content scrollable

### DIFF
--- a/packages/package_info_plus/package_info_plus/example/lib/main.dart
+++ b/packages/package_info_plus/package_info_plus/example/lib/main.dart
@@ -19,17 +19,18 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'PackageInfo Demo',
-      theme: ThemeData(primarySwatch: Colors.blue),
-      home: const MyHomePage(title: 'PackageInfo example app'),
+      title: 'PackageInfoPlus Demo',
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: const Color(0x9f4376f8),
+      ),
+      home: const MyHomePage(),
     );
   }
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key, this.title}) : super(key: key);
-
-  final String? title;
+  const MyHomePage({Key? key}) : super(key: key);
 
   @override
   State<MyHomePage> createState() => _MyHomePageState();
@@ -69,10 +70,10 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title!),
+        title: const Text('PackageInfoPlus example'),
+        elevation: 4,
       ),
-      body: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+      body: ListView(
         children: <Widget>[
           _infoTile('App name', _packageInfo.appName),
           _infoTile('Package name', _packageInfo.packageName),

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -45,6 +45,7 @@ class DemoAppState extends State<DemoApp> {
       home: Scaffold(
         appBar: AppBar(
           title: const Text('Share Plus Plugin Demo'),
+          elevation: 4,
         ),
         body: SingleChildScrollView(
           padding: const EdgeInsets.all(24),


### PR DESCRIPTION
## Description

While testing some changes for package_info_plus saw that example app has non-scrollable content, so in landscape mode there is an overflow (see attached screenshot). This PR fixes it along with switching example app to usage of Material 3. Used the same color seed as in `share_plus`. The only addition is an elevation to AppBar, so it is not white by default. Did the same adjustment to `share_plus` for consistency.

Before:
![photo_2023-03-11 22 01 13](https://user-images.githubusercontent.com/13467769/224509201-e178bccc-4e0f-4db3-b969-95c8b49b8bd8.jpeg)
After:
![photo_2023-03-11 22 01 16](https://user-images.githubusercontent.com/13467769/224509203-30736eba-361c-41b3-a76e-df611128f491.jpeg)


## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

