### PR TITLE
fix(sensors_plus): Fix issues with emitting multiple sensors events on iOS

### DIFF
--- a/packages/sensors_plus/sensors_plus/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/sensors_plus/sensors_plus/example/ios/Runner.xcodeproj/project.pbxproj
@@ -211,6 +211,7 @@
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (

--- a/packages/sensors_plus/sensors_plus/ios/Classes/FLTSensorsPlusPlugin.m
+++ b/packages/sensors_plus/sensors_plus/ios/Classes/FLTSensorsPlusPlugin.m
@@ -40,7 +40,7 @@ BOOL _isCleanUp = NO;
   [_eventChannels setObject:userAccelerometerChannel
                      forKey:userAccelerometerStreamHandlerName];
   [_streamHandlers setObject:userAccelerometerStreamHandler
-                      forKey:accelerometerStreamHandlerName];
+                      forKey:userAccelerometerStreamHandlerName];
 
   FLTGyroscopeStreamHandlerPlus *gyroscopeStreamHandler =
       [[FLTGyroscopeStreamHandlerPlus alloc] init];
@@ -52,7 +52,7 @@ BOOL _isCleanUp = NO;
   [gyroscopeChannel setStreamHandler:gyroscopeStreamHandler];
   [_eventChannels setObject:gyroscopeChannel forKey:gyroscopeStreamHandlerName];
   [_streamHandlers setObject:gyroscopeStreamHandler
-                      forKey:accelerometerStreamHandlerName];
+                      forKey:gyroscopeStreamHandlerName];
 
   FLTMagnetometerStreamHandlerPlus *magnetometerStreamHandler =
       [[FLTMagnetometerStreamHandlerPlus alloc] init];
@@ -65,7 +65,7 @@ BOOL _isCleanUp = NO;
   [_eventChannels setObject:magnetometerChannel
                      forKey:magnetometerStreamHandlerName];
   [_streamHandlers setObject:magnetometerStreamHandler
-                      forKey:accelerometerStreamHandlerName];
+                      forKey:magnetometerStreamHandlerName];
 
   _isCleanUp = NO;
 }
@@ -89,7 +89,7 @@ static void _cleanUp() {
 
 @end
 
-const double GRAVITY = 9.8;
+const double GRAVITY = 9.81;
 CMMotionManager *_motionManager;
 
 void _initMotionManager(void) {


### PR DESCRIPTION
## Description

Potential fix for #1733. In any case it seems wrong that the same key was used for different sensors. I assume it was a typo from copy-paste actions during one of PRs.

## Related Issues

#1733

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

