### PR TITLE
chore(android_intent_plus): Update Flutter dependencies, set Flutter >=3.3.0 and Dart to >=2.18.0 <4.0.0

### DIFF
--- a/packages/android_intent_plus/android/build.gradle
+++ b/packages/android_intent_plus/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.androidintent'
 

--- a/packages/android_intent_plus/example/android/app/build.gradle
+++ b/packages/android_intent_plus/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     namespace 'io.flutter.plugins.androidintentexample'
 
@@ -41,7 +41,7 @@ android {
     defaultConfig {
         applicationId "io.flutter.plugins.androidintentexample"
         minSdkVersion 16
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/android_intent_plus/example/lib/main.dart
+++ b/packages/android_intent_plus/example/lib/main.dart
@@ -21,7 +21,8 @@ class MyApp extends StatelessWidget {
     return MaterialApp(
       title: 'Flutter Demo',
       theme: ThemeData(
-        primarySwatch: Colors.blue,
+        useMaterial3: true,
+        colorSchemeSeed: const Color(0x9f4376f8),
       ),
       home: const MyHomePage(),
       routes: <String, WidgetBuilder>{
@@ -88,7 +89,8 @@ class MyHomePage extends StatelessWidget {
     }
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Plugin example app'),
+        title: const Text('Android intent plus example app'),
+        elevation: 4,
       ),
       body: Center(child: body),
     );
@@ -204,6 +206,7 @@ class ExplicitIntentsWidget extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Test explicit intents'),
+        elevation: 4,
       ),
       body: Center(
         child: SingleChildScrollView(
@@ -216,40 +219,48 @@ class ExplicitIntentsWidget extends StatelessWidget {
                 child: const Text(
                     'Tap here to display panorama\nimagery in Google Street View.'),
               ),
+              const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: _displayMapInGoogleMaps,
                 child: const Text('Tap here to display\na map in Google Maps.'),
               ),
+              const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: _launchTurnByTurnNavigationInGoogleMaps,
                 child: const Text(
                     'Tap here to launch turn-by-turn\nnavigation in Google Maps.'),
               ),
+              const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: _openLinkInGoogleChrome,
                 child: const Text('Tap here to open link in Google Chrome.'),
               ),
+              const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: _startActivityInNewTask,
                 child: const Text('Tap here to start activity in new task.'),
               ),
+              const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: _testExplicitIntentFallback,
                 child: const Text(
                     'Tap here to test explicit intent fallback to implicit.'),
               ),
+              const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: _openLocationSettingsConfiguration,
                 child: const Text(
                   'Tap here to open Location Settings Configuration',
                 ),
               ),
+              const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: _openApplicationDetails,
                 child: const Text(
                   'Tap here to open Application Details',
                 ),
               ),
+              const SizedBox(height: 16),
               ElevatedButton(
                 onPressed: _openGmail,
                 child: const Text(

--- a/packages/android_intent_plus/example/pubspec.yaml
+++ b/packages/android_intent_plus/example/pubspec.yaml
@@ -2,7 +2,7 @@ name: android_intent_example
 description: Demonstrates how to use the android_intent plugin.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -6,8 +6,8 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/android_intent_plus
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.20.0"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"
 
 flutter:
   plugin:
@@ -20,11 +20,11 @@ dependencies:
   flutter:
     sdk: flutter
   platform: ^3.1.0
-  meta: ^1.3.0
+  meta: ^1.8.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  test: ^1.16.4
-  mockito: ^5.0.0
-  flutter_lints: ">=1.0.4 <3.0.0"
+  test: ^1.12.0
+  mockito: ^5.4.0
+  flutter_lints: ^2.0.1


### PR DESCRIPTION
## Description

Updating used dependencies and aligning constraint with other plugins maintained by the Flutter team (for example, here: https://github.com/flutter/packages/blob/main/packages/url_launcher/url_launcher/pubspec.yaml#L8). Not marking as a breaking change as we already have namespace marked as breaking change.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

