### PR TITLE
docs(package_info_plus): Explain why buildNumber returns version when no build number defined

### DIFF
--- a/docs/package_info_plus/usage.mdx
+++ b/docs/package_info_plus/usage.mdx
@@ -46,6 +46,11 @@ requires the Xcode build folder to be rebuilt after changes to the version strin
 Clean the Xcode build folder with:
 `XCode Menu -> Product -> (Holding Option Key) Clean build folder`.
 
+#### Plugin returns package version in `buildNumber` when no build number specified in pubspec.yaml
+
+Plugin doesn't modify the output of iOS. In this case `buildNumber` in the plugin is CFBundleVersion in iOS. This property returns version when build number is not specified.buildNumber
+See [CFBundleVersion docs](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion) for more inf.
+
 ### Android (and potentially all platforms)
 
 Calling to `PackageInfo.fromPlatform()` before the `runApp()` call will cause an exception.

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -60,6 +60,8 @@ class PackageInfo {
   final String version;
 
   /// The build number. `CFBundleVersion` on iOS, `versionCode` on Android.
+  /// Note, on iOS if an app has no buildNumber specified this property will return version
+  /// Docs about CFBundleVersion: https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion
   final String buildNumber;
 
   /// The build signature. Empty string on iOS, signing key signature (hex) on Android.


### PR DESCRIPTION
## Description

Added an explanation on why `buildNumber` sometimes returns the same value as `version` property.

## Related Issues

Closes #1644 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

