### PR TITLE
chore(connectivity_plus): Update Flutter dependencies, set Flutter >=3.3.0 and Dart to >=2.18.0 <4.0.0

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.connectivity'
 

--- a/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     namespace 'io.flutter.plugins.connectivityexample'
 
@@ -41,7 +41,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.plugins.connectivityexample"
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/connectivity_plus/connectivity_plus/example/lib/main.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/lib/main.dart
@@ -24,7 +24,8 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        useMaterial3: true,
+        colorSchemeSeed: const Color(0x9f4376f8),
       ),
       home: const MyHomePage(title: 'Flutter Demo Home Page'),
     );
@@ -92,6 +93,7 @@ class _MyHomePageState extends State<MyHomePage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Connectivity example app'),
+        elevation: 4,
       ),
       body: Center(
           child: Text('Connection Status: ${_connectionStatus.toString()}')),

--- a/packages/connectivity_plus/connectivity_plus/lib/src/connectivity_plus_web.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/src/connectivity_plus_web.dart
@@ -1,7 +1,6 @@
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 
-import 'web/network_information_api_connectivity_plugin.dart';
 import 'web/dart_html_connectivity_plugin.dart';
 
 /// The web implementation of the ConnectivityPlatform of the Connectivity plugin.
@@ -11,17 +10,18 @@ class ConnectivityPlusWebPlugin extends ConnectivityPlatform {
   static void registerWith(Registrar registrar) {
     // Since the `NetworkInformationApi` is currently an experimental API and
     // does not provide a reliable way to check a connectivity change
-    // from an onnline state to an offline state,
+    // from an online state to an offline state,
     // its implementation is disabled for now.
     // See also: https://developer.mozilla.org/en-US/docs/Web/API/Network_Information_API
     //
     // TODO: use `NetworkInformationApiConnectivityPlugin.isSupported()` when it becomes a stable DOM API.
-    const isSupported = false;
+    // const isSupported = false;
+    // if (isSupported) {
+    //   ConnectivityPlatform.instance = NetworkInformationApiConnectivityPlugin();
+    // } else {
+    //   ConnectivityPlatform.instance = DartHtmlConnectivityPlugin();
+    // }
 
-    if (isSupported) {
-      ConnectivityPlatform.instance = NetworkInformationApiConnectivityPlugin();
-    } else {
-      ConnectivityPlatform.instance = DartHtmlConnectivityPlugin();
-    }
+    ConnectivityPlatform.instance = DartHtmlConnectivityPlugin();
   }
 }

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/connectivity_plus
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.11.0"
+  sdk: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:
@@ -33,16 +33,16 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   connectivity_plus_platform_interface: ^1.2.4
-  js: ^0.6.3
+  js: ^0.6.5
   meta: ^1.8.0
   nm: ^0.5.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  build_runner: ^2.1.11
-  dbus: ^0.7.5
+  build_runner: ^2.3.3
+  dbus: ^0.7.8
   flutter_lints: ^2.0.1
-  mockito: ^5.2.0
-  plugin_platform_interface: ^2.1.2
-  test: ^1.21.1
+  mockito: ^5.4.0
+  plugin_platform_interface: ^2.1.4
+  test: ^1.22.0

--- a/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
@@ -5,14 +5,14 @@ homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=2.11.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.7.0
-  plugin_platform_interface: ^2.1.2
+  meta: ^1.8.0
+  plugin_platform_interface: ^2.1.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

Updating used dependencies and aligning constraint with other plugins maintained by the Flutter team (for example, here: https://github.com/flutter/packages/blob/main/packages/url_launcher/url_launcher/pubspec.yaml#L8). Not marking as a breaking change as we already have namespace marked as breaking change.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

