### PR TITLE
refactor(package_info_plus): Tidy up Windows implementation

### DIFF
--- a/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_web_test.dart
+++ b/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_web_test.dart
@@ -1,3 +1,6 @@
+@TestOn('browser')
+library package_info_plus_web_test;
+
 import 'dart:convert';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
@@ -57,8 +57,8 @@ class FileVersionInfo {
       [GetUserDefaultLangID(), 1252],
     ];
 
-    final Pointer<IntPtr> lplpBuffer = calloc<IntPtr>();
-    final Pointer<Uint32> puLen = calloc<Uint32>();
+    final lplpBuffer = calloc<LPWSTR>();
+    final puLen = calloc<UINT>();
     String toHex4(int val) => val.toRadixString(16).padLeft(4, '0');
 
     try {
@@ -70,9 +70,8 @@ class FileVersionInfo {
             VerQueryValue(_data.lpBlock, lpSubBlock, lplpBuffer.cast(), puLen);
         free(lpSubBlock);
 
-        if (res != 0 && lplpBuffer.value != 0 && puLen.value > 0) {
-          final ptr = Pointer<Utf16>.fromAddress(lplpBuffer.value);
-          return ptr.toDartString();
+        if (res != 0 && lplpBuffer.address != 0 && puLen.value > 0) {
+          return lplpBuffer.value.toDartString();
         }
       }
 

--- a/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
@@ -22,7 +22,7 @@ class LANGANDCODEPAGE extends Struct {
 
 class FileVersionInfoData {
   const FileVersionInfoData({required this.lpBlock, required this.lpLang});
-  final Pointer<Uint8> lpBlock;
+  final Pointer<BYTE> lpBlock;
   final Pointer<LANGANDCODEPAGE> lpLang;
 }
 
@@ -34,18 +34,18 @@ class FileVersionInfo {
 
   void dispose() => free(_data.lpBlock);
 
-  String? get companyName => getValue('CompanyName');
-  String? get companyShortName => getValue('CompanyShortName');
-  String? get productName => getValue('ProductName');
-  String? get productShortName => getValue('ProductShortName');
-  String? get internalName => getValue('InternalName');
-  String? get productVersion => getValue('ProductVersion');
-  String? get specialBuild => getValue('SpecialBuild');
-  String? get originalFilename => getValue('OriginalFilename');
-  String? get fileDescription => getValue('FileDescription');
-  String? get fileVersion => getValue('FileVersion');
+  String get companyName => getValue('CompanyName');
+  String get companyShortName => getValue('CompanyShortName');
+  String get productName => getValue('ProductName');
+  String get productShortName => getValue('ProductShortName');
+  String get internalName => getValue('InternalName');
+  String get productVersion => getValue('ProductVersion');
+  String get specialBuild => getValue('SpecialBuild');
+  String get originalFilename => getValue('OriginalFilename');
+  String get fileDescription => getValue('FileDescription');
+  String get fileVersion => getValue('FileVersion');
 
-  String? getValue(String name) {
+  String getValue(String name) {
     final langCodepages = [
       // try the language and codepage from the EXE
       [_data.lpLang.ref.wLanguage, _data.lpLang.ref.wCodePage],
@@ -57,30 +57,30 @@ class FileVersionInfo {
       [GetUserDefaultLangID(), 1252],
     ];
 
-    String? value;
     final Pointer<IntPtr> lplpBuffer = calloc<IntPtr>();
     final Pointer<Uint32> puLen = calloc<Uint32>();
-
     String toHex4(int val) => val.toRadixString(16).padLeft(4, '0');
 
-    for (final langCodepage in langCodepages) {
-      final lang = toHex4(langCodepage[0]);
-      final codepage = toHex4(langCodepage[1]);
-      final lpSubBlock = TEXT('\\StringFileInfo\\$lang$codepage\\$name');
-      final res =
-          VerQueryValue(_data.lpBlock, lpSubBlock, lplpBuffer.cast(), puLen);
-      free(lpSubBlock);
+    try {
+      for (final langCodepage in langCodepages) {
+        final lang = toHex4(langCodepage[0]);
+        final codepage = toHex4(langCodepage[1]);
+        final lpSubBlock = TEXT('\\StringFileInfo\\$lang$codepage\\$name');
+        final res =
+            VerQueryValue(_data.lpBlock, lpSubBlock, lplpBuffer.cast(), puLen);
+        free(lpSubBlock);
 
-      if (res != 0 && lplpBuffer.value != 0 && puLen.value > 0) {
-        final ptr = Pointer<Utf16>.fromAddress(lplpBuffer.value);
-        value = ptr.toDartString();
-        break;
+        if (res != 0 && lplpBuffer.value != 0 && puLen.value > 0) {
+          final ptr = Pointer<Utf16>.fromAddress(lplpBuffer.value);
+          return ptr.toDartString();
+        }
       }
-    }
 
-    calloc.free(lplpBuffer);
-    calloc.free(puLen);
-    return value;
+      return '';
+    } finally {
+      free(lplpBuffer);
+      free(puLen);
+    }
   }
 
   static FileVersionInfoData getData(String filePath) {

--- a/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
@@ -7,6 +7,7 @@
 // - github.com/timsneath/win32/example/filever.dart
 
 import 'dart:ffi';
+import 'dart:io';
 
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
@@ -83,6 +84,10 @@ class FileVersionInfo {
   }
 
   static FileVersionInfoData getData(String filePath) {
+    if (!File(filePath).existsSync()) {
+      throw ArgumentError.value(filePath, 'filePath', 'File not present');
+    }
+
     final lptstrFilename = TEXT(filePath);
     final dwLen = GetFileVersionInfoSize(lptstrFilename, nullptr);
 

--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_windows.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_windows.dart
@@ -13,7 +13,7 @@ part 'file_version_info.dart';
 
 /// The Windows implementation of [PackageInfoPlatform].
 class PackageInfoPlusWindowsPlugin extends PackageInfoPlatform {
-  /// Register this dart class as the platform implementation for linux
+  /// Register this dart class as the platform implementation for Windows
   static void registerWith() {
     PackageInfoPlatform.instance = PackageInfoPlusWindowsPlugin();
   }

--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_windows.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_windows.dart
@@ -20,10 +20,10 @@ class PackageInfoPlusWindowsPlugin extends PackageInfoPlatform {
   @override
   Future<PackageInfoData> getAll() {
     final info = FileVersionInfo(Platform.resolvedExecutable);
-    final versions = info.productVersion!.split('+');
+    final versions = info.productVersion.split('+');
     final data = PackageInfoData(
-      appName: info.productName ?? '',
-      packageName: info.internalName ?? '',
+      appName: info.productName,
+      packageName: info.internalName,
       version: versions.getOrNull(0) ?? '',
       buildNumber: versions.getOrNull(1) ?? '',
       buildSignature: '',

--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_windows.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_windows.dart
@@ -1,15 +1,12 @@
 /// The Windows implementation of `package_info_plus`.
 library package_info_plus_windows;
 
-import 'dart:ffi';
 import 'dart:io';
 
-import 'package:ffi/ffi.dart';
 import 'package:package_info_plus_platform_interface/package_info_data.dart';
 import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
-import 'package:win32/win32.dart';
 
-part 'file_version_info.dart';
+import 'file_version_info.dart';
 
 /// The Windows implementation of [PackageInfoPlatform].
 class PackageInfoPlusWindowsPlugin extends PackageInfoPlatform {
@@ -22,7 +19,7 @@ class PackageInfoPlusWindowsPlugin extends PackageInfoPlatform {
   /// appName, packageName, version, buildNumber
   @override
   Future<PackageInfoData> getAll() {
-    final info = _FileVersionInfo(Platform.resolvedExecutable);
+    final info = FileVersionInfo(Platform.resolvedExecutable);
     final versions = info.productVersion!.split('+');
     final data = PackageInfoData(
       appName: info.productName ?? '',

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.3.0
   path: ^1.8.0
   package_info_plus_platform_interface: ^2.0.1
-  win32: ">=2.7.0 <5.0.0"
+  win32: ^4.0.0
 
 dev_dependencies:
   flutter_lints: ^2.0.1
@@ -42,5 +42,5 @@ dev_dependencies:
   test: ^1.21.1
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.16.0 <3.0.0"
   flutter: ">=2.11.0"

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -39,7 +39,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  test: ^1.24.1
+  test: ^1.24.0
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -39,7 +39,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  test: ^1.21.1
+  test: ^1.24.2
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -39,7 +39,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  test: ^1.24.2
+  test: ^1.24.1
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -39,7 +39,7 @@ dev_dependencies:
   flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
-  test: ^1.24.0
+  test: ^1.21.1
 
 environment:
   sdk: ">=2.16.0 <3.0.0"

--- a/packages/package_info_plus/package_info_plus/test/package_info_plus_linux_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_plus_linux_test.dart
@@ -1,3 +1,6 @@
+@TestOn('linux')
+library package_info_plus_linux_test;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';

--- a/packages/package_info_plus/package_info_plus/test/package_info_plus_windows_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_plus_windows_test.dart
@@ -14,7 +14,7 @@ void main() {
     expect(PackageInfoPlatform.instance, isA<PackageInfoPlusWindowsPlugin>());
   });
 
-  test('File version info works for standard Windows DLL', () {
+  test('File version info for standard Windows DLL', () {
     final windir = Platform.environment['WINDIR']!; // normally C:\Windows
 
     // Every valid Windows release should have this file
@@ -29,5 +29,17 @@ void main() {
     // For example, "Windows NT BASE API Client DLL" (in Windows 10)
     expect(kernelVersion.fileDescription, contains('Windows'));
     kernelVersion.dispose();
+  });
+
+  test('File version info for missing file', () {
+    const missingFile = 'C:\\macos\\system128\\colonel.dll';
+
+    expect(
+        () => FileVersionInfo(missingFile),
+        throwsA(isArgumentError.having(
+          (e) => e.message,
+          'message',
+          startsWith('File not present'),
+        )));
   });
 }

--- a/packages/package_info_plus/package_info_plus/test/package_info_plus_windows_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_plus_windows_test.dart
@@ -1,4 +1,8 @@
+@TestOn('windows')
+library package_info_plus_windows_test;
+
 import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/src/file_version_info.dart';
 import 'package:package_info_plus/src/package_info_plus_windows.dart';
 import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
 
@@ -6,5 +10,13 @@ void main() {
   test('registered instance', () {
     PackageInfoPlusWindowsPlugin.registerWith();
     expect(PackageInfoPlatform.instance, isA<PackageInfoPlusWindowsPlugin>());
+  });
+
+  test('File version info works for standard Windows DLL', () {
+    // Every valid Windows release should have this file
+    final kernelVersion = FileVersionInfo('%WINDIR%\\System32\\kernel32.dll');
+    expect(kernelVersion.productName?.indexOf('Windows'), greaterThan(-1));
+    expect(kernelVersion.productVersion, isNotNull);
+    kernelVersion.dispose();
   });
 }

--- a/packages/package_info_plus/package_info_plus/test/package_info_plus_windows_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_plus_windows_test.dart
@@ -1,6 +1,8 @@
 @TestOn('windows')
 library package_info_plus_windows_test;
 
+import 'dart:io' show Platform;
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/src/file_version_info.dart';
 import 'package:package_info_plus/src/package_info_plus_windows.dart';
@@ -13,10 +15,19 @@ void main() {
   });
 
   test('File version info works for standard Windows DLL', () {
+    final windir = Platform.environment['WINDIR']!; // normally C:\Windows
+
     // Every valid Windows release should have this file
-    final kernelVersion = FileVersionInfo('%WINDIR%\\System32\\kernel32.dll');
-    expect(kernelVersion.productName?.indexOf('Windows'), greaterThan(-1));
+    final kernelVersion = FileVersionInfo('$windir\\System32\\kernel32.dll');
+
+    // For example, "Microsoft® Windows® Operating System"
+    expect(kernelVersion.productName, contains('Windows'));
+
+    // For example, "10.0.19041.2788"
     expect(kernelVersion.productVersion, isNotNull);
+
+    // For example, "Windows NT BASE API Client DLL" (in Windows 10)
+    expect(kernelVersion.fileDescription, contains('Windows'));
     kernelVersion.dispose();
   });
 }


### PR DESCRIPTION
## Description

- Use Win32 `GetUserDefaultLangID` rather than redefining
- Use Win32 `typedef`s for Windows types
- Remove unnecessary nullability in `_FileVersionInfoData`
- Reduced wide dependency on Win32
- Upgraded minimum Dart version to match language features already used
- Add some tests

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.*

*e.g.*
- *Fix #123*
- *Related #456*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.

