### PR TITLE
refactor(device_info_plus): Declare proper nullability for iOS properties

### DIFF
--- a/packages/device_info_plus/device_info_plus/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/device_info_plus/device_info_plus/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -200,6 +200,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -231,6 +232,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/packages/device_info_plus/device_info_plus/example/ios/Runner/Info.plist
+++ b/packages/device_info_plus/device_info_plus/example/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/device_info_plus/device_info_plus/lib/src/model/ios_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/ios_device_info.dart
@@ -11,11 +11,11 @@ class IosDeviceInfo extends BaseDeviceInfo {
   /// IOS device info class.
   IosDeviceInfo._({
     required Map<String, dynamic> data,
-    this.name,
-    this.systemName,
-    this.systemVersion,
-    this.model,
-    this.localizedModel,
+    required this.name,
+    required this.systemName,
+    required this.systemVersion,
+    required this.model,
+    required this.localizedModel,
     this.identifierForVendor,
     required this.isPhysicalDevice,
     required this.utsname,
@@ -27,19 +27,19 @@ class IosDeviceInfo extends BaseDeviceInfo {
   /// On iOS >= 16 returns a generic device name if project has
   /// no entitlement to get user-assigned device name.
   /// See: https://developer.apple.com/documentation/uikit/uidevice/1620015-name
-  final String? name;
+  final String name;
 
   /// The name of the current operating system.
-  final String? systemName;
+  final String systemName;
 
   /// The current operating system version.
-  final String? systemVersion;
+  final String systemVersion;
 
   /// Device model.
-  final String? model;
+  final String model;
 
   /// Localized name of the device model.
-  final String? localizedModel;
+  final String localizedModel;
 
   /// Unique UUID value identifying the current device.
   final String? identifierForVendor;
@@ -71,27 +71,27 @@ class IosDeviceInfo extends BaseDeviceInfo {
 /// See http://pubs.opengroup.org/onlinepubs/7908799/xsh/sysutsname.h.html for details.
 class IosUtsname {
   const IosUtsname._({
-    this.sysname,
-    this.nodename,
-    this.release,
-    this.version,
-    this.machine,
+    required this.sysname,
+    required this.nodename,
+    required this.release,
+    required this.version,
+    required this.machine,
   });
 
   /// Operating system name.
-  final String? sysname;
+  final String sysname;
 
   /// Network node name.
-  final String? nodename;
+  final String nodename;
 
   /// Release level.
-  final String? release;
+  final String release;
 
   /// Version level.
-  final String? version;
+  final String version;
 
   /// Hardware type (e.g. 'iPhone7,1' for iPhone 6 Plus).
-  final String? machine;
+  final String machine;
 
   /// Deserializes from the map message received from [_kChannel].
   static IosUtsname _fromMap(Map<String, dynamic> map) {


### PR DESCRIPTION
## Description

One more refactor similar to #1246, but this time for iOS.
According to https://developer.apple.com/documentation/uikit/uidevice and https://pubs.opengroup.org/onlinepubs/7908799/xsh/sysutsname.h.html almost all properties that we return with the plugin are not nullable. So this PR updates nullability of properties to match the iOS specs.

## Related Issues

Closes #1670

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

