### PR TITLE
fix(battery_plus): Huawei power save mode check

### DIFF
--- a/packages/battery_plus/battery_plus/example/android/build.gradle
+++ b/packages/battery_plus/battery_plus/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.22'
+    ext.kotlin_version = '1.8.20'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Description

Replacement PR for #1629 to get the fix merged faster.
Additionally did a minor code cleanup

## Related Issues

Found this Stack Overflow answer related to Huawei: https://stackoverflow.com/questions/45743484/ispowersavemode-always-returns-false-for-huawei-devices/65682806#65682806

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

