### PR TITLE
chore(release): prepare for release

### DIFF
--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 9.0.2
+
+ - **DOCS**(device_info_plus): Add links to Android and iOS docs to every field ([#1857](https://github.com/fluttercommunity/plus_plugins/issues/1857)). ([89eb5217](https://github.com/fluttercommunity/plus_plugins/commit/89eb52177c90d5453ba512e73472536fc8a03c9a))
+
 ## 9.0.1
 
  - **FIX**: Add jvm target compatibility to Kotlin plugins ([#1798](https://github.com/fluttercommunity/plus_plugins/issues/1798)). ([1b7dc432](https://github.com/fluttercommunity/plus_plugins/commit/1b7dc432ffb8d0474c9be6339d20b5a2cbcbab3f))

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the device_info_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus: ^9.0.1
+  device_info_plus: ^9.0.2
 
 dev_dependencies:
   flutter_driver:

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 9.0.1
+version: 9.0.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/device_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus

--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.2
+
+- **CHORE**(package_info_plus): Update http dependency constraints (#1851)([#1851](https://github.com/fluttercommunity/plus_plugins/pull/1851)). ([1463bea](https://github.com/fluttercommunity/plus_plugins/commit/1463bea77b79ee1460798b9f65d2a467023b2e38))
+
 ## 4.0.1
 
  - **FIX**(package_info_plus): Get Windows package info when app is on a network drive ([#1697](https://github.com/fluttercommunity/plus_plugins/issues/1697)). ([d7f9c28b](https://github.com/fluttercommunity/plus_plugins/commit/d7f9c28b20842b882b5e196bc3d1ce7963067db6))

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   http: ">=0.13.5 <2.0.0"
-  package_info_plus: ^4.0.1
+  package_info_plus: ^4.0.2
 
 dev_dependencies:
   build_runner: ^2.3.3

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 4.0.1
+version: 4.0.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/package_info_plus

--- a/packages/sensors_plus/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.2
+
+ - **FIX**(sensors_plus): Fix issues with emitting multiple sensors events on iOS ([#1859](https://github.com/fluttercommunity/plus_plugins/issues/1859)). ([d33b20fa](https://github.com/fluttercommunity/plus_plugins/commit/d33b20fa7c76368dbcc12064df8469c301658b53))
+
 ## 3.0.1
 
  - **FIX**(sensors_plus): Fix crash on Android if device has no requested sensor ([#1405](https://github.com/fluttercommunity/plus_plugins/issues/1405)). ([a078b4e8](https://github.com/fluttercommunity/plus_plugins/commit/a078b4e8464a3b8dce24ee5112394097d981a173))

--- a/packages/sensors_plus/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the sensors plugin.
 dependencies:
   flutter:
     sdk: flutter
-  sensors_plus: ^3.0.1
+  sensors_plus: ^3.0.2
 
 dev_dependencies:
   flutter_driver:

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sensors_plus
 description: Flutter plugin for accessing accelerometer, gyroscope, and
   magnetometer sensors.
-version: 3.0.1
+version: 3.0.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/sensors_plus

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.2
+
+- **CHORE**(share_plus): Update file dependency constraints ([#1853](https://github.com/fluttercommunity/plus_plugins/pull/1853)). ([d8ff0cdb](https://github.com/fluttercommunity/plus_plugins/commit/d8ff0cdb665048c59c8acc5fecd1a9c099ee012f))
+
 ## 7.0.1
 
  - **FIX**: Add jvm target compatibility to Kotlin plugins ([#1798](https://github.com/fluttercommunity/plus_plugins/issues/1798)). ([1b7dc432](https://github.com/fluttercommunity/plus_plugins/commit/1b7dc432ffb8d0474c9be6339d20b5a2cbcbab3f))

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 7.0.1
+version: 7.0.2
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus


### PR DESCRIPTION
## Description

New release. Mainly updated constraints for `http` and `file` packages to let people use Dart 3 versions of these packages.
Additionally `sensors_plus` potentially gets a fix for listening multiple sensors events on iOS.