### PR TITLE
docs(sensor_plus): Add info about possible error cases

### DIFF
--- a/docs/sensors_plus/usage.mdx
+++ b/docs/sensors_plus/usage.mdx
@@ -36,29 +36,62 @@ These events are exposed through a `BroadcastStream`: `accelerometerEvents`,
 `userAccelerometerEvents`, `gyroscopeEvents`, and `magnetometerEvents`,
 respectively.
 
+> **Note**
+>
+> Some low end or old Android devices don't have all sensors available. Plugin won't crash the app,
+> but it is highly recommended to add onError() to handle such cases gracefully.
+
 ### Example
 
 ```dart
 import 'package:sensors_plus/sensors_plus.dart';
 
-userAccelerometerEvents.listen((UserAccelerometerEvent event) {
-  print(event);
-});
-// [UserAccelerometerEvent (x: 0.0, y: 0.0, z: 0.0)]
-
-accelerometerEvents.listen((AccelerometerEvent event) {
-  print(event);
-});
+accelerometerEvents.listen(
+  (AccelerometerEvent event) {
+    print(event);
+  },
+  onError: (error) {
+    // Logic to handle error
+    // Needed for Android in case sensor is not available
+    },
+  cancelOnError: true,
+);
 // [AccelerometerEvent (x: 0.0, y: 9.8, z: 0.0)]
 
-gyroscopeEvents.listen((GyroscopeEvent event) {
-  print(event);
-});
+userAccelerometerEvents.listen(
+  (UserAccelerometerEvent event) {
+    print(event);
+  },
+  onError: (error) {
+    // Logic to handle error
+    // Needed for Android in case sensor is not available
+    },
+  cancelOnError: true,
+);
+// [UserAccelerometerEvent (x: 0.0, y: 0.0, z: 0.0)]
+
+gyroscopeEvents.listen(
+  (GyroscopeEvent event) {
+    print(event);
+  },
+  onError: (error) {
+    // Logic to handle error
+    // Needed for Android in case sensor is not available
+    },
+  cancelOnError: true,
+);
 // [GyroscopeEvent (x: 0.0, y: 0.0, z: 0.0)]
 
-magnetometerEvents.listen((MagnetometerEvent event) {
-  print(event);
-});
+magnetometerEvents.listen(
+  (MagnetometerEvent event) {
+    print(event);
+  },
+  onError: (error) {
+    // Logic to handle error
+    // Needed for Android in case sensor is not available
+    },
+  cancelOnError: true,
+);
 // [MagnetometerEvent (x: -23.6, y: 6.2, z: -34.9)]
 
 ```

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -37,29 +37,62 @@ These events are exposed through a `BroadcastStream`: `accelerometerEvents`,
 `userAccelerometerEvents`, `gyroscopeEvents`, and `magnetometerEvents`,
 respectively.
 
+> **Note**
+>
+> Some low end or old Android devices don't have all sensors available. Plugin won't crash the app,
+> but it is highly recommended to add onError() to handle such cases gracefully.
+
 ### Example
 
 ```dart
 import 'package:sensors_plus/sensors_plus.dart';
 
-accelerometerEvents.listen((AccelerometerEvent event) {
-  print(event);
-});
+accelerometerEvents.listen(
+  (AccelerometerEvent event) {
+    print(event);
+  },
+  onError: (error) {
+    // Logic to handle error
+    // Needed for Android in case sensor is not available
+    },
+  cancelOnError: true,
+);
 // [AccelerometerEvent (x: 0.0, y: 9.8, z: 0.0)]
 
-userAccelerometerEvents.listen((UserAccelerometerEvent event) {
-  print(event);
-});
+userAccelerometerEvents.listen(
+  (UserAccelerometerEvent event) {
+    print(event);
+  },
+  onError: (error) {
+    // Logic to handle error
+    // Needed for Android in case sensor is not available
+    },
+  cancelOnError: true,
+);
 // [UserAccelerometerEvent (x: 0.0, y: 0.0, z: 0.0)]
 
-gyroscopeEvents.listen((GyroscopeEvent event) {
-  print(event);
-});
+gyroscopeEvents.listen(
+  (GyroscopeEvent event) {
+    print(event);
+  },
+  onError: (error) {
+    // Logic to handle error
+    // Needed for Android in case sensor is not available
+    },
+  cancelOnError: true,
+);
 // [GyroscopeEvent (x: 0.0, y: 0.0, z: 0.0)]
 
-magnetometerEvents.listen((MagnetometerEvent event) {
-  print(event);
-});
+magnetometerEvents.listen(
+  (MagnetometerEvent event) {
+    print(event);
+  },
+  onError: (error) {
+    // Logic to handle error
+    // Needed for Android in case sensor is not available
+    },
+  cancelOnError: true,
+);
 // [MagnetometerEvent (x: -23.6, y: 6.2, z: -34.9)]
 
 ```

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -23,12 +23,23 @@ Add `sensors_plus` as a dependency in your pubspec.yaml file.
 
 This will expose such classes of sensor events through a set of streams:
 
-- `AccelerometerEvent` describes the velocity of the device, including the
-  effects of gravity. Put simply, you can use accelerometer readings to tell if
-  the device is moving in a particular direction.
-- `UserAccelerometerEvent` also describes the velocity of the device, but don't
-  include gravity. They can also be thought of as just the user's affect on the
-  device.
+- `UserAccelerometerEvent` describes the acceleration of the device, in m/s<sup>2</sup>.
+  If the device is still, or is moving along a straight line at constant speed,
+  the reported acceleration is zero.
+  If the device is moving e.g. towards north and its speed is increasing, the reported acceleration
+  is towards north; if it is slowing down, the reported acceleration is towards south;
+  if it is turning right, the reported acceleration is towards east.
+  The data of this stream is obtained by filtering out the effect of gravity from `AccelerometerEvent`.
+- `AccelerometerEvent` describes the acceleration of the device, in m/s<sup>2</sup>, including the
+  effects of gravity. Unlike `UserAccelerometerEvent`, this stream reports raw data from
+  the accelerometer (physical sensor embedded in the mobile device) without any post-processing.
+  The accelerometer is unable to distinguish between the effect of an accelerated movement of the
+  device and the effect of the surrounding gravitational field.
+  This means that, at the surface of Earth, even if the device is completely still,
+  the reading of `AccelerometerEvent` is an acceleration of intensity 9.8 directed upwards
+  (the opposite of the graviational acceleration).
+  This can be used to infer information about the position of the device (horizontal/vertical/tilted).
+  `AccelerometerEvent` reports zero acceleration if the device is free falling.
 - `GyroscopeEvent` describes the rotation of the device.
 - `MagnetometerEvent` describes the ambient magnetic field surrounding the
   device. A compass is an example usage of this data.


### PR DESCRIPTION
## Description

As after #1405 `sensors_plus` returns error in case some sensor is not available. This PR adds info about such error into README and website docs.
Additionally unified plugin events description between README and website.

