### PR TITLE
fix(share_plus_android): Fix strict compilation errors in MIME reduction function

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -184,35 +184,27 @@ internal class Share(
         return uris
     }
 
-    /**
-     * Reduces provided MIME types to a common one to provide [Intent] with a correct type
-     * to share multiple files
-     */
-    private fun reduceMimeTypes(mimeTypes: List<String>?): String {
-        var reducedMimeType = "*/*"
+  /**
+   * Reduces provided MIME types to a common one to provide [Intent] with a correct type to share
+   * multiple files
+   */
+  private fun reduceMimeTypes(mimeTypes: List<String>?): String {
+    if (mimeTypes?.isEmpty() ?: true) return "*/*"
+    if (mimeTypes!!.size == 1) return mimeTypes.first()
 
-        mimeTypes?.let { types ->
-            {
-                if (types.size == 1) {
-                    reducedMimeType = types.first()
-                } else if (types.size > 1) {
-                    var commonMimeType = types.first()
-                    for (i in 1..types.lastIndex) {
-                        if (commonMimeType != types[i]) {
-                            if (getMimeTypeBase(commonMimeType) == getMimeTypeBase(types[i])) {
-                                commonMimeType = getMimeTypeBase(types[i]) + "/*"
-                            } else {
-                                commonMimeType = "*/*"
-                                break
-                            }
-                        }
-                    }
-                    reducedMimeType = commonMimeType
-                }
-            }
+    var commonMimeType = mimeTypes.first()
+    for (i in 1..mimeTypes.lastIndex) {
+      if (commonMimeType != mimeTypes[i]) {
+        if (getMimeTypeBase(commonMimeType) == getMimeTypeBase(mimeTypes[i])) {
+          commonMimeType = getMimeTypeBase(mimeTypes[i]) + "/*"
+        } else {
+          commonMimeType = "*/*"
+          break
         }
-        return reducedMimeType
+      }
     }
+    return commonMimeType
+  }
 
     /**
      * Returns the first part of provided MIME type, which comes before '/' symbol


### PR DESCRIPTION
## Description

Without this change I see the following errors with strict compilation flags:

```
Error: 'types' is captured by a lambda expression that is passed as immutable type(s) String but is of type List which is mutable [Immutable]
        if (types.size == 1) {
            ~~~~~
Error: 'reducedMimeType' is captured by a lambda expression that is passed as immutable type(s) String but is not final [Immutable]
          reducedMimeType = types.first()
          ~~~~~~~~~~~~~~~
```

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

