### PR TITLE
chore(network_info_plus)!: Bump min Android and iOS versions, update podspec file

### DIFF
--- a/packages/network_info_plus/network_info_plus/android/build.gradle
+++ b/packages/network_info_plus/network_info_plus/android/build.gradle
@@ -35,7 +35,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/packages/network_info_plus/network_info_plus/example/android/app/build.gradle
+++ b/packages/network_info_plus/network_info_plus/example/android/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
     defaultConfig {
         applicationId "dev.fluttercommunity.plus.network_info_plus_example"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/network_info_plus/network_info_plus/ios/network_info_plus.podspec
+++ b/packages/network_info_plus/network_info_plus/ios/network_info_plus.podspec
@@ -11,12 +11,12 @@ Downloaded by pub (not CocoaPods).
                        DESC
   s.homepage         = 'https://github.com/fluttercommunity/plus_plugins'
   s.license          = { :type => 'BSD', :file => '../LICENSE' }
-  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.author           = { 'Flutter Community' => 'community@flutter.zone' }
   s.source           = { :http => 'https://github.com/fluttercommunity/plus_plugins/tree/main/packages/network_info_plus' }
   s.documentation_url = 'https://pub.dev/packages/network_info_plus'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '11.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end


### PR DESCRIPTION
## Description

Aligning minimally supported platforms with Flutter supported platforms: https://docs.flutter.dev/reference/supported-platforms.

Additionally saw that podspec file still had old info about maintainers, so fixed it.

## Related Issues

#1665

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

