### PR TITLE
fix(network_info_plus): fixed Unhandled Exception: type 'Null' is not a subtype of type 'String' in type cast for Linux

### DIFF
--- a/packages/network_info_plus/network_info_plus/lib/src/network_info_plus_linux.dart
+++ b/packages/network_info_plus/network_info_plus/lib/src/network_info_plus_linux.dart
@@ -91,7 +91,7 @@ class NetworkInfoPlusLinuxPlugin extends NetworkInfoPlatform {
   }
 
   String? _getIpAddress(List<Map<String, dynamic>>? data) {
-    return data?.firstOrNull?['address'] as String;
+    return data?.firstOrNull?['address'] as String?;
   }
 
   String? _getSubnetMask(List<Map<String, dynamic>>? data) {


### PR DESCRIPTION
## Description

*Fixes `Unhandled Exception: type 'Null' is not a subtype of type 'String' in type cast` if Linux device is not connected to network*

## Related Issues
- *Fix #1716*


## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

