### PR TITLE
chore(sensors_plus): Update Flutter dependencies, set Flutter >=3.3.0 and Dart to >=2.18.0 <4.0.0

### DIFF
--- a/packages/sensors_plus/sensors_plus/example/android/app/build.gradle
+++ b/packages/sensors_plus/sensors_plus/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     namespace 'io.flutter.plugins.sensorsexample'
 
@@ -41,7 +41,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.plugins.sensorsexample"
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/sensors_plus/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/example/pubspec.yaml
@@ -4,12 +4,7 @@ description: Demonstrates how to use the sensors plugin.
 dependencies:
   flutter:
     sdk: flutter
-  sensors_plus:
-    path: ../
-
-dependency_overrides:
-  sensors_plus_platform_interface:
-    path: ../../sensors_plus_platform_interface
+  sensors_plus: ^2.0.5
 
 dev_dependencies:
   flutter_driver:

--- a/packages/sensors_plus/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/example/pubspec.yaml
@@ -24,4 +24,4 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <4.0.0'

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -25,11 +25,11 @@ dependencies:
     sdk: flutter
   sensors_plus_platform_interface: ^1.1.3
 dev_dependencies:
-  test: ^1.16.4
+  test: ^1.22.0
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.11.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"

--- a/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
@@ -7,15 +7,15 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.7.0
-  plugin_platform_interface: ^2.0.0
+  meta: ^1.8.0
+  plugin_platform_interface: ^2.1.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^2.0.1
-  test: ^1.21.1
+  test: ^1.22.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.11.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"


### PR DESCRIPTION
## Description

Updating used dependencies and aligning constraint with other plugins maintained by the Flutter team (for example, here: https://github.com/flutter/packages/blob/main/packages/url_launcher/url_launcher/pubspec.yaml#L8). Not marking as a breaking change as we already have namespace marked as breaking change.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

