### PR TITLE
refactor(all): Remove all manual dependency_overrides

### DIFF
--- a/packages/android_alarm_manager_plus/example/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/example/pubspec.yaml
@@ -8,8 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  android_alarm_manager_plus:
-    path: ../
+  android_alarm_manager_plus: ^2.1.1
   shared_preferences: ^2.0.13
   path_provider: ^2.0.9
 

--- a/packages/android_intent_plus/example/pubspec.yaml
+++ b/packages/android_intent_plus/example/pubspec.yaml
@@ -8,8 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   platform: ^3.1.0
-  android_intent_plus:
-    path: ../
+  android_intent_plus: ^3.1.6
 
 dev_dependencies:
   flutter_driver:

--- a/packages/battery_plus/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/example/pubspec.yaml
@@ -7,8 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  battery_plus:
-    path: ../
+  battery_plus: ^3.0.3
 
 dev_dependencies:
   flutter_driver:

--- a/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
@@ -7,12 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  connectivity_plus:
-    path: ../
-
-dependency_overrides:
-  connectivity_plus_platform_interface:
-    path: ../../connectivity_plus_platform_interface
+  connectivity_plus: ^3.0.3
 
 dev_dependencies:
   flutter_driver:

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -4,12 +4,7 @@ description: Demonstrates how to use the device_info_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus:
-    path: ../
-
-dependency_overrides:
-  device_info_plus_platform_interface:
-    path: ../../device_info_plus_platform_interface
+  device_info_plus: ^8.1.0
 
 dev_dependencies:
   flutter_driver:

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -7,12 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus:
-    path: ../
-
-dependency_overrides:
-  network_info_plus_platform_interface:
-    path: ../../network_info_plus_platform_interface
+  network_info_plus: ^3.0.2
 
 dev_dependencies:
   flutter_driver:

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -9,12 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus:
-    path: ../
-
-dependency_overrides:
-  package_info_plus_platform_interface:
-    path: ../../package_info_plus_platform_interface
+  package_info_plus: ^3.0.3
 
 dev_dependencies:
   integration_test:


### PR DESCRIPTION
## Description

Manual dependency_overrides in the examples shouldn't be needed since Melos already should handle those.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

