### PR TITLE
feat(share_plus): Allow user to share URI with preview image on the iOS native share sheet

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
@@ -18,6 +18,17 @@ internal class MethodCallHandler(
         val isWithResult = isResultRequested && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
 
         when (call.method) {
+            "shareUri" -> {
+                expectMapArguments(call)
+                share.share(
+                    call.argument<Any>("uri") as String,
+                    subject = null,
+                    withResult= false
+                )
+                if (!isWithResult) {
+                    result.success(null)
+                }
+            }
             "share", "shareWithResult" -> {
                 expectMapArguments(call)
                 if (isWithResult && !manager.setCallback(result)) return

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -31,6 +31,7 @@ class DemoApp extends StatefulWidget {
 class DemoAppState extends State<DemoApp> {
   String text = '';
   String subject = '';
+  String uri = '';
   List<String> imageNames = [];
   List<String> imagePaths = [];
 
@@ -74,6 +75,18 @@ class DemoAppState extends State<DemoApp> {
                 maxLines: null,
                 onChanged: (String value) => setState(() {
                   subject = value;
+                }),
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Share uri',
+                  hintText: 'Enter the uri you want to share',
+                ),
+                maxLines: null,
+                onChanged: (String value) => setState(() {
+                  uri = value;
                 }),
               ),
               const SizedBox(height: 16),
@@ -122,7 +135,7 @@ class DemoAppState extends State<DemoApp> {
                       foregroundColor: Theme.of(context).colorScheme.onPrimary,
                       backgroundColor: Theme.of(context).colorScheme.primary,
                     ),
-                    onPressed: text.isEmpty && imagePaths.isEmpty
+                    onPressed: text.isEmpty && imagePaths.isEmpty && uri.isEmpty
                         ? null
                         : () => _onShare(context),
                     child: const Text('Share'),
@@ -183,7 +196,9 @@ class DemoAppState extends State<DemoApp> {
     // has its position and size after it's built.
     final box = context.findRenderObject() as RenderBox?;
 
-    if (imagePaths.isNotEmpty) {
+    if (uri.isNotEmpty) {
+      await Share.shareUri(Uri.parse(uri));
+    } else if (imagePaths.isNotEmpty) {
       final files = <XFile>[];
       for (var i = 0; i < imagePaths.length; i++) {
         files.add(XFile(imagePaths[i], name: imageNames[i]));

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -85,9 +85,9 @@ class DemoAppState extends State<DemoApp> {
                   hintText: 'Enter the uri you want to share',
                 ),
                 maxLines: null,
-                onChanged: (String value) => setState(() {
-                  uri = value;
-                }),
+                onChanged: (String value) {
+                  setState(() => uri = value);
+                },
               ),
               const SizedBox(height: 16),
               ImagePreviews(imagePaths, onDelete: _onDeleteImage),

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -334,11 +334,7 @@ TopViewControllerForViewController(UIViewController *viewController) {
           if (!withResult)
             result(nil);
         } else if ([@"shareUri" isEqualToString:call.method]) {
-          // log share uri
-          NSLog(@"ShareUri  abcccc");
-
           NSString *uri = arguments[@"uri"];
-
 
           if (uri.length == 0) {
             result([FlutterError errorWithCode:@"error"

--- a/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FLTSharePlusPlugin.m
@@ -1,7 +1,6 @@
 // Copyright 2019 The Flutter Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
 #import "FLTSharePlusPlugin.h"
 #import "LinkPresentation/LPLinkMetadata.h"
 #import "LinkPresentation/LPMetadataProvider.h"
@@ -334,6 +333,35 @@ TopViewControllerForViewController(UIViewController *viewController) {
                   withResult:withResult];
           if (!withResult)
             result(nil);
+        } else if ([@"shareUri" isEqualToString:call.method]) {
+          // log share uri
+          NSLog(@"ShareUri  abcccc");
+
+          NSString *uri = arguments[@"uri"];
+
+
+          if (uri.length == 0) {
+            result([FlutterError errorWithCode:@"error"
+                                       message:@"Non-empty uri expected"
+                                       details:nil]);
+            return;
+          }
+
+          UIViewController *rootViewController = RootViewController();
+          if (!rootViewController) {
+            result([FlutterError errorWithCode:@"error"
+                                       message:@"No root view controller found"
+                                       details:nil]);
+            return;
+          }
+          UIViewController *topViewController =
+              TopViewControllerForViewController(rootViewController);
+
+          [self shareUri:uri
+              withController:topViewController
+                    atSource:originRect
+                    toResult:result
+                  withResult:withResult];
         } else {
           result(FlutterMethodNotImplemented);
         }
@@ -396,6 +424,20 @@ TopViewControllerForViewController(UIViewController *viewController) {
   [controller presentViewController:activityViewController
                            animated:YES
                          completion:nil];
+}
+
++ (void)shareUri:(NSString *)uri
+    withController:(UIViewController *)controller
+          atSource:(CGRect)origin
+          toResult:(FlutterResult)result
+        withResult:(BOOL)withResult {
+  NSURL *data = [NSURL URLWithString:uri];
+  [self share:@[ data ]
+         withSubject:nil
+      withController:controller
+            atSource:origin
+            toResult:result
+          withResult:withResult];
 }
 
 + (void)shareText:(NSString *)shareText

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -18,6 +18,22 @@ export 'src/share_plus_windows.dart'
 class Share {
   static SharePlatform get _platform => SharePlatform.instance;
 
+  /// Summons the platform's share sheet to share uri.
+  ///
+  /// Wraps the platform's native share dialog. Can share a URL.
+  /// It uses the `ACTION_SEND` Intent on Android and `UIActivityViewController`
+  /// on iOS. [shareUri] will trigger the iOS system to fetch the html page
+  /// (if available), and the website icon will be extracted and displayed on
+  /// the iOS share sheet.
+  static Future<void> shareUri(
+      Uri uri,
+  ) async {
+    return _platform.shareUri(
+      uri
+    );
+  }
+
+
   /// Summons the platform's share sheet to share text.
   ///
   /// Wraps the platform's native share dialog. Can share a text and/or a URL.

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -26,13 +26,10 @@ class Share {
   /// (if available), and the website icon will be extracted and displayed on
   /// the iOS share sheet.
   static Future<void> shareUri(
-      Uri uri,
+    Uri uri,
   ) async {
-    return _platform.shareUri(
-      uri
-    );
+    return _platform.shareUri(uri);
   }
-
 
   /// Summons the platform's share sheet to share text.
   ///

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -24,12 +24,8 @@ class MethodChannelShare extends SharePlatform {
       MethodChannel('dev.fluttercommunity.plus/share');
 
   @override
-  Future<void> shareUri(
-      Uri uri
-  ) {
-    final params = <String, dynamic> {
-      'uri': uri.toString()
-    };
+  Future<void> shareUri(Uri uri) {
+    final params = <String, dynamic>{'uri': uri.toString()};
     return channel.invokeMethod<void>('shareUri', params);
   }
 

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -23,6 +23,16 @@ class MethodChannelShare extends SharePlatform {
   static const MethodChannel channel =
       MethodChannel('dev.fluttercommunity.plus/share');
 
+  @override
+  Future<void> shareUri(
+      Uri uri
+  ) {
+    final params = <String, dynamic> {
+      'uri': uri.toString()
+    };
+    return channel.invokeMethod<void>('shareUri', params);
+  }
+
   /// Summons the platform's share sheet to share text.
   @override
   Future<void> share(

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -31,9 +31,7 @@ class SharePlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<void> shareUri(Uri uri) {
-    return _instance.shareUri(uri);
-  }
+  Future<void> shareUri(Uri uri) => _instance.shareUri(uri);
 
   /// Share text.
   Future<void> share(

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -31,6 +31,15 @@ class SharePlatform extends PlatformInterface {
     _instance = instance;
   }
 
+
+  Future<void> shareUri(
+      Uri uri
+  ) {
+    return _instance.shareUri(
+        uri
+    );
+  }
+
   /// Share text.
   Future<void> share(
     String text, {

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -31,13 +31,8 @@ class SharePlatform extends PlatformInterface {
     _instance = instance;
   }
 
-
-  Future<void> shareUri(
-      Uri uri
-  ) {
-    return _instance.shareUri(
-        uri
-    );
+  Future<void> shareUri(Uri uri) {
+    return _instance.shareUri(uri);
   }
 
   /// Share text.


### PR DESCRIPTION
## Description

Allow user to share URI with preview image on the iOS native share sheet. The image is fetched from the iOS native side rather than on the flutter side.

![Simulator Screen Shot - iPhone 14 Pro - 2023-05-05 at 11 47 32](https://user-images.githubusercontent.com/10171977/236373927-306d3de5-88cc-4f2d-a33a-48ce20e75bda.png)


## Related Issues
None

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

