### PR TITLE
chore(network_info_plus): Update Flutter dependencies, set Flutter >=3.3.0 and Dart to >=2.18.0 <4.0.0

### DIFF
--- a/packages/network_info_plus/network_info_plus/example/integration_test/network_info_plus_test.dart
+++ b/packages/network_info_plus/network_info_plus/example/integration_test/network_info_plus_test.dart
@@ -1,9 +1,6 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// @dart=2.9
-
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
@@ -13,29 +10,27 @@ import 'package:network_info_plus/network_info_plus.dart';
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  group('NetworkInfo test driver', () {
-    NetworkInfo networkInfo;
+  late NetworkInfo networkInfo;
 
-    setUpAll(() async {
-      networkInfo = NetworkInfo();
-    });
+  setUp(() async {
+    networkInfo = NetworkInfo();
+  });
 
-    testWidgets('test location methods, iOS only', (WidgetTester tester) async {
-      if (Platform.isIOS) {
-        // ignore: deprecated_member_use
-        expect((await networkInfo.getLocationServiceAuthorization()),
-            LocationAuthorizationStatus.notDetermined);
-      }
-    }, skip: !Platform.isIOS);
+  testWidgets('test location methods, iOS only', (WidgetTester tester) async {
+    if (Platform.isIOS) {
+      // ignore: deprecated_member_use
+      expect((await networkInfo.getLocationServiceAuthorization()),
+          LocationAuthorizationStatus.notDetermined);
+    }
+  }, skip: !Platform.isIOS);
 
-    testWidgets('test non-null network value', (WidgetTester tester) async {
-      expect(networkInfo.getWifiName(), isNotNull);
-      expect(networkInfo.getWifiBSSID(), isNotNull);
-      expect(networkInfo.getWifiIP(), isNotNull);
-      expect(networkInfo.getWifiIPv6(), isNotNull);
-      expect(networkInfo.getWifiSubmask(), isNotNull);
-      expect(networkInfo.getWifiGatewayIP(), isNotNull);
-      expect(networkInfo.getWifiBroadcast(), isNotNull);
-    });
+  testWidgets('test non-null network value', (WidgetTester tester) async {
+    expect(networkInfo.getWifiName(), isNotNull);
+    expect(networkInfo.getWifiBSSID(), isNotNull);
+    expect(networkInfo.getWifiIP(), isNotNull);
+    expect(networkInfo.getWifiIPv6(), isNotNull);
+    expect(networkInfo.getWifiSubmask(), isNotNull);
+    expect(networkInfo.getWifiGatewayIP(), isNotNull);
+    expect(networkInfo.getWifiBroadcast(), isNotNull);
   });
 }

--- a/packages/network_info_plus/network_info_plus/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/network_info_plus/network_info_plus/example/ios/Flutter/AppFrameworkInfo.plist
@@ -25,6 +25,6 @@
     <string>arm64</string>
   </array>
   <key>MinimumOSVersion</key>
-  <string>9.0</string>
+  <string>11.0</string>
 </dict>
 </plist>

--- a/packages/network_info_plus/network_info_plus/example/ios/Flutter/Flutter.podspec
+++ b/packages/network_info_plus/network_info_plus/example/ios/Flutter/Flutter.podspec
@@ -6,12 +6,12 @@
 Pod::Spec.new do |s|
   s.name             = 'Flutter'
   s.version          = '1.0.0'
-  s.summary          = 'High-performance, high-fidelity mobile apps.'
-  s.homepage         = 'https://flutter.io'
-  s.license          = { :type => 'MIT' }
+  s.summary          = 'A UI toolkit for beautiful and fast apps.'
+  s.homepage         = 'https://flutter.dev'
+  s.license          = { :type => 'BSD' }
   s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
   s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '11.0'
   # Framework linking is handled by Flutter tooling, not CocoaPods.
   # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
   s.vendored_frameworks = 'path/to/nothing'

--- a/packages/network_info_plus/network_info_plus/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/network_info_plus/network_info_plus/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -206,6 +206,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -238,6 +239,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -333,7 +335,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -383,7 +385,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/packages/network_info_plus/network_info_plus/example/ios/Runner/Info.plist
+++ b/packages/network_info_plus/network_info_plus/example/ios/Runner/Info.plist
@@ -49,5 +49,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/network_info_plus/network_info_plus/example/lib/main.dart
+++ b/packages/network_info_plus/network_info_plus/example/lib/main.dart
@@ -35,7 +35,8 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        useMaterial3: true,
+        colorSchemeSeed: const Color(0x9f4376f8),
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
@@ -66,6 +67,7 @@ class _MyHomePageState extends State<MyHomePage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('NetworkInfoPlus example'),
+        elevation: 4,
       ),
       body: Center(
           child: Column(

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -10,13 +10,11 @@ dependencies:
   network_info_plus: ^3.0.5
 
 dev_dependencies:
-  flutter_driver:
-    sdk: flutter
   flutter_test:
     sdk: flutter
   integration_test:
     sdk: flutter
-  test: ^1.22.0
+  test: ^1.21.0
   flutter_lints: ^2.0.1
 
 flutter:

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: network_info_plus_example
 description: Demonstrates how to use the network_info_plus plugin.
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <4.0.0'
 
 dependencies:
   flutter:
@@ -16,7 +16,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  test: ^1.16.4
+  test: ^1.22.0
   flutter_lints: ^2.0.1
 
 flutter:

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/network_info_plus
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.11.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:
@@ -28,7 +28,7 @@ flutter:
         fileName: src/network_info_plus_web.dart
 
 dependencies:
-  collection: ^1.15.0
+  collection: ^1.17.0
   nm: ^0.5.0
   flutter:
     sdk: flutter
@@ -36,9 +36,10 @@ dependencies:
     sdk: flutter
   meta: ^1.8.0
   network_info_plus_platform_interface: ^1.1.3
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  mockito: ^5.3.2
-  plugin_platform_interface: ^2.1.3
+  mockito: ^5.4.0
+  plugin_platform_interface: ^2.1.4
   flutter_lints: ^2.0.1

--- a/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
@@ -5,16 +5,16 @@ homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.11.0"
+  sdk: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.7.0
-  plugin_platform_interface: ^2.1.2
+  meta: ^1.8.0
+  plugin_platform_interface: ^2.1.4
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ">=1.0.4 <3.0.0"
+  flutter_lints: ^2.0.1


### PR DESCRIPTION
## Description

Updating used dependencies and aligning constraint with other plugins maintained by the Flutter team (for example, here: https://github.com/flutter/packages/blob/main/packages/url_launcher/url_launcher/pubspec.yaml#L8). Not marking as a breaking change as we already have namespace marked as breaking change.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

