### PR TITLE
chore(share_plus): Update Flutter dependencies, set Flutter >=3.3.0 and Dart to >=2.18.0 <4.0.0

### DIFF
--- a/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
@@ -144,6 +144,10 @@ class WebSensorsPlugin extends SensorsPlatform {
       );
       _gyroscopeEventResultStream =
           _gyroscopeEventStreamController!.stream.asBroadcastStream();
+
+      _gyroscopeEventStreamController!.onCancel = () {
+        _gyroscopeEventStreamController!.close();
+      };
     }
 
     return _gyroscopeEventResultStream;

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -4,14 +4,9 @@ description: Demonstrates how to use the share_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  share_plus:
-    path: ../
-  image_picker: ^0.8.4
-  file_selector: ^0.9.2+1
-
-dependency_overrides:
-  share_plus_platform_interface:
-    path: ../../share_plus_platform_interface
+  share_plus: ^6.3.4
+  image_picker: ^0.8.7+4
+  file_selector: ^0.9.2+4
 
 dev_dependencies:
   flutter_driver:

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   url_launcher_linux: ^3.0.5
   url_launcher_platform_interface: ^2.1.2
   ffi: ^2.0.1
-  win32: ^4.1.3
+  win32: ^4.0.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -25,21 +25,21 @@ flutter:
         pluginClass: SharePlusWindowsPluginCApi
 
 dependencies:
-  cross_file: ^0.3.3+2
-  meta: ^1.7.0
-  mime: ^1.0.2
+  cross_file: ^0.3.3+4
+  meta: ^1.8.0
+  mime: ^1.0.4
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  share_plus_platform_interface: ^3.2.0
-  file: ^6.0.0
-  url_launcher_web: ^2.0.13
-  url_launcher_windows: ^3.0.1
-  url_launcher_linux: ^3.0.1
-  url_launcher_platform_interface: ^2.1.1
+  share_plus_platform_interface: ^3.2.1
+  file: ^6.1.4
+  url_launcher_web: ^2.0.16
+  url_launcher_windows: ^3.0.6
+  url_launcher_linux: ^3.0.5
+  url_launcher_platform_interface: ^2.1.2
   ffi: ^2.0.1
-  win32: ^3.0.0
+  win32: ^4.1.3
 
 dev_dependencies:
   flutter_test:
@@ -47,5 +47,5 @@ dev_dependencies:
   flutter_lints: ^2.0.1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.11.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -5,22 +5,22 @@ homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 dependencies:
-  cross_file: ^0.3.3+2
+  cross_file: ^0.3.3+4
   flutter:
     sdk: flutter
-  meta: ^1.7.0
-  mime: ^1.0.2
-  plugin_platform_interface: ^2.0.0
-  path_provider: ^2.0.11
-  uuid: ^3.0.6
+  meta: ^1.8.0
+  mime: ^1.0.4
+  plugin_platform_interface: ^2.1.4
+  path_provider: ^2.0.14
+  uuid: ^3.0.7
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.2.0
+  mockito: ^5.4.0
   flutter_lints: ^2.0.1
-  test: ^1.21.1
+  test: ^1.22.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.11.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"


### PR DESCRIPTION
## Description

Updating used dependencies and aligning constraint with other plugins maintained by the Flutter team (for example, here: https://github.com/flutter/packages/blob/main/packages/url_launcher/url_launcher/pubspec.yaml#L8). Not marking as a breaking change as we already have `namespace` marked as breaking change.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

