### PR TITLE
test(all): Fix Flutter 3.10 deprecations in tests

### DIFF
--- a/packages/android_alarm_manager_plus/test/android_alarm_manager_test.dart
+++ b/packages/android_alarm_manager_plus/test/android_alarm_manager_test.dart
@@ -22,14 +22,22 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   setUpAll(() {
-    testChannel.setMockMethodCallHandler((MethodCall call) => null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      testChannel,
+      (message) => null,
+    );
   });
 
   test('${AndroidAlarmManager.initialize}', () async {
-    testChannel.setMockMethodCallHandler((MethodCall call) async {
-      assert(call.method == 'AlarmService.start');
-      return true;
-    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      testChannel,
+      (MethodCall call) async {
+        assert(call.method == 'AlarmService.start');
+        return true;
+      },
+    );
 
     final initialized = await AndroidAlarmManager.initialize();
 
@@ -83,19 +91,23 @@ void main() {
       const rescheduleOnReboot = true;
       const params = <String, dynamic>{'title': 'myAlarm'};
 
-      testChannel.setMockMethodCallHandler((MethodCall call) async {
-        expect(call.method, 'Alarm.oneShotAt');
-        expect(call.arguments[0], id);
-        expect(call.arguments[1], alarmClock);
-        expect(call.arguments[2], allowWhileIdle);
-        expect(call.arguments[3], exact);
-        expect(call.arguments[4], wakeup);
-        expect(call.arguments[5], alarm.millisecondsSinceEpoch);
-        expect(call.arguments[6], rescheduleOnReboot);
-        expect(call.arguments[7], rawHandle);
-        expect(call.arguments[8], params);
-        return true;
-      });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        testChannel,
+        (MethodCall call) async {
+          expect(call.method, 'Alarm.oneShotAt');
+          expect(call.arguments[0], id);
+          expect(call.arguments[1], alarmClock);
+          expect(call.arguments[2], allowWhileIdle);
+          expect(call.arguments[3], exact);
+          expect(call.arguments[4], wakeup);
+          expect(call.arguments[5], alarm.millisecondsSinceEpoch);
+          expect(call.arguments[6], rescheduleOnReboot);
+          expect(call.arguments[7], rawHandle);
+          expect(call.arguments[8], params);
+          return true;
+        },
+      );
 
       final result = await AndroidAlarmManager.oneShotAt(
         alarm,
@@ -129,22 +141,26 @@ void main() {
     const wakeup = true;
     const rescheduleOnReboot = true;
     const params = <String, dynamic>{'title': 'myAlarm'};
-    testChannel.setMockMethodCallHandler((MethodCall call) async {
-      expect(call.method, 'Alarm.oneShotAt');
-      expect(call.arguments[0], id);
-      expect(call.arguments[1], alarmClock);
-      expect(call.arguments[2], allowWhileIdle);
-      expect(call.arguments[3], exact);
-      expect(call.arguments[4], wakeup);
-      expect(
-        call.arguments[5],
-        now.millisecondsSinceEpoch + alarm.inMilliseconds,
-      );
-      expect(call.arguments[6], rescheduleOnReboot);
-      expect(call.arguments[7], rawHandle);
-      expect(call.arguments[8], params);
-      return true;
-    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      testChannel,
+      (MethodCall call) async {
+        expect(call.method, 'Alarm.oneShotAt');
+        expect(call.arguments[0], id);
+        expect(call.arguments[1], alarmClock);
+        expect(call.arguments[2], allowWhileIdle);
+        expect(call.arguments[3], exact);
+        expect(call.arguments[4], wakeup);
+        expect(
+          call.arguments[5],
+          now.millisecondsSinceEpoch + alarm.inMilliseconds,
+        );
+        expect(call.arguments[6], rescheduleOnReboot);
+        expect(call.arguments[7], rawHandle);
+        expect(call.arguments[8], params);
+        return true;
+      },
+    );
 
     final result = await AndroidAlarmManager.oneShot(
       alarm,
@@ -201,22 +217,26 @@ void main() {
       const period = Duration(seconds: 1);
       const params = <String, dynamic>{'title': 'myAlarm'};
 
-      testChannel.setMockMethodCallHandler((MethodCall call) async {
-        expect(call.method, 'Alarm.periodic');
-        expect(call.arguments[0], id);
-        expect(call.arguments[1], allowWhileIdle);
-        expect(call.arguments[2], exact);
-        expect(call.arguments[3], wakeup);
-        expect(
-          call.arguments[4],
-          (now.millisecondsSinceEpoch + period.inMilliseconds),
-        );
-        expect(call.arguments[5], period.inMilliseconds);
-        expect(call.arguments[6], rescheduleOnReboot);
-        expect(call.arguments[7], rawHandle);
-        expect(call.arguments[8], params);
-        return true;
-      });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        testChannel,
+        (MethodCall call) async {
+          expect(call.method, 'Alarm.periodic');
+          expect(call.arguments[0], id);
+          expect(call.arguments[1], allowWhileIdle);
+          expect(call.arguments[2], exact);
+          expect(call.arguments[3], wakeup);
+          expect(
+            call.arguments[4],
+            (now.millisecondsSinceEpoch + period.inMilliseconds),
+          );
+          expect(call.arguments[5], period.inMilliseconds);
+          expect(call.arguments[6], rescheduleOnReboot);
+          expect(call.arguments[7], rawHandle);
+          expect(call.arguments[8], params);
+          return true;
+        },
+      );
 
       final result = await AndroidAlarmManager.periodic(
         period,
@@ -232,75 +252,83 @@ void main() {
       expect(result, isTrue);
     });
 
-    test('throws if params not parsable, works if params parsable', () async {
-      final now = DateTime(1993);
-      const rawHandle = 4;
-      AndroidAlarmManager.setTestOverrides(
-        now: () => now,
-        getCallbackHandle: (Function _) =>
-            CallbackHandle.fromRawHandle(rawHandle),
-      );
+    test(
+      'throws if params not parsable, works if params parsable',
+      () async {
+        final now = DateTime(1993);
+        const rawHandle = 4;
+        AndroidAlarmManager.setTestOverrides(
+          now: () => now,
+          getCallbackHandle: (Function _) =>
+              CallbackHandle.fromRawHandle(rawHandle),
+        );
 
-      const id = 1;
-      const period = Duration(seconds: 1);
-      final notParsableParams = <String, dynamic>{
-        'title': 'myAlarm',
-        'obj': const NotJsonParsableClass(),
-      };
+        const id = 1;
+        const period = Duration(seconds: 1);
+        final notParsableParams = <String, dynamic>{
+          'title': 'myAlarm',
+          'obj': const NotJsonParsableClass(),
+        };
 
-      expectLater(
-        () => AndroidAlarmManager.periodic(
+        expectLater(
+          () => AndroidAlarmManager.periodic(
+            period,
+            id,
+            validCallbackWithParams,
+            params: notParsableParams,
+          ),
+          throwsUnsupportedError,
+        );
+
+        final parsableParams = <String, dynamic>{
+          'title': 'myAlarm',
+          'obj': const JsonParsableClass('MyName')
+        };
+
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(testChannel, (MethodCall call) async {
+          expect(call.method, 'Alarm.periodic');
+          expect(call.arguments[0], id);
+          expect(
+            call.arguments[4],
+            (now.millisecondsSinceEpoch + period.inMilliseconds),
+          );
+          expect(call.arguments[5], period.inMilliseconds);
+          expect(call.arguments[7], rawHandle);
+          expect(call.arguments[8], isA<Map>());
+          expect(
+            JsonParsableClass.fromJson(call.arguments[8]['obj']),
+            isA<JsonParsableClass>(),
+          );
+          expect(
+            JsonParsableClass.fromJson(call.arguments[8]['obj']),
+            const JsonParsableClass('MyName'),
+          );
+          return true;
+        });
+
+        final result = await AndroidAlarmManager.periodic(
           period,
           id,
           validCallbackWithParams,
-          params: notParsableParams,
-        ),
-        throwsUnsupportedError,
-      );
-
-      final parsableParams = <String, dynamic>{
-        'title': 'myAlarm',
-        'obj': const JsonParsableClass('MyName')
-      };
-
-      testChannel.setMockMethodCallHandler((MethodCall call) async {
-        expect(call.method, 'Alarm.periodic');
-        expect(call.arguments[0], id);
-        expect(
-          call.arguments[4],
-          (now.millisecondsSinceEpoch + period.inMilliseconds),
+          params: parsableParams,
         );
-        expect(call.arguments[5], period.inMilliseconds);
-        expect(call.arguments[7], rawHandle);
-        expect(call.arguments[8], isA<Map>());
-        expect(
-          JsonParsableClass.fromJson(call.arguments[8]['obj']),
-          isA<JsonParsableClass>(),
-        );
-        expect(
-          JsonParsableClass.fromJson(call.arguments[8]['obj']),
-          const JsonParsableClass('MyName'),
-        );
-        return true;
-      });
 
-      final result = await AndroidAlarmManager.periodic(
-        period,
-        id,
-        validCallbackWithParams,
-        params: parsableParams,
-      );
-
-      expect(result, isTrue);
-    });
+        expect(result, isTrue);
+      },
+    );
   });
 
   test('${AndroidAlarmManager.cancel}', () async {
     const id = 1;
-    testChannel.setMockMethodCallHandler((MethodCall call) async {
-      assert(call.method == 'Alarm.cancel' && call.arguments[0] == id);
-      return true;
-    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      testChannel,
+      (MethodCall call) async {
+        assert(call.method == 'Alarm.cancel' && call.arguments[0] == id);
+        return true;
+      },
+    );
 
     final canceled = await AndroidAlarmManager.cancel(id);
 

--- a/packages/battery_plus/battery_plus/lib/src/battery_plus_web.dart
+++ b/packages/battery_plus/battery_plus/lib/src/battery_plus_web.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:html' as html show window, BatteryManager, Navigator;
-import 'dart:js';
 import 'dart:js_util';
 import 'package:battery_plus_platform_interface/battery_plus_platform_interface.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';

--- a/packages/battery_plus/battery_plus_platform_interface/test/battery_plus_platform_interface_test.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/test/battery_plus_platform_interface_test.dart
@@ -13,38 +13,47 @@ void main() {
     setUp(() async {
       methodChannelBattery = MethodChannelBattery();
 
-      methodChannelBattery.methodChannel
-          .setMockMethodCallHandler((MethodCall methodCall) async {
-        log.add(methodCall);
-        switch (methodCall.method) {
-          case 'getBatteryLevel':
-            return 100;
-          case 'isInBatterySaveMode':
-            return true;
-          case 'getBatteryState':
-            return 'charging';
-          default:
-            return null;
-        }
-      });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        methodChannelBattery.methodChannel,
+        (MethodCall methodCall) async {
+          log.add(methodCall);
+          switch (methodCall.method) {
+            case 'getBatteryLevel':
+              return 100;
+            case 'isInBatterySaveMode':
+              return true;
+            case 'getBatteryState':
+              return 'charging';
+            default:
+              return null;
+          }
+        },
+      );
       log.clear();
-      MethodChannel(methodChannelBattery.eventChannel.name)
-          .setMockMethodCallHandler((MethodCall methodCall) async {
-        switch (methodCall.method) {
-          case 'listen':
-            await ServicesBinding.instance.defaultBinaryMessenger
-                .handlePlatformMessage(
-              methodChannelBattery.eventChannel.name,
-              methodChannelBattery.eventChannel.codec
-                  .encodeSuccessEnvelope('full'),
-              (_) {},
-            );
-            break;
-          case 'cancel':
-          default:
-            return null;
-        }
-      });
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        MethodChannel(methodChannelBattery.eventChannel.name),
+        (MethodCall methodCall) async {
+          switch (methodCall.method) {
+            case 'listen':
+              await TestDefaultBinaryMessengerBinding
+                  .instance.defaultBinaryMessenger
+                  .handlePlatformMessage(
+                methodChannelBattery.eventChannel.name,
+                methodChannelBattery.eventChannel.codec
+                    .encodeSuccessEnvelope('full'),
+                (_) {},
+              );
+              break;
+            case 'cancel':
+            default:
+              return null;
+          }
+          return null;
+        },
+      );
     });
 
     test('onBatteryChanged', () async {

--- a/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -1,7 +1,6 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
 import 'dart:io';
 
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -12,6 +11,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   late Connectivity connectivity;
+
   group('Connectivity test driver', () {
     setUpAll(() async {
       connectivity = Connectivity();

--- a/packages/connectivity_plus/connectivity_plus_platform_interface/test/method_channel_connectivity_test.dart
+++ b/packages/connectivity_plus/connectivity_plus_platform_interface/test/method_channel_connectivity_test.dart
@@ -17,34 +17,43 @@ void main() {
     setUp(() async {
       methodChannelConnectivity = MethodChannelConnectivity();
 
-      methodChannelConnectivity.methodChannel
-          .setMockMethodCallHandler((MethodCall methodCall) async {
-        log.add(methodCall);
-        switch (methodCall.method) {
-          case 'check':
-            return 'wifi';
-          default:
-            return null;
-        }
-      });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        methodChannelConnectivity.methodChannel,
+        (MethodCall methodCall) async {
+          log.add(methodCall);
+          switch (methodCall.method) {
+            case 'check':
+              return 'wifi';
+            default:
+              return null;
+          }
+        },
+      );
       log.clear();
-      MethodChannel(methodChannelConnectivity.eventChannel.name)
-          .setMockMethodCallHandler((MethodCall methodCall) async {
-        switch (methodCall.method) {
-          case 'listen':
-            await ServicesBinding.instance.defaultBinaryMessenger
-                .handlePlatformMessage(
-              methodChannelConnectivity.eventChannel.name,
-              methodChannelConnectivity.eventChannel.codec
-                  .encodeSuccessEnvelope('wifi'),
-              (_) {},
-            );
-            break;
-          case 'cancel':
-          default:
-            return null;
-        }
-      });
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        MethodChannel(methodChannelConnectivity.eventChannel.name),
+        (MethodCall methodCall) async {
+          switch (methodCall.method) {
+            case 'listen':
+              await TestDefaultBinaryMessengerBinding
+                  .instance.defaultBinaryMessenger
+                  .handlePlatformMessage(
+                methodChannelConnectivity.eventChannel.name,
+                methodChannelConnectivity.eventChannel.codec
+                    .encodeSuccessEnvelope('wifi'),
+                (_) {},
+              );
+              break;
+            case 'cancel':
+            default:
+              return null;
+          }
+          return null;
+        },
+      );
     });
 
     test('onConnectivityChanged', () async {

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/method_channel_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/method_channel_device_info_test.dart
@@ -15,15 +15,18 @@ void main() {
     setUp(() async {
       methodChannelDeviceInfo = MethodChannelDeviceInfo();
 
-      methodChannelDeviceInfo.channel
-          .setMockMethodCallHandler((MethodCall methodCall) async {
-        switch (methodCall.method) {
-          case 'getDeviceInfo':
-            return {'device_info': 'is_fake'};
-          default:
-            return null;
-        }
-      });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        methodChannelDeviceInfo.channel,
+        (MethodCall methodCall) async {
+          switch (methodCall.method) {
+            case 'getDeviceInfo':
+              return {'device_info': 'is_fake'};
+            default:
+              return null;
+          }
+        },
+      );
     });
 
     test('deviceInfo', () async {

--- a/packages/network_info_plus/network_info_plus_platform_interface/test/method_channel_network_info_test.dart
+++ b/packages/network_info_plus/network_info_plus_platform_interface/test/method_channel_network_info_test.dart
@@ -17,32 +17,35 @@ void main() {
     setUp(() async {
       methodChannelNetworkInfo = MethodChannelNetworkInfo();
 
-      methodChannelNetworkInfo.methodChannel
-          .setMockMethodCallHandler((MethodCall methodCall) async {
-        log.add(methodCall);
-        switch (methodCall.method) {
-          case 'wifiName':
-            return '1337wifi';
-          case 'wifiBSSID':
-            return 'c0:ff:33:c0:d3:55';
-          case 'wifiIPAddress':
-            return '127.0.0.1';
-          case 'wifiIPv6Address':
-            return '2002:7f00:0001:0:0:0:0:0';
-          case 'wifiBroadcast':
-            return '127.0.0.255';
-          case 'wifiGatewayAddress':
-            return '127.0.0.0';
-          case 'wifiSubmask':
-            return '255.255.255.0';
-          case 'requestLocationServiceAuthorization':
-            return 'authorizedAlways';
-          case 'getLocationServiceAuthorization':
-            return 'authorizedAlways';
-          default:
-            return null;
-        }
-      });
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        methodChannelNetworkInfo.methodChannel,
+        (MethodCall methodCall) async {
+          log.add(methodCall);
+          switch (methodCall.method) {
+            case 'wifiName':
+              return '1337wifi';
+            case 'wifiBSSID':
+              return 'c0:ff:33:c0:d3:55';
+            case 'wifiIPAddress':
+              return '127.0.0.1';
+            case 'wifiIPv6Address':
+              return '2002:7f00:0001:0:0:0:0:0';
+            case 'wifiBroadcast':
+              return '127.0.0.255';
+            case 'wifiGatewayAddress':
+              return '127.0.0.0';
+            case 'wifiSubmask':
+              return '255.255.255.0';
+            case 'requestLocationServiceAuthorization':
+              return 'authorizedAlways';
+            case 'getLocationServiceAuthorization':
+              return 'authorizedAlways';
+            default:
+              return null;
+          }
+        },
+      );
       log.clear();
     });
 

--- a/packages/package_info_plus/package_info_plus/test/package_info_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_test.dart
@@ -12,22 +12,26 @@ void main() {
   const channel = MethodChannel('dev.fluttercommunity.plus/package_info');
   final log = <MethodCall>[];
 
-  channel.setMockMethodCallHandler((MethodCall methodCall) async {
-    log.add(methodCall);
-    switch (methodCall.method) {
-      case 'getAll':
-        return <String, dynamic>{
-          'appName': 'package_info_example',
-          'buildNumber': '1',
-          'packageName': 'io.flutter.plugins.packageinfoexample',
-          'version': '1.0',
-          'installerStore': null,
-        };
-      default:
-        assert(false);
-        return null;
-    }
-  });
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
+    channel,
+    (MethodCall methodCall) async {
+      log.add(methodCall);
+      switch (methodCall.method) {
+        case 'getAll':
+          return <String, dynamic>{
+            'appName': 'package_info_example',
+            'buildNumber': '1',
+            'packageName': 'io.flutter.plugins.packageinfoexample',
+            'version': '1.0',
+            'installerStore': null,
+          };
+        default:
+          assert(false);
+          return null;
+      }
+    },
+  );
 
   tearDown(() {
     log.clear();

--- a/packages/package_info_plus/package_info_plus_platform_interface/test/method_channel_package_info_test.dart
+++ b/packages/package_info_plus/package_info_plus_platform_interface/test/method_channel_package_info_test.dart
@@ -37,22 +37,26 @@ void main() {
   group('$MethodChannelPackageInfo()', () {
     const channel = MethodChannel('dev.fluttercommunity.plus/package_info');
     final log = <MethodCall>[];
-    channel.setMockMethodCallHandler((MethodCall methodCall) async {
-      log.add(methodCall);
-      switch (methodCall.method) {
-        case 'getAll':
-          return <String, dynamic>{
-            'appName': 'package_info_example',
-            'buildNumber': '1',
-            'packageName': 'io.flutter.plugins.packageinfoexample',
-            'version': '1.0',
-            'installerStore': 'testflight',
-          };
-        default:
-          assert(false);
-          return null;
-      }
-    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        log.add(methodCall);
+        switch (methodCall.method) {
+          case 'getAll':
+            return <String, dynamic>{
+              'appName': 'package_info_example',
+              'buildNumber': '1',
+              'packageName': 'io.flutter.plugins.packageinfoexample',
+              'version': '1.0',
+              'installerStore': 'testflight',
+            };
+          default:
+            assert(false);
+            return null;
+        }
+      },
+    );
 
     final packageInfo = MethodChannelPackageInfo();
 

--- a/packages/sensors_plus/sensors_plus/example/integration_test/sensors_plus_test.dart
+++ b/packages/sensors_plus/sensors_plus/example/integration_test/sensors_plus_test.dart
@@ -1,7 +1,6 @@
 // Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
 import 'dart:async';
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
@@ -12,7 +11,7 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   // NOTE: The accelerometer events are not returned on iOS simulators.
-  testWidgets('Can subscript to accelerometerEvents and get non-null events',
+  testWidgets('Can subscribe to accelerometerEvents and get non-null events',
       (WidgetTester tester) async {
     final completer = Completer<AccelerometerEvent>();
     late StreamSubscription<AccelerometerEvent> subscription;

--- a/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'dart:developer' as developer;
 import 'dart:html' as html
     show LinearAccelerationSensor, Accelerometer, Gyroscope, Magnetometer;
-import 'dart:js';
 import 'dart:js_util';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';

--- a/packages/sensors_plus/sensors_plus/test/sensors_test.dart
+++ b/packages/sensors_plus/sensors_plus/test/sensors_test.dart
@@ -64,7 +64,8 @@ void _initializeFakeSensorChannel(String channelName, List<double> sensorData) {
   const standardMethod = StandardMethodCodec();
 
   void emitEvent(ByteData? event) {
-    ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
       channelName,
       event,
       (ByteData? reply) {},

--- a/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
@@ -87,7 +87,8 @@ void _initializeFakeSensorChannel(String channelName, List<double> sensorData) {
   const standardMethod = StandardMethodCodec();
 
   void emitEvent(ByteData? event) {
-    ServicesBinding.instance.defaultBinaryMessenger.handlePlatformMessage(
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .handlePlatformMessage(
       channelName,
       event,
       (ByteData? reply) {},

--- a/packages/share_plus/share_plus/example/android/build.gradle
+++ b/packages/share_plus/share_plus/example/android/build.gradle
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }

--- a/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
+++ b/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
@@ -1,7 +1,6 @@
 // Copyright 2019, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
-
 import 'dart:io';
 
 import 'package:flutter/services.dart';


### PR DESCRIPTION
## Description

Resolving all analyzer warnings from Flutter 3.10.0 reported in tests.
Here is one of jobs with such warnings: https://github.com/fluttercommunity/plus_plugins/actions/runs/4956135708/jobs/8866237373

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

