### PR TITLE
fix(battery_plus): Close StreamController on Web and Linux when done

### DIFF
--- a/packages/battery_plus/battery_plus/lib/src/battery_plus_linux.dart
+++ b/packages/battery_plus/battery_plus/lib/src/battery_plus_linux.dart
@@ -84,6 +84,7 @@ class BatteryPlusLinuxPlugin extends BatteryPlatform {
   }
 
   void _stopListenState() {
+    _stateController?.close();
     _stateClient?.close();
     _stateClient = null;
   }

--- a/packages/battery_plus/battery_plus/lib/src/battery_plus_web.dart
+++ b/packages/battery_plus/battery_plus/lib/src/battery_plus_web.dart
@@ -75,6 +75,10 @@ class BatteryPlusWebPlugin extends BatteryPlatform {
 
       _batteryChange =
           _batteryChangeStreamController!.stream.asBroadcastStream();
+
+      _batteryChangeStreamController?.onCancel = () {
+        _batteryChangeStreamController?.close();
+      };
     }
     return _batteryChange;
   }


### PR DESCRIPTION
## Description

Addressing the issue reported in `Score` section on pub.dev https://pub.dev/packages/battery_plus/score about Sink not being closed on Web and Linux.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

