### PR TITLE
chore(device_info_plus): Update Flutter dependencies, set Flutter >=3.3.0 and Dart to >=2.18.0 <4.0.0

### DIFF
--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -216,6 +216,10 @@ class _MyAppState extends State<MyApp> {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: const Color(0x9f4376f8),
+      ),
       home: Scaffold(
         appBar: AppBar(
           title: Text(
@@ -233,6 +237,7 @@ class _MyAppState extends State<MyApp> {
                                     ? 'Windows Device Info'
                                     : '',
           ),
+          elevation: 4,
         ),
         body: ListView(
           children: _deviceData.keys.map(

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -19,4 +19,4 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <4.0.0'

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -27,21 +27,21 @@ flutter:
 dependencies:
   device_info_plus_platform_interface: ^7.0.0
   ffi: ^2.0.1
-  file: ^6.0.0
+  file: ^6.1.4
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.3.0
-  win32: ">=2.7.0 <5.0.0"
+  meta: ^1.8.0
+  win32: ^4.1.3
 
 dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0
-  test: ^1.16.4
+  mockito: ^5.4.0
+  test: ^1.22.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.11.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -7,15 +7,15 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.3.0
-  plugin_platform_interface: ^2.0.0
+  meta: ^1.8.0
+  plugin_platform_interface: ^2.1.4
 
 dev_dependencies:
-  flutter_lints: ">=1.0.4 <3.0.0"
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0
+  mockito: ^5.4.0
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.11.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"


### PR DESCRIPTION
## Description

Updating used dependencies and aligning constraint with other plugins maintained by the Flutter team (for example, here: https://github.com/flutter/packages/blob/main/packages/url_launcher/url_launcher/pubspec.yaml#L8). Not marking as a breaking change as we already have namespace marked as breaking change.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

