### PR TITLE
build(android_alarm_manager_plus): Bump example app compileSDK to 33

### DIFF
--- a/packages/android_alarm_manager_plus/example/android/app/build.gradle
+++ b/packages/android_alarm_manager_plus/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
## Description

location: packages\android_alarm_manager_plus\example\android\app\build.gradle

compileSdkVersion changed to 33 from 31 because its showing an error in Debug Console 

error: 
One or more plugins require a higher Android SDK version.
Fix this issue by adding the following to C:\Users\HP\Desktop\codes\plus_plugins\packages\android_alarm_manager_plus\example\android\app\build.gradle:
android {
  compileSdkVersion 33
  ...
}



