### PR TITLE
fix(all): Add namespace for compatibility with AGP <4.2

### DIFF
--- a/packages/android_alarm_manager_plus/android/build.gradle
+++ b/packages/android_alarm_manager_plus/android/build.gradle
@@ -22,6 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'dev.fluttercommunity.plus.androidalarmmanager'
+    }
     compileSdkVersion 31
 
     namespace 'dev.fluttercommunity.plus.androidalarmmanager'

--- a/packages/android_intent_plus/android/build.gradle
+++ b/packages/android_intent_plus/android/build.gradle
@@ -22,6 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'dev.fluttercommunity.plus.androidintent'
+    }
     compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.androidintent'

--- a/packages/battery_plus/battery_plus/android/build.gradle
+++ b/packages/battery_plus/battery_plus/android/build.gradle
@@ -23,6 +23,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'dev.fluttercommunity.plus.battery'
+    }
     compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.battery'

--- a/packages/connectivity_plus/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/android/build.gradle
@@ -22,6 +22,10 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'dev.fluttercommunity.plus.connectivity'
+    }
     compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.connectivity'

--- a/packages/device_info_plus/device_info_plus/android/build.gradle
+++ b/packages/device_info_plus/device_info_plus/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'dev.fluttercommunity.plus.device_info'
+    }
     compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.device_info'

--- a/packages/network_info_plus/network_info_plus/android/build.gradle
+++ b/packages/network_info_plus/network_info_plus/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'dev.fluttercommunity.plus.network_info'
+    }
     compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.network_info'

--- a/packages/package_info_plus/package_info_plus/android/build.gradle
+++ b/packages/package_info_plus/package_info_plus/android/build.gradle
@@ -26,6 +26,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'dev.fluttercommunity.plus.packageinfo'
+    }
     compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.packageinfo'

--- a/packages/sensors_plus/sensors_plus/android/build.gradle
+++ b/packages/sensors_plus/sensors_plus/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'dev.fluttercommunity.plus.sensors'
+    }
     compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.sensors'

--- a/packages/share_plus/share_plus/android/build.gradle
+++ b/packages/share_plus/share_plus/android/build.gradle
@@ -25,6 +25,10 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    // Conditional for compatibility with AGP <4.2.
+    if (project.android.hasProperty("namespace")) {
+        namespace 'dev.fluttercommunity.plus.share'
+    }
     compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.share'


### PR DESCRIPTION
## Description

These changes need for compatibility with AGP <4.2. For more information: https://developer.android.com/studio/build/agp-upgrade-assistant

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

