### PR TITLE
fix(device_info_plus, package_info_plus): fixed a bug!

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/build.gradle
+++ b/packages/device_info_plus/device_info_plus/android/build.gradle
@@ -30,8 +30,8 @@ android {
     namespace 'dev.fluttercommunity.plus.device_info'
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility project.sourceCompatibility != JavaVersion.VERSION_1_8 ? project.sourceCompatibility : JavaVersion.VERSION_1_8
+        targetCompatibility project.targetCompatibility != JavaVersion.VERSION_1_8 ? project.targetCompatibility : JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {

--- a/packages/package_info_plus/package_info_plus/android/build.gradle
+++ b/packages/package_info_plus/package_info_plus/android/build.gradle
@@ -31,8 +31,8 @@ android {
     namespace 'dev.fluttercommunity.plus.packageinfo'
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility project.sourceCompatibility != JavaVersion.VERSION_1_8 ? project.sourceCompatibility : JavaVersion.VERSION_1_8
+        targetCompatibility project.targetCompatibility != JavaVersion.VERSION_1_8 ? project.targetCompatibility : JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {


### PR DESCRIPTION
…rom the one defined in the project.

## Description

In this PR was added a condition to check if the java version defined in the project is different from the default version of the package, if it is different, we get the version from the project, if it is not, we define the default version.

## Related Issues

#1821

*e.g.*
- *Fix ##1821*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

