### PR TITLE
ci: Replace deprecated flutter command

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: "Validate Dart formatting"
         run: |
           melos exec -c 1 -- \
-            "flutter format ."
+            "dart format ."
           ./.github/workflows/scripts/validate-formatting.sh
       - name: "Validate Objective-C formatting"
         if: ${{ success() || failure() }}


### PR DESCRIPTION
## Description

`flutter format` was deprecated in favor of `dart format`.

https://github.com/fluttercommunity/plus_plugins/actions/runs/4940139249/jobs/8831507992