### PR TITLE
refactor(connectivity_plus): improve connectivity_plus readability

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
@@ -21,27 +21,21 @@ class Connectivity {
   // When a second instance is created, the first instance will not be able to listen to the
   // EventChannel because it is overridden. Forcing the class to be a singleton class can prevent
   // misuse of creating a second instance from a programmer.
-  factory Connectivity() {
-    _singleton ??= Connectivity._();
-    return _singleton!;
-  }
+  factory Connectivity() => _singleton ??= Connectivity._();
 
   Connectivity._();
 
   static Connectivity? _singleton;
 
-  static ConnectivityPlatform get _platform {
-    return ConnectivityPlatform.instance;
-  }
+  static ConnectivityPlatform get _platform => ConnectivityPlatform.instance;
 
   /// Fires whenever the connectivity state changes.
   ///
   /// On iOS, the connectivity status might not update when WiFi
   /// status changes, this is a known issue that only affects simulators.
   /// For details see https://github.com/fluttercommunity/plus_plugins/issues/479.
-  Stream<ConnectivityResult> get onConnectivityChanged {
-    return _platform.onConnectivityChanged;
-  }
+  Stream<ConnectivityResult> get onConnectivityChanged =>
+      _platform.onConnectivityChanged;
 
   /// Checks the connection status of the device.
   ///
@@ -49,7 +43,6 @@ class Connectivity {
   /// make a network request. It only gives you the radio status.
   ///
   /// Instead listen for connectivity changes via [onConnectivityChanged] stream.
-  Future<ConnectivityResult> checkConnectivity() {
-    return _platform.checkConnectivity();
-  }
+  Future<ConnectivityResult> checkConnectivity() =>
+      _platform.checkConnectivity();
 }


### PR DESCRIPTION
## Description

Update `connectivity_plus` class syntax.

#### Reasons
**_Conciseness_**: The new syntax is more concise and reduces the amount of boilerplate code required to implement the factory function. This results in cleaner and more readable code, making it easier for developers to understand and maintain the codebase.
**_Clarity_**: The fat arrow syntax is a more expressive way of defining a function that returns a value. It makes it clear that the function returns _singleton if it exists, otherwise, it creates a new instance of Connectivity._() and returns it.
**_Modern Syntax_**: The fat arrow syntax is a modern feature in Dart and is becoming increasingly popular in the Dart community. By using this syntax, the codebase can be updated to follow the latest best practices and conventions.

## Related Issues
None.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

None.
