### PR TITLE
update and remove win32

### DIFF
--- a/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
+++ b/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:io';
 
 import 'package:flutter/services.dart';

--- a/packages/share_plus/share_plus/example/ios/Flutter/Flutter.podspec
+++ b/packages/share_plus/share_plus/example/ios/Flutter/Flutter.podspec
@@ -1,0 +1,18 @@
+#
+# This podspec is NOT to be published. It is only used as a local source!
+# This is a generated file; do not edit or check into version control.
+#
+
+Pod::Spec.new do |s|
+  s.name             = 'Flutter'
+  s.version          = '1.0.0'
+  s.summary          = 'A UI toolkit for beautiful and fast apps.'
+  s.homepage         = 'https://flutter.dev'
+  s.license          = { :type => 'BSD' }
+  s.author           = { 'Flutter Dev Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :git => 'https://github.com/flutter/engine', :tag => s.version.to_s }
+  s.ios.deployment_target = '11.0'
+  # Framework linking is handled by Flutter tooling, not CocoaPods.
+  # Add a placeholder to satisfy `s.dependency 'Flutter'` plugin podspecs.
+  s.vendored_frameworks = 'path/to/nothing'
+end

--- a/packages/share_plus/share_plus/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/share_plus/share_plus/example/ios/Runner.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (

--- a/packages/share_plus/share_plus/example/test_driver/share_plus_test.dart
+++ b/packages/share_plus/share_plus/example/test_driver/share_plus_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   url_launcher_linux: ^3.0.5
   url_launcher_platform_interface: ^2.1.2
   ffi: ^2.0.1
-  win32: ^4.0.0
+  # win32: ^4.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

There was an issue while updating to flutter 3.10, one of the plugins WIN32 uses an old plugin chiew 1.0.0, so had to remove it and it didn't break anything so far

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.*

*e.g.*
- *Fix #123*
- *Related #456*

## Checklist

- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

