### PR TITLE
chore(connectivity_plus)!: Bump min Android and iOS versions, update podspec file

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/android/build.gradle
@@ -32,7 +32,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 16
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
@@ -40,7 +40,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.connectivityexample"
-        minSdkVersion 16
+        minSdkVersion 19
         targetSdkVersion 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus.podspec
+++ b/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus.podspec
@@ -12,13 +12,13 @@ Downloaded by pub (not CocoaPods).
   s.homepage         = 'https://plus.fluttercommunity.dev/'
   s.license          = { :type => 'BSD', :file => '../LICENSE' }
   s.author           = { 'Flutter Community Team' => 'authors@fluttercommunity.dev' }
-  s.source           = { :http => 'https://github.com/fluttercommunity/plus_plugins' }
+  s.source           = { :http => 'https://github.com/fluttercommunity/plus_plugins/tree/main/packages/connectivity_plus' }
   s.documentation_url = 'https://pub.dev/packages/connectivity_plus'
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'ReachabilitySwift'
-  s.platform = :ios, '9.0'
+  s.platform = :ios, '11.0'
   s.swift_version = '5.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
 end


### PR DESCRIPTION
## Description

Aligning minimally supported platforms with Flutter supported platforms: https://docs.flutter.dev/reference/supported-platforms.

Additionally saw that podspec file still had old info about maintainers, docs url, etc., so fixed it.

## Related Issues

#1665

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

