### PR TITLE
chore(device_info_plus): Remove redundant checks for PRODUCT strings with sdk

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
@@ -107,7 +107,7 @@ internal class MethodCallHandlerImpl(
      * detection systems
      */
     private val isEmulator: Boolean
-        get() = (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic")
+        get() = ((Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
             || Build.FINGERPRINT.startsWith("generic")
             || Build.FINGERPRINT.startsWith("unknown")
             || Build.HARDWARE.contains("goldfish")
@@ -116,10 +116,7 @@ internal class MethodCallHandlerImpl(
             || Build.MODEL.contains("Emulator")
             || Build.MODEL.contains("Android SDK built for x86")
             || Build.MANUFACTURER.contains("Genymotion")
-            || Build.PRODUCT.contains("sdk_google")
-            || Build.PRODUCT.contains("google_sdk")
             || Build.PRODUCT.contains("sdk")
-            || Build.PRODUCT.contains("sdk_x86")
             || Build.PRODUCT.contains("vbox86p")
             || Build.PRODUCT.contains("emulator")
             || Build.PRODUCT.contains("simulator"))


### PR DESCRIPTION
There's already a check for PRODUCT contains "sdk", so there's no need to test various combinations of this. Perhaps it's also worth using case-insensitive tests and, for example, simply checking if MODEL then contains "sdk"?

## Description

There's already a check for PRODUCT contains "sdk", so there's no need to test various combinations of this. Also, added parenthesis around the initial conjunction for better readability (in terms of precedence).
Perhaps it's also worth using case-insensitive tests and, for example, simply checking if MODEL then contains "sdk"?

This is a bit of a micro-optimization, but I've noticed this code is [referenced on Stack Overflow, etc.,](https://stackoverflow.com/a/55355049/2872279) and this could potentially be simplified further. It should also stop additional checks being erroneously added.

## Checklist

- [X] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.

