### PR TITLE
fix(battery_plus): Use context compat to set exported state

### DIFF
--- a/packages/battery_plus/battery_plus/android/build.gradle
+++ b/packages/battery_plus/battery_plus/android/build.gradle
@@ -47,4 +47,5 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "androidx.core:core-ktx:1.10.1"
 }

--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -84,7 +84,6 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
     @SuppressLint("WrongConstant") // Error in ContextCompat for RECEIVER_NOT_EXPORTED
     override fun onListen(arguments: Any?, events: EventSink) {
         chargingStateChangeReceiver = createChargingStateChangeReceiver(events)
-        // DO NOT MERGE, this alternates states. reidbaker debug before review.
         applicationContext?.let {
             ContextCompat.registerReceiver(
                 it, chargingStateChangeReceiver,

--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -20,6 +20,8 @@ import java.util.Locale
 import android.os.PowerManager
 import android.provider.Settings
 import androidx.annotation.RequiresApi
+import androidx.core.content.ContextCompat
+
 
 /** BatteryPlusPlugin  */
 class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, FlutterPlugin {
@@ -79,7 +81,11 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
 
     override fun onListen(arguments: Any?, events: EventSink) {
         chargingStateChangeReceiver = createChargingStateChangeReceiver(events)
-        applicationContext?.registerReceiver(chargingStateChangeReceiver, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+        ContextCompat.registerReceiver(
+            applicationContext?,
+            chargingStateChangeReceiver,
+            IntentFilter(Intent.ACTION_BATTERY_CHANGED),
+            ContextCompat.RECEIVER_EXPORTED);
         val status = getBatteryStatus()
         publishBatteryStatus(events, status)
     }

--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -21,6 +21,7 @@ import android.os.PowerManager
 import android.provider.Settings
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
+import androidx.core.content.ContextCompat.RECEIVER_EXPORTED
 
 
 /** BatteryPlusPlugin  */
@@ -81,11 +82,13 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
 
     override fun onListen(arguments: Any?, events: EventSink) {
         chargingStateChangeReceiver = createChargingStateChangeReceiver(events)
-        ContextCompat.registerReceiver(
-            applicationContext!,
-            chargingStateChangeReceiver,
-            IntentFilter(Intent.ACTION_BATTERY_CHANGED),
-            ContextCompat.RECEIVER_EXPORTED)
+        // DO NOT MERGE, this alternates states. reidbaker debug before review.
+        applicationContext?.let {
+            ContextCompat.registerReceiver(
+                it, chargingStateChangeReceiver,
+                IntentFilter(Intent.ACTION_BATTERY_CHANGED), RECEIVER_EXPORTED
+            )
+        }
         val status = getBatteryStatus()
         publishBatteryStatus(events, status)
     }

--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -82,10 +82,10 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
     override fun onListen(arguments: Any?, events: EventSink) {
         chargingStateChangeReceiver = createChargingStateChangeReceiver(events)
         ContextCompat.registerReceiver(
-            applicationContext?,
+            applicationContext!,
             chargingStateChangeReceiver,
             IntentFilter(Intent.ACTION_BATTERY_CHANGED),
-            ContextCompat.RECEIVER_EXPORTED);
+            ContextCompat.RECEIVER_EXPORTED)
         val status = getBatteryStatus()
         publishBatteryStatus(events, status)
     }

--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -1,5 +1,6 @@
 package dev.fluttercommunity.plus.battery
 
+import android.annotation.SuppressLint
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.EventChannel
 import io.flutter.embedding.engine.plugins.FlutterPlugin
@@ -21,7 +22,7 @@ import android.os.PowerManager
 import android.provider.Settings
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
-import androidx.core.content.ContextCompat.RECEIVER_EXPORTED
+import androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED
 
 
 /** BatteryPlusPlugin  */
@@ -80,13 +81,14 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
         }
     }
 
+    @SuppressLint("WrongConstant") // Error in ContextCompat for RECEIVER_NOT_EXPORTED
     override fun onListen(arguments: Any?, events: EventSink) {
         chargingStateChangeReceiver = createChargingStateChangeReceiver(events)
         // DO NOT MERGE, this alternates states. reidbaker debug before review.
         applicationContext?.let {
             ContextCompat.registerReceiver(
                 it, chargingStateChangeReceiver,
-                IntentFilter(Intent.ACTION_BATTERY_CHANGED), RECEIVER_EXPORTED
+                IntentFilter(Intent.ACTION_BATTERY_CHANGED), RECEIVER_NOT_EXPORTED
             )
         }
         val status = getBatteryStatus()

--- a/packages/battery_plus/battery_plus/example/android/build.gradle
+++ b/packages/battery_plus/battery_plus/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
## Description
Most of the context is in the bug but short summary is that broadcast receivers will require and export state if apps are targeting android api 34. Unfortunately I cant find a public document or post saying this but I see this on internal facing documents. 

There is an internal to google team using battery_plus who wishes to target api 34 and they reached out to me as the TL of flutter on android to help get their dependencies updated. You can see a similar issues and a pull request to fix our own url_launcher plugin below. 

I think the other examples of registerReceiver are ok because they are protected by a version check and not called on api 34. If that is incorrect I can fix those in a different pr. 

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/1810
https://github.com/flutter/flutter/issues/126460
https://github.com/flutter/packages/pull/3973

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

