### PR TITLE
chore(android_alarm_manager_plus): Update Flutter dependencies, set Flutter >=3.3.0 and Dart to >=2.18.0 <4.0.0

### DIFF
--- a/packages/android_alarm_manager_plus/example/lib/main.dart
+++ b/packages/android_alarm_manager_plus/example/lib/main.dart
@@ -1,9 +1,6 @@
 // Copyright 2017 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-// ignore_for_file: public_member_api_docs
-
 import 'dart:developer' as developer;
 import 'dart:isolate';
 import 'dart:math';
@@ -49,16 +46,19 @@ class AlarmManagerExampleApp extends StatelessWidget {
   // This widget is the root of your application.
   @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
+    return MaterialApp(
       title: 'Flutter Demo',
-      home: _AlarmHomePage(title: 'Flutter Demo Home Page'),
+      theme: ThemeData(
+        useMaterial3: true,
+        colorSchemeSeed: const Color(0x9f4376f8),
+      ),
+      home: const _AlarmHomePage(),
     );
   }
 }
 
 class _AlarmHomePage extends StatefulWidget {
-  const _AlarmHomePage({Key? key, required this.title}) : super(key: key);
-  final String title;
+  const _AlarmHomePage({Key? key}) : super(key: key);
 
   @override
   _AlarmHomePageState createState() => _AlarmHomePageState();
@@ -109,7 +109,8 @@ class _AlarmHomePageState extends State<_AlarmHomePage> {
     final textStyle = Theme.of(context).textTheme.headlineMedium;
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title),
+        title: const Text('Android alarm manager plus example'),
+        elevation: 4,
       ),
       body: Center(
         child: Column(
@@ -133,6 +134,7 @@ class _AlarmHomePageState extends State<_AlarmHomePage> {
                 ),
               ],
             ),
+            const SizedBox(height: 24),
             ElevatedButton(
               key: const ValueKey('RegisterOneShotAlarm'),
               onPressed: () async {

--- a/packages/android_alarm_manager_plus/example/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/example/pubspec.yaml
@@ -2,20 +2,18 @@ name: android_alarm_manager_example
 description: Demonstrates how to use the android_alarm_manager_plus plugin.
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  sdk: ">=2.18.0 <3.0.0"
+  flutter: ">=3.3.0"
 
 dependencies:
   flutter:
     sdk: flutter
   android_alarm_manager_plus: ^2.1.4
-  shared_preferences: ^2.0.13
-  path_provider: ^2.0.9
+  shared_preferences: ^2.1.0
+  path_provider: ^2.0.14
 
 dev_dependencies:
-  espresso: ^0.3.0
-  flutter_driver:
-    sdk: flutter
+  espresso: ^0.3.0+4
   flutter_test:
     sdk: flutter
   integration_test:

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ">=1.0.4 <3.0.0"
+  flutter_lints: ^2.0.1
 
 flutter:
   plugin:
@@ -23,5 +23,5 @@ flutter:
         pluginClass: AndroidAlarmManagerPlugin
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5"
+  sdk: ">=2.18.0 <4.0.0"
+  flutter: ">=3.3.0"


### PR DESCRIPTION
## Description

Updating used dependencies and aligning constraint with other plugins maintained by the Flutter team (for example, here: https://github.com/flutter/packages/blob/main/packages/url_launcher/url_launcher/pubspec.yaml#L8). Not marking as a breaking change as we already have namespace marked as breaking change.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

