### PR TITLE
ci(all): Bootstrap for integration tests, update runners

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -18,8 +18,8 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*android_alarm_manager_example*"
 
 jobs:
-  android:
-    runs-on: macos-latest
+  android_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -39,7 +39,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       matrix:
@@ -60,7 +60,7 @@ jobs:
           java-version: "11"
 
       - name: "Bootstrap Workspace"
-        run: melos bootstrap
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -18,8 +18,8 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*android_intent_example*"
 
 jobs:
-  android_build:
-    runs-on: macos-latest
+  android_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -39,7 +39,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       matrix:
@@ -60,7 +60,7 @@ jobs:
           java-version: "11"
 
       - name: "Bootstrap Workspace"
-        run: melos bootstrap
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
 
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -22,8 +22,8 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*battery_plus_example*"
 
 jobs:
-  android:
-    runs-on: macos-latest
+  android_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -43,7 +43,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       matrix:
@@ -64,7 +64,7 @@ jobs:
           java-version: "11"
 
       - name: "Bootstrap Workspace"
-        run: melos bootstrap
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -76,8 +76,8 @@ jobs:
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android battery_plus_example
 
-  ios:
-    runs-on: macos-latest
+  ios_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -90,7 +90,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh ios ./lib/main.dart
 
   ios_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -99,15 +99,17 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v2
         with:
-          model: "iPhone 8"
+          model: "iPhone 14"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios battery_plus_example
 
-  macos:
-    runs-on: macos-latest
+  macos_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -121,22 +123,21 @@ jobs:
 
   macos_integration_test:
     if: false # Disabled as battery_plus APIs don't complete in github actions macos VMs.
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
-      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.3.10'
+        run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh macos battery_plus_example
 
-  linux:
+  linux_example_build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -163,10 +164,12 @@ jobs:
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Install UPower"
         run: sudo apt install upower
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh linux battery_plus_example
 
-  windows:
+  windows_example_build:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -189,10 +192,12 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh windows battery_plus_example
 
-  web:
+  web_example_build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -193,7 +193,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
-        run: melos bootstrap --scope="$PLUGIN_SCOPE"
+        run: melos.bat bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh windows battery_plus_example
 

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -22,8 +22,8 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*connectivity_plus_example*"
 
 jobs:
-  android:
-    runs-on: macos-latest
+  android_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -43,7 +43,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       matrix:
@@ -64,7 +64,7 @@ jobs:
           java-version: "11"
 
       - name: "Bootstrap Workspace"
-        run: melos bootstrap
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -76,8 +76,8 @@ jobs:
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android connectivity_plus_example
 
-  ios:
-    runs-on: macos-latest
+  ios_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -99,15 +99,17 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v2
         with:
-          model: 'iPhone 8'
+          model: 'iPhone 14'
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios connectivity_plus_example
 
-  macos:
-    runs-on: macos-latest
+  macos_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -120,22 +122,21 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
   macos_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
-      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.3.10'
+        run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh macos connectivity_plus_example
 
-  linux:
+  linux_example_build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -158,12 +159,14 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Install NetworkManager"
         run: sudo apt-get update && sudo apt-get install -y network-manager
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh linux connectivity_plus_example
 
-  windows:
+  windows_example_build:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -186,10 +189,12 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh windows connectivity_plus_example
 
-  web:
+  web_example_build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -190,7 +190,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
-        run: melos bootstrap --scope="$PLUGIN_SCOPE"
+        run: melos.bat bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh windows connectivity_plus_example
 

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -22,8 +22,8 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*device_info_plus_example*"
 
 jobs:
-  android_build:
-    runs-on: macos-latest
+  android_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -43,7 +43,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       matrix:
@@ -64,7 +64,7 @@ jobs:
           java-version: "11"
 
       - name: "Bootstrap Workspace"
-        run: melos bootstrap
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -76,8 +76,8 @@ jobs:
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android device_info_plus_example
 
-  ios:
-    runs-on: macos-latest
+  ios_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -90,7 +90,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh ios ./lib/main.dart
 
   ios_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -99,6 +99,8 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v2
         with:
@@ -106,7 +108,7 @@ jobs:
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios device_info_plus_example
 
-  macos:
+  macos_example_build:
     runs-on: macos-latest
     timeout-minutes: 30
     steps:
@@ -119,24 +121,22 @@ jobs:
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
-
   macos_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
-      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.3.10'
+        run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh macos device_info_plus_example
 
-  linux:
+  linux_example_build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -159,10 +159,12 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh linux device_info_plus_example
 
-  windows:
+  windows_example_build:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -185,10 +187,12 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh windows device_info_plus_example
 
-  web:
+  web_example_build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -188,7 +188,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
-        run: melos bootstrap --scope="$PLUGIN_SCOPE"
+        run: melos.bat bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh windows device_info_plus_example
 

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -104,7 +104,7 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v2
         with:
-          model: 'iPhone 8'
+          model: 'iPhone 14'
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios device_info_plus_example
 

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -22,8 +22,8 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*network_info_plus_example*"
 
 jobs:
-  android_build:
-    runs-on: macos-latest
+  android_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -43,7 +43,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       matrix:
@@ -64,7 +64,7 @@ jobs:
           java-version: "11"
 
       - name: "Bootstrap Workspace"
