### PR TITLE
chore(network_info_plus): Update win32 dependency constraints

### DIFF
--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -36,7 +36,8 @@ dependencies:
     sdk: flutter
   meta: ^1.8.0
   network_info_plus_platform_interface: ^1.1.3
-  win32: ^4.1.4
+  # win32 is compatible across v4 and v5 for Win32 only (not COM)
+  win32: ">=4.0.0 <6.0.0"
   ffi: ^2.0.1
 
 dev_dependencies:


### PR DESCRIPTION
## Description

After #1805 only `network_info_plus` had not updated constraints for win32 package. Fixing with this PR. 

## Related Issues

#1801 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

