### PR TITLE
chore(release): prepare for release

### DIFF
--- a/packages/android_alarm_manager_plus/CHANGELOG.md
+++ b/packages/android_alarm_manager_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.1.2
+
+ - **REFACTOR**(all): Remove all manual dependency_overrides (#1628).
+ - **FIX**(all): Fix depreciations for flutter 3.7 and 2.19 dart (#1529).
+
 ## 2.1.1
 
  - **DOCS**: Updates for READMEs and website pages (#1389).

--- a/packages/android_alarm_manager_plus/example/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  android_alarm_manager_plus: ^2.1.1
+  android_alarm_manager_plus: ^2.1.2
   shared_preferences: ^2.0.13
   path_provider: ^2.0.9
 

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager_plus
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 2.1.1
+version: 2.1.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/android_alarm_manager_plus

--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.1.7
+
+ - **REFACTOR**(all): Remove all manual dependency_overrides (#1628).
+ - **FIX**(all): Fix depreciations for flutter 3.7 and 2.19 dart (#1529).
+
 ## 3.1.6
 
  - **DOCS**: Updates for READMEs and website pages (#1389).

--- a/packages/android_intent_plus/example/pubspec.yaml
+++ b/packages/android_intent_plus/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   flutter:
     sdk: flutter
   platform: ^3.1.0
-  android_intent_plus: ^3.1.6
+  android_intent_plus: ^3.1.7
 
 dev_dependencies:
   flutter_driver:

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 3.1.6
+version: 3.1.7
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/android_intent_plus

--- a/packages/battery_plus/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.4
+
+ - **REFACTOR**(all): Remove all manual dependency_overrides (#1628).
+ - **FIX**(all): Fix depreciations for flutter 3.7 and 2.19 dart (#1529).
+
 ## 3.0.3
 
  - **FIX**: broadcast stream (#1479).

--- a/packages/battery_plus/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  battery_plus: ^3.0.3
+  battery_plus: ^3.0.4
 
 dev_dependencies:
   flutter_driver:

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 3.0.3
+version: 3.0.4
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/battery_plus

--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.4
+
+ - **REFACTOR**(all): Remove all manual dependency_overrides (#1628).
+ - **DOCS**(connectivity_plus): Documentation added for the missing network interface enums (#1524).
+
 ## 3.0.3
 
  - **FIX**: Do not return ConnectivityResult.none on iOS and MacOS with VPN (#1335).

--- a/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  connectivity_plus: ^3.0.3
+  connectivity_plus: ^3.0.4
 
 dev_dependencies:
   flutter_driver:

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 3.0.3
+version: 3.0.4
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/connectivity_plus

--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 8.2.0
+
+ - **REFACTOR**(all): Remove all manual dependency_overrides (#1628).
+ - **FEAT**(device_info_plus): add major, minor and patch versions to macos (#1649).
+
 ## 8.1.0
 
  - **FEAT**: Add serialNumber property to AndroidDeviceInfo (#1349).

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the device_info_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus: ^8.1.0
+  device_info_plus: ^8.2.0
 
 dev_dependencies:
   flutter_driver:

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 8.1.0
+version: 8.2.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/device_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus

--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.3
+
+ - **REFACTOR**(all): Remove all manual dependency_overrides (#1628).
+ - **FIX**(network_info_plus): import original `getgateway.*` from libnatpmp (#1592).
+ - **FIX**(all): Fix depreciations for flutter 3.7 and 2.19 dart (#1529).
+
 ## 3.0.2
 
  - **DOCS**: Updates for READMEs and website pages (#1389).

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus: ^3.0.2
+  network_info_plus: ^3.0.3
 
 dev_dependencies:
   flutter_driver:

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 3.0.2
+version: 3.0.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/network_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/network_info_plus

--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 3.1.0
+
+ - **REFACTOR**(all): Remove all manual dependency_overrides (#1628).
+ - **FIX**(package_info_plus): Make example app content scrollable (#1614).
+ - **FIX**(package_info_plus): Make installerStore an optional argument in mocks (#1547).
+ - **FIX**(all): Fix depreciations for flutter 3.7 and 2.19 dart (#1529).
+ - **FEAT**(package_info_plus): Use new API to get install source on Android >= 11 (#1616).
+
 ## 3.0.3
 
  - **REFACTOR**: Remove nullable struct fields (#1526).

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  package_info_plus: ^3.0.3
+  package_info_plus: ^3.1.0
 
 dev_dependencies:
   integration_test:

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 3.0.3
+version: 3.1.0
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/package_info_plus

--- a/packages/sensors_plus/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.3
+
+ - **DOCS**(sensor_plus): improve description of accelerometer (#1425).
+
 ## 2.0.2
 
  - **DOCS**: Updates for READMEs and website pages (#1389).

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sensors_plus
 description: Flutter plugin for accessing accelerometer, gyroscope, and
   magnetometer sensors.
-version: 2.0.2
+version: 2.0.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/sensors_plus

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.3.2
+
+ - **FIX**(share_plus): Set exported=false for BroadcastReceiver on Android (#1613).
+ - **FIX**(package_info_plus): Make example app content scrollable (#1614).
+ - **FIX**(all): Fix depreciations for flutter 3.7 and 2.19 dart (#1529).
+
 ## 6.3.1
 
  - **FIX**: Fix the error of requestCode value range. (#1340).

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 6.3.1
+version: 6.3.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus

--- a/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
+++ b/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1
+
+ - **FIX**(all): Fix depreciations for flutter 3.7 and 2.19 dart (#1529).
+
 ## 3.2.0
 
  - **FIX**: export XFile (#1286).

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_platform_interface
 description: A common platform interface for the share_plus plugin.
-version: 3.2.0
+version: 3.2.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

Long awaited release of packages.

To workaround the problem we had with publishing that we had when `share_plus` dry run failed due to not being able to find the `share_plus_platform_interface` I have changed version of platform interface to be not `3.2.1` which we are going to publish, but `3.2.0`. With this change we are able to run `melos publish` successfully and I don't expect breaking changes caused by this changes.

As soon as I publish this release I will create a new release for `share_plus` plugin only which should publish successfully as platform interface `3.2.1` will be already available on pub.dev.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