-        run: melos bootstrap
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
 
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
@@ -77,8 +77,8 @@ jobs:
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android network_info_plus_example
 
-  ios:
-    runs-on: macos-latest
+  ios_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -91,7 +91,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh ios ./lib/main.dart
 
   ios_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -103,12 +103,12 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v2
         with:
-          model: 'iPhone 8'
+          model: 'iPhone 14'
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios network_info_plus_example
 
-  macos:
-    runs-on: macos-latest
+  macos_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -121,22 +121,21 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
   macos_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
-      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.3.10'
+        run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh macos network_info_plus_example
 
-  linux:
+  linux_example_build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -159,10 +158,12 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh linux network_info_plus_example
 
-  windows:
+  windows_example_build:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -186,10 +187,12 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh windows network_info_plus_example
 
-  web:
+  web_example_build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -188,7 +188,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
-        run: melos bootstrap --scope="$PLUGIN_SCOPE"
+        run: melos.bat bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh windows network_info_plus_example
 

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -22,8 +22,8 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*package_info_plus_example*"
 
 jobs:
-  android_build:
-    runs-on: macos-latest
+  android_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -43,7 +43,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       matrix:
@@ -64,7 +64,7 @@ jobs:
           java-version: "11"
 
       - name: "Bootstrap Workspace"
-        run: melos bootstrap
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -76,8 +76,8 @@ jobs:
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android package_info_plus_example
 
-  ios:
-    runs-on: macos-latest
+  ios_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -90,7 +90,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh ios ./lib/main.dart
 
   ios_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -99,15 +99,17 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v2
         with:
-          model: 'iPhone 8'
+          model: 'iPhone 14'
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios package_info_plus_example
 
-  macos:
-    runs-on: macos-latest
+  macos_example_build:
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -120,22 +122,21 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
   macos_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
-      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.3.10'
+        run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh macos package_info_plus_example
 
-  linux:
+  linux_example_build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -158,10 +159,12 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh linux package_info_plus_example
 
-  windows:
+  windows_example_build:
     runs-on: windows-latest
     timeout-minutes: 30
     steps:
@@ -184,10 +187,12 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh windows package_info_plus_example
 
-  web:
+  web_example_build:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -210,5 +215,7 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh web package_info_plus_example

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -188,7 +188,7 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
-        run: melos bootstrap --scope="$PLUGIN_SCOPE"
+        run: melos.bat bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh windows package_info_plus_example
 

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   android_build:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -39,7 +39,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       matrix:
@@ -60,7 +60,8 @@ jobs:
           java-version: "11"
 
       - name: "Bootstrap Workspace"
-        run: melos bootstrap
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
+
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -73,7 +74,7 @@ jobs:
           script: ./.github/workflows/scripts/integration-test.sh android sensors_plus_example
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -86,7 +87,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh ios ./lib/main.dart
 
   ios_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -98,7 +99,9 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v2
         with:
-          model: 'iPhone 8'
+          model: 'iPhone 14'
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios sensors_plus_example
 

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -103,7 +103,7 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v2
         with:
-          model: 'iPhone 8'
+          model: 'iPhone 14'
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios share_plus_example
 

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   android_build:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -43,7 +43,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       matrix:
@@ -64,7 +64,8 @@ jobs:
           java-version: "11"
 
       - name: "Bootstrap Workspace"
-        run: melos bootstrap
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
+
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:
@@ -77,7 +78,7 @@ jobs:
           script: ./.github/workflows/scripts/integration-test.sh android share_plus_example
 
   ios:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -90,7 +91,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh ios ./lib/main.dart
 
   ios_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -107,7 +108,7 @@ jobs:
         run: ./.github/workflows/scripts/integration-test.sh ios share_plus_example
 
   macos:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -120,18 +121,17 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
   macos_integration_test:
-    runs-on: macos-latest
+    runs-on: macos-13
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v3
-      # Use till https://github.com/flutter/flutter/issues/118469 is resolved
       - name: "Install Flutter"
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.3.10'
+        run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh macos share_plus_example
 
@@ -159,6 +159,8 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh linux share_plus_example
 
@@ -185,6 +187,8 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos.bat bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh windows share_plus_example
 

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -67,7 +67,7 @@ void main() {
 
   testWidgets('Can get non-null iOS utsname fields',
       (WidgetTester tester) async {
-    expect(iosInfo.utsname.machine, 'iPhone10,4');
+    expect(iosInfo.utsname.machine, 'iPhone14,7');
     expect(iosInfo.utsname.nodename, isNotNull);
     expect(iosInfo.utsname.release, isNotNull);
     expect(iosInfo.utsname.sysname, isNotNull);


### PR DESCRIPTION
## Description

Fixing workflows as due to changes introduced in #1628 it is required to run `melos bootstrap` in integration tests for release PRs to resolve versions properly.
We had the problem of failing checks in https://github.com/fluttercommunity/plus_plugins/pull/1674 and in https://github.com/fluttercommunity/plus_plugins/pull/1718 due to missing bootstrapping.

Also, switched to `macos-13` runners as they help to avoid issues like https://github.com/flutter/flutter/issues/118469 as we had earlier this year.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

