### PR TITLE
fix: Value of key `appName` possibly not of type String on iOS.

### DIFF
--- a/packages/package_info_plus/package_info_plus_platform_interface/lib/method_channel_package_info.dart
+++ b/packages/package_info_plus/package_info_plus_platform_interface/lib/method_channel_package_info.dart
@@ -12,7 +12,7 @@ class MethodChannelPackageInfo extends PackageInfoPlatform {
   Future<PackageInfoData> getAll() async {
     final map = await _channel.invokeMapMethod<String, dynamic>('getAll');
     return PackageInfoData(
-      appName: map!['appName'] ?? '',
+      appName: map!['appName']?.toString() ?? '',
       packageName: map['packageName'] ?? '',
       version: map['version'] ?? '',
       buildNumber: map['buildNumber'] ?? '',


### PR DESCRIPTION
## Description

### `package_info_plus`

After upgrading flutter SDK (see flutter doctor below) ...

in `method_channel_package_info.dart`:
**Value of key 'appName' possibly is not of type String on iOS.**

<img width="961" alt="image" src="https://github.com/fluttercommunity/plus_plugins/assets/93587054/fc145cbf-17ae-470f-b473-ed157d28e3cb">

I think the type boils down to `Char` as a native type coming from the MethodChannel. I Would prefer to ensure the type in the native implementation, but I won't touch your Objective-C implementation.
The `?.toString()` should not hurt in any already expected case.
For whatever reason this only applies to the `appName`, but obviously the other values may cause the same error. So far I just fixed what is broken.

Let me know what you think.

### Environment
`pubspec.yaml`:
```
environment:
  sdk: ">=2.10.0 <3.0.0"

dependencies:
  package_info_plus: ^4.0.0
  ...
```

_Flutter Doctor:_
```
[!] Flutter (Channel stable, 3.7.12, on macOS 13.3.1 22E772610a darwin-arm64, locale en-US)
    • Flutter version 3.7.12 on channel stable at /Users/<USER>/.fvm/versions/3.7.12
    ! Warning: `dart` on your path resolves to /opt/homebrew/Cellar/dart/3.0.0/libexec/bin/dart, which is not inside your current Flutter SDK checkout at /Users/<USER>/.fvm/versions/3.7.12. Consider adding /Users/<USER>/.fvm/versions/3.7.12/bin to the front of your path.
    • Upstream repository https://github.com/flutter/flutter.git
    • Framework revision 4d9e56e694 (4 weeks ago), 2023-04-17 21:47:46 -0400
    • Engine revision 1a65d409c7
    • Dart version 2.19.6
    • DevTools version 2.20.1
    • If those were intentional, you can disregard the above warnings; however it is recommended to use "git" directly to perform update checks and upgrades.

[✓] Android toolchain - develop for Android devices (Android SDK version 33.0.0)
    • Android SDK at /Users/<USER>/Library/Android/sdk
    • Platform android-33, build-tools 33.0.0
    • ANDROID_HOME = /Users/<USER>/Library/Android/sdk
    • Java binary at: /Applications/Android Studio.app/Contents/jre/Contents/Home/bin/java
    • Java version OpenJDK Runtime Environment (build 11.0.12+0-b1504.28-7817840)
    • All Android licenses accepted.

[✓] Xcode - develop for iOS and macOS (Xcode 14.2)
    • Xcode at /Applications/Xcode.app/Contents/Developer
    • Build 14C18
    • CocoaPods version 1.11.3

[✓] Android Studio (version 2021.2)
    • Android Studio at /Applications/Android Studio.app/Contents
    • Flutter plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/9212-flutter
    • Dart plugin can be installed from:
      🔨 https://plugins.jetbrains.com/plugin/6351-dart
    • Java version OpenJDK Runtime Environment (build 11.0.12+0-b1504.28-7817840)

[✓] VS Code (version 1.78.2)
    • VS Code at /Applications/Visual Studio Code.app/Contents
    • Flutter extension version 3.64.0
```

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

