### PR TITLE
feat(package_info_plus): Use new API to get install source on Android >= 11

### DIFF
--- a/packages/package_info_plus/package_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/packageinfo/PackageInfoPlugin.kt
+++ b/packages/package_info_plus/package_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/packageinfo/PackageInfoPlugin.kt
@@ -38,7 +38,7 @@ class PackageInfoPlugin : MethodCallHandler, FlutterPlugin {
 
                 val buildSignature = getBuildSignature(packageManager)
 
-                val installerPackage = packageManager.getInstallerPackageName(applicationContext!!.packageName);
+                val installerPackage = getInstallerPackageName()
 
                 val infoMap = HashMap<String, String>()
                 infoMap.apply {
@@ -56,6 +56,21 @@ class PackageInfoPlugin : MethodCallHandler, FlutterPlugin {
             }
         } catch (ex: PackageManager.NameNotFoundException) {
             result.error("Name not found", ex.message, null)
+        }
+    }
+
+    /**
+     * Using initiatingPackageName on Android 11 and newer because it can't be changed
+     * https://developer.android.com/reference/android/content/pm/InstallSourceInfo#getInitiatingPackageName()
+     */
+    private fun getInstallerPackageName(): String? {
+        val packageManager = applicationContext!!.packageManager
+        val packageName = applicationContext!!.packageName
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            packageManager.getInstallSourceInfo(packageName).initiatingPackageName
+        } else {
+            @Suppress("DEPRECATION")
+            packageManager.getInstallerPackageName(packageName)
         }
     }
 


### PR DESCRIPTION
## Description

Added calls to a newer API that is suggested since Android 11 to get information about package that installed the app.

## Related Issues

Closes #1598 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

