### PR TITLE
ci(all): Fix Melos version on 2.9.0

### DIFF
--- a/.github/workflows/scripts/install-tools.sh
+++ b/.github/workflows/scripts/install-tools.sh
@@ -3,7 +3,7 @@
 set -e
 
 flutter config --no-analytics
-flutter pub global activate melos
+flutter pub global activate melos 2.9.0
 echo "$HOME/.pub-cache/bin" >> $GITHUB_PATH
 echo "$HOME/AppData/Local/Pub/Cache/bin" >> $GITHUB_PATH
 echo "$GITHUB_WORKSPACE/_flutter/.pub-cache/bin" >> $GITHUB_PATH


### PR DESCRIPTION
## Description

CI workflow was activating latest version of Melos, so in #1614 and #1613 checks were already running with Melos 3.0.0, which was released just recently. Initially I wanted to follow the migration guide, but saw in changelogs that version 3.0.0 requires 2.18 as min Dart SDK: https://github.com/invertase/melos/blob/main/CHANGELOG.md#melos---v300
I wouldn't like us to bump plugins min Dart version for now, so modified the script to use 2.9.0 as it was used before.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

