### PR TITLE
docs(share_plus): Updated document with latest available method

### DIFF
--- a/docs/share_plus/usage.mdx
+++ b/docs/share_plus/usage.mdx
@@ -40,7 +40,7 @@ if (result.status == ShareResultStatus.dismissed) {
 ```
 
 ```dart
-final result = await  Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
+final result = await Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
 
 if (result.status == ShareResultStatus.dismissed) {
     print('did you not like the pictures?');

--- a/docs/share_plus/usage.mdx
+++ b/docs/share_plus/usage.mdx
@@ -36,7 +36,7 @@ Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
 Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
 ```
 
-If you are interested in the action your user performed with the share sheet, you can instead use the `shareWithResult` and `shareFilesWithResult` methods.
+If you are interested in the action your user performed with the share sheet, you can instead use the `shareWithResult` and `shareXFiles` methods.
 
 ```dart
 final result = await Share.shareWithResult('check out my website https://example.com');
@@ -47,7 +47,7 @@ if (result.status == ShareResultStatus.success) {
 ```
 
 ```dart
-final result = await Share.shareFilesWithResult(['${directory.path}/image.jpg'], text: 'Great picture');
+final result = await Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
 
 if (result.status == ShareResultStatus.dismissed) {
     print('did you not like the picture?');

--- a/docs/share_plus/usage.mdx
+++ b/docs/share_plus/usage.mdx
@@ -29,13 +29,23 @@ sharing to email.
 Share.share('check out my website https://example.com', subject: 'Look what I made!');
 ```
 
+If you are interested in the action your user performed with the share sheet, you can instead use the `shareWithResult` method.
+
+```dart
+final result = await Share.shareWithResult('check out my website https://example.com');
+
+if (result.status == ShareResultStatus.success) {
+    print('Thank you for sharing my website!');
+}
+```
+
 To share one or multiple files invoke the static `shareXFiles` method anywhere in your Dart code, which returns a `ShareResult`. Optionally you can pass `subject`, `text` and `sharePositionOrigin`.
 
 ```dart
 final result = await Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
 
-if (result.status == ShareResultStatus.dismissed) {
-    print('did you not like the picture with text?');
+if (result.status == ShareResultStatus.success) {
+    print('Thank you for sharing the picture!');
 }
 ```
 
@@ -43,16 +53,6 @@ if (result.status == ShareResultStatus.dismissed) {
 final result = await Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
 
 if (result.status == ShareResultStatus.dismissed) {
-    print('did you not like the pictures?');
-}
-```
-
-If you are interested in the action your user performed with the share sheet, you can instead use the `shareWithResult` method.
-
-```dart
-final result = await Share.shareWithResult('check out my website https://example.com');
-
-if (result.status == ShareResultStatus.success) {
-    print('thank you for sharing my website!');
+    print('Did you not like the pictures?');
 }
 ```

--- a/docs/share_plus/usage.mdx
+++ b/docs/share_plus/usage.mdx
@@ -29,11 +29,11 @@ sharing to email.
 Share.share('check out my website https://example.com', subject: 'Look what I made!');
 ```
 
-To share one or multiple files invoke the static `shareFiles` method anywhere in your Dart code. Optionally you can also pass in `text` and `subject`.
+To share one or multiple files invoke the static `shareXFiles` method anywhere in your Dart code. Optionally you can also pass in `text` and `subject`.
 
 ```dart
-Share.shareFiles(['${directory.path}/image.jpg'], text: 'Great picture');
-Share.shareFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
+Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
+Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
 ```
 
 If you are interested in the action your user performed with the share sheet, you can instead use the `shareWithResult` and `shareFilesWithResult` methods.

--- a/docs/share_plus/usage.mdx
+++ b/docs/share_plus/usage.mdx
@@ -29,7 +29,7 @@ sharing to email.
 Share.share('check out my website https://example.com', subject: 'Look what I made!');
 ```
 
-To share one or multiple files invoke the static `shareXFiles` method anywhere in your Dart code and it'll return the `ShareResult`. Optionally you can also pass in `text` and `subject`.
+To share one or multiple files invoke the static `shareXFiles` method anywhere in your Dart code, which returns a `ShareResult`. Optionally you can pass `subject`, `text` and `sharePositionOrigin`.
 
 ```dart
 final result = await Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');

--- a/docs/share_plus/usage.mdx
+++ b/docs/share_plus/usage.mdx
@@ -39,7 +39,7 @@ if (result.status == ShareResultStatus.success) {
 }
 ```
 
-To share one or multiple files invoke the static `shareXFiles` method anywhere in your Dart code, which returns a `ShareResult`. Optionally you can pass `subject`, `text` and `sharePositionOrigin`.
+To share one or multiple files, invoke the static `shareXFiles` method anywhere in your Dart code. The method returns a `ShareResult`. Optionally, you can pass `subject`, `text` and `sharePositionOrigin`.
 
 ```dart
 final result = await Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');

--- a/docs/share_plus/usage.mdx
+++ b/docs/share_plus/usage.mdx
@@ -29,27 +29,30 @@ sharing to email.
 Share.share('check out my website https://example.com', subject: 'Look what I made!');
 ```
 
-To share one or multiple files invoke the static `shareXFiles` method anywhere in your Dart code. Optionally you can also pass in `text` and `subject`.
+To share one or multiple files invoke the static `shareXFiles` method anywhere in your Dart code and it'll return the `ShareResult`. Optionally you can also pass in `text` and `subject`.
 
 ```dart
-Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
-Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
+final result = await Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
+
+if (result.status == ShareResultStatus.dismissed) {
+    print('did you not like the picture with text?');
+}
 ```
 
-If you are interested in the action your user performed with the share sheet, you can instead use the `shareWithResult` and `shareXFiles` methods.
+```dart
+final result = await  Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
+
+if (result.status == ShareResultStatus.dismissed) {
+    print('did you not like the pictures?');
+}
+```
+
+If you are interested in the action your user performed with the share sheet, you can instead use the `shareWithResult` method.
 
 ```dart
 final result = await Share.shareWithResult('check out my website https://example.com');
 
 if (result.status == ShareResultStatus.success) {
     print('thank you for sharing my website!');
-}
-```
-
-```dart
-final result = await Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
-
-if (result.status == ShareResultStatus.dismissed) {
-    print('did you not like the picture?');
 }
 ```

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -52,8 +52,8 @@ Share.share('check out my website https://example.com', subject: 'Look what I ma
 To share one or multiple files invoke the static `shareFiles` method anywhere in your Dart code. Optionally you can also pass in `text` and `subject`.
 
 ```dart
-Share.shareFiles(['${directory.path}/image.jpg'], text: 'Great picture');
-Share.shareFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
+Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
+Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
 ```
 
 On web you can use `SharePlus.shareXFiles()`. This uses the [Web Share API](https://web.dev/web-share/)
@@ -123,4 +123,3 @@ See the `main.dart` in the `example` for a complete example.
 
 - [API Documentation](https://pub.dev/documentation/share_plus/latest/share_plus/share_plus-library.html)
 - [Plugin documentation website](https://plus.fluttercommunity.dev/docs/share_plus/overview)
-

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -59,7 +59,7 @@ if (result.status == ShareResultStatus.success) {
 }
 ```
 
-To share one or multiple files invoke the static `shareXFiles` method anywhere in your Dart code, which returns a `ShareResult`. Optionally you can pass `subject`, `text` and `sharePositionOrigin`.
+To share one or multiple files, invoke the static `shareXFiles` method anywhere in your Dart code. The method returns a `ShareResult`. Optionally, you can pass `subject`, `text` and `sharePositionOrigin`.
 
 ```dart
 final result = await Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -49,11 +49,22 @@ sharing to email.
 Share.share('check out my website https://example.com', subject: 'Look what I made!');
 ```
 
-To share one or multiple files invoke the static `shareFiles` method anywhere in your Dart code. Optionally you can also pass in `text` and `subject`.
+To share one or multiple files invoke the static `shareXFiles` method anywhere in your Dart code and it'll return the `ShareResult`. Optionally you can also pass in `text` and `subject`.
 
 ```dart
-Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
-Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
+final result = await Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
+
+if (result.status == ShareResultStatus.dismissed) {
+    print('did you not like the picture with text?');
+}
+```
+
+```dart
+final result = await  Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
+
+if (result.status == ShareResultStatus.dismissed) {
+    print('did you not like the pictures?');
+}
 ```
 
 On web you can use `SharePlus.shareXFiles()`. This uses the [Web Share API](https://web.dev/web-share/)

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -49,25 +49,36 @@ sharing to email.
 Share.share('check out my website https://example.com', subject: 'Look what I made!');
 ```
 
-To share one or multiple files invoke the static `shareXFiles` method anywhere in your Dart code and it'll return the `ShareResult`. Optionally you can also pass in `text` and `subject`.
+If you are interested in the action your user performed with the share sheet, you can instead use the `shareWithResult` method.
+
+```dart
+final result = await Share.shareWithResult('check out my website https://example.com');
+
+if (result.status == ShareResultStatus.success) {
+    print('Thank you for sharing my website!');
+}
+```
+
+To share one or multiple files invoke the static `shareXFiles` method anywhere in your Dart code, which returns a `ShareResult`. Optionally you can pass `subject`, `text` and `sharePositionOrigin`.
 
 ```dart
 final result = await Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
 
-if (result.status == ShareResultStatus.dismissed) {
-    print('did you not like the picture with text?');
+if (result.status == ShareResultStatus.success) {
+    print('Thank you for sharing the picture!');
 }
 ```
 
 ```dart
-final result = await  Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
+final result = await Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
 
 if (result.status == ShareResultStatus.dismissed) {
-    print('did you not like the pictures?');
+    print('Did you not like the pictures?');
 }
 ```
 
-On web you can use `SharePlus.shareXFiles()`. This uses the [Web Share API](https://web.dev/web-share/)
+
+On web, you can use `SharePlus.shareXFiles()`. This uses the [Web Share API](https://web.dev/web-share/)
 if it's available. Otherwise it falls back to downloading the shared files.
 See [Can I Use - Web Share API](https://caniuse.com/web-share) to understand
 which browsers are supported. This builds on the [`cross_file`](https://pub.dev/packages/cross_file)


### PR DESCRIPTION
## Description

- Removed deprecated method `shareFiles` usage from the document.

## Related Issues

- fixes #1906 

## Checklist

- [X] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.

