### PR TITLE
chore(share_plus)!: Bump min Android and iOS versions, update podspec file

### DIFF
--- a/packages/share_plus/share_plus/android/build.gradle
+++ b/packages/share_plus/share_plus/android/build.gradle
@@ -30,7 +30,7 @@ android {
     namespace 'dev.fluttercommunity.plus.share'
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/share_plus/share_plus/example/android/app/build.gradle
+++ b/packages/share_plus/share_plus/example/android/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.shareexample"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 31
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/share_plus/share_plus/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/share_plus/share_plus/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -206,6 +206,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -238,6 +239,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/packages/share_plus/share_plus/example/ios/Runner/Info.plist
+++ b/packages/share_plus/share_plus/example/ios/Runner/Info.plist
@@ -53,5 +53,7 @@
 	<string>This app requires access to the camera for sharing images.</string>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -24,4 +24,4 @@ flutter:
     - assets/flutter_logo.png
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: '>=2.18.0 <4.0.0'

--- a/packages/share_plus/share_plus/ios/share_plus.podspec
+++ b/packages/share_plus/share_plus/ios/share_plus.podspec
@@ -11,7 +11,7 @@ Downloaded by pub (not CocoaPods).
                        DESC
   s.homepage         = 'https://github.com/fluttercommunity/plus_plugins'
   s.license          = { :type => 'BSD', :file => '../LICENSE' }
-  s.author           = { 'Flutter Community' => 'us@fluttercommunity.dev' }
+  s.author           = { 'Flutter Community' => 'community@flutter.zone' }
   s.source           = { :http => 'https://github.com/fluttercommunity/plus_plugins/tree/main/packages/share_plus/share_plus' }
   s.documentation_url = 'https://pub.dev/packages/share_plus'
   s.source_files = 'Classes/**/*'

--- a/packages/share_plus/share_plus/ios/share_plus.podspec
+++ b/packages/share_plus/share_plus/ios/share_plus.podspec
@@ -9,11 +9,11 @@ Pod::Spec.new do |s|
 A Flutter plugin to share content from your Flutter app via the platform's share dialog.
 Downloaded by pub (not CocoaPods).
                        DESC
-  s.homepage         = 'https://github.com/flutter/plugins'
+  s.homepage         = 'https://github.com/fluttercommunity/plus_plugins'
   s.license          = { :type => 'BSD', :file => '../LICENSE' }
-  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
-  s.source           = { :http => 'https://github.com/flutter/plugins/tree/main/packages/share' }
-  s.documentation_url = 'https://pub.dev/packages/share'
+  s.author           = { 'Flutter Community' => 'us@fluttercommunity.dev' }
+  s.source           = { :http => 'https://github.com/fluttercommunity/plus_plugins/tree/main/packages/share_plus/share_plus' }
+  s.documentation_url = 'https://pub.dev/packages/share_plus'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'

--- a/packages/share_plus/share_plus/ios/share_plus.podspec
+++ b/packages/share_plus/share_plus/ios/share_plus.podspec
@@ -19,7 +19,7 @@ Downloaded by pub (not CocoaPods).
   s.dependency 'Flutter'
   s.ios.weak_framework = 'LinkPresentation'
 
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '11.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end
 


### PR DESCRIPTION
## Description

Aligning minimally supported platforms with Flutter supported platforms: https://docs.flutter.dev/reference/supported-platforms.

Additionally saw that podspec file still had old info about maintainers, docs url, etc., so fixed it.

## Related Issues

#1665 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

