### PR TITLE
fix(all): Revert addition of namespace to avoid build fails on old AGPs

### DIFF
--- a/packages/android_alarm_manager_plus/android/build.gradle
+++ b/packages/android_alarm_manager_plus/android/build.gradle
@@ -23,15 +23,12 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 31
-    namespace 'dev.fluttercommunity.plus.androidalarmmanager'
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
+
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/packages/android_alarm_manager_plus/example/android/app/build.gradle
+++ b/packages/android_alarm_manager_plus/example/android/app/build.gradle
@@ -27,7 +27,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 33
-    namespace 'com.example.example'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/packages/android_intent_plus/android/build.gradle
+++ b/packages/android_intent_plus/android/build.gradle
@@ -23,15 +23,16 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 31
-    namespace 'dev.fluttercommunity.plus.androidintent'
 
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }
+
     testOptions {
         unitTests.includeAndroidResources = true
     }

--- a/packages/android_intent_plus/example/android/app/build.gradle
+++ b/packages/android_intent_plus/example/android/app/build.gradle
@@ -26,7 +26,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 31
-    namespace 'io.flutter.plugins.androidintentexample'
 
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/battery_plus/battery_plus/android/build.gradle
+++ b/packages/battery_plus/battery_plus/android/build.gradle
@@ -24,12 +24,12 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 33
-    namespace 'dev.fluttercommunity.plus.battery'
 
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/packages/battery_plus/battery_plus/example/android/app/build.gradle
+++ b/packages/battery_plus/battery_plus/example/android/app/build.gradle
@@ -27,7 +27,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 33
-    namespace 'io.flutter.plugins.batteryexample.example'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/packages/connectivity_plus/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/android/build.gradle
@@ -23,12 +23,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 31
-    namespace 'dev.fluttercommunity.plus.connectivity'
-
-    compileOptions {
-      sourceCompatibility JavaVersion.VERSION_1_8
-      targetCompatibility JavaVersion.VERSION_1_8
-    }
 
     defaultConfig {
         minSdkVersion 16

--- a/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
@@ -26,7 +26,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 31
-    namespace 'io.flutter.plugins.connectivityexample'
 
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/device_info_plus/device_info_plus/android/build.gradle
+++ b/packages/device_info_plus/device_info_plus/android/build.gradle
@@ -26,12 +26,12 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 33
-    namespace 'dev.fluttercommunity.plus.device_info'
 
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/packages/device_info_plus/device_info_plus/example/android/app/build.gradle
+++ b/packages/device_info_plus/device_info_plus/example/android/app/build.gradle
@@ -27,7 +27,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 33
-    namespace 'io.flutter.plugins.deviceinfoexample.example'
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/packages/network_info_plus/network_info_plus/android/build.gradle
+++ b/packages/network_info_plus/network_info_plus/android/build.gradle
@@ -26,12 +26,12 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 33
-    namespace 'dev.fluttercommunity.plus.network_info'
 
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/packages/network_info_plus/network_info_plus/example/android/app/build.gradle
+++ b/packages/network_info_plus/network_info_plus/example/android/app/build.gradle
@@ -26,7 +26,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 33
-    namespace 'dev.fluttercommunity.plus.network_info_plus_example'
 
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/package_info_plus/package_info_plus/android/build.gradle
+++ b/packages/package_info_plus/package_info_plus/android/build.gradle
@@ -27,12 +27,12 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
-    namespace 'dev.fluttercommunity.plus.packageinfo'
 
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/packages/package_info_plus/package_info_plus/example/android/app/build.gradle
+++ b/packages/package_info_plus/package_info_plus/example/android/app/build.gradle
@@ -26,7 +26,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 31
-    namespace 'io.flutter.plugins.packageinfoexample'
 
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/sensors_plus/sensors_plus/android/build.gradle
+++ b/packages/sensors_plus/sensors_plus/android/build.gradle
@@ -26,12 +26,12 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
-    namespace 'dev.fluttercommunity.plus.sensors'
 
     defaultConfig {
         minSdkVersion 16
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/packages/sensors_plus/sensors_plus/example/android/app/build.gradle
+++ b/packages/sensors_plus/sensors_plus/example/android/app/build.gradle
@@ -26,7 +26,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 31
-    namespace 'io.flutter.plugins.sensorsexample'
 
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/share_plus/share_plus/android/build.gradle
+++ b/packages/share_plus/share_plus/android/build.gradle
@@ -26,12 +26,12 @@ apply plugin: 'kotlin-android'
 
 android {
   compileSdkVersion 33
-  namespace 'dev.fluttercommunity.plus.share'
 
   defaultConfig {
     minSdkVersion 16
     testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
   }
+
   lintOptions {
     disable 'InvalidPackage'
   }

--- a/packages/share_plus/share_plus/example/android/app/build.gradle
+++ b/packages/share_plus/share_plus/example/android/app/build.gradle
@@ -26,7 +26,6 @@ apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
     compileSdkVersion 33
-    namespace 'io.flutter.plugins.shareexample'
 
     lintOptions {
         disable 'InvalidPackage'


### PR DESCRIPTION
## Description

Reverting `namespace` addition to release a fix for those who use old AGP versions.

## Related Issues

Closes #1722 
Closes #1724 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

