### PR TITLE
sensor_plus_platform_interface에 game rotation vector 추가

### DIFF
--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/sensors_plus_platform_interface.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/sensors_plus_platform_interface.dart
@@ -8,6 +8,7 @@ import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:sensors_plus_platform_interface/src/method_channel_sensors.dart';
 
 import 'src/accelerometer_event.dart';
+import 'src/game_rotation_vector_event.dart';
 import 'src/gyroscope_event.dart';
 import 'src/magnetometer_event.dart';
 import 'src/user_accelerometer_event.dart';
@@ -57,5 +58,10 @@ abstract class SensorsPlatform extends PlatformInterface {
   /// A broadcast stream of events from the device magnetometer.
   Stream<MagnetometerEvent> get magnetometerEvents {
     throw UnimplementedError('magnetometerEvents has not been implemented.');
+  }
+
+  /// A broadcast stream of events from the device game rotation vector.
+  Stream<GameRotationVectorEvent> get gameRotationVectorEvent {
+    throw UnimplementedError('gameRotationVectorEvents has not been implemented.');
   }
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/game_rotation_vector_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/game_rotation_vector_event.dart
@@ -1,0 +1,28 @@
+/// A sensor sample from a game rotation vector.
+///
+/// Identical to Sensor.TYPE_ROTATION_VECTOR except that it doesn't use the
+/// geomagnetic field. Therefore the Y axis doesn't point north, but instead
+/// to some other reference, that reference is allowed to drift by the same
+/// order of magnitude as the gyroscope drift around the Z axis.
+///
+/// In the ideal case, a phone rotated and returning to the same real-world
+/// orientation will report the same game rotation vector (without using the
+/// earth's geomagnetic field). However, the orientation may drift somewhat
+/// over time. See Sensor.TYPE_ROTATION_VECTOR for a detailed description
+/// of the values. This sensor will not have the estimated heading accuracy
+/// value.
+///
+/// A compass is an example of a general utility for gameRotationVector data.
+class GameRotationVectorEvent {
+  /// Constructs a new instance with the given [x], [y], [z] and [w] values.
+  ///
+  /// See [GameRotationVectorEvent] for more information.
+  GameRotationVectorEvent(this.x, this.y, this.z, this.w);
+
+  /// The ambient magnetic field in this axis surrounding the sensor in
+  /// microteslas ***μT***.
+  final double x, y, z, w;
+
+  @override
+  String toString() => '[GameRotationVectorEvent (x: $x, y: $y, z: $z, w: $w)]';
+}

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/method_channel_sensors.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/method_channel_sensors.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 import 'package:sensors_plus_platform_interface/sensors_plus_platform_interface.dart';
+import 'package:sensors_plus_platform_interface/src/game_rotation_vector_event.dart';
 
 /// A method channel -based implementation of the SensorsPlatform interface.
 class MethodChannelSensors extends SensorsPlatform {
@@ -21,10 +22,14 @@ class MethodChannelSensors extends SensorsPlatform {
   static const EventChannel _magnetometerEventChannel =
       EventChannel('dev.fluttercommunity.plus/sensors/magnetometer');
 
+  static const EventChannel _gameRotationVectorEventChannel =
+  EventChannel('dev.fluttercommunity.plus/sensors/gameRotationVector');
+
   Stream<AccelerometerEvent>? _accelerometerEvents;
   Stream<GyroscopeEvent>? _gyroscopeEvents;
   Stream<UserAccelerometerEvent>? _userAccelerometerEvents;
   Stream<MagnetometerEvent>? _magnetometerEvents;
+  Stream<GameRotationVectorEvent>? _gameRotationVectorEvents;
 
   /// A broadcast stream of events from the device accelerometer.
   @override
@@ -70,5 +75,16 @@ class MethodChannelSensors extends SensorsPlatform {
       return MagnetometerEvent(list[0]!, list[1]!, list[2]!);
     });
     return _magnetometerEvents!;
+  }
+
+  /// A broadcast stream of events from the device magnetometer.
+  @override
+  Stream<GameRotationVectorEvent> get gameRotationVectorEvent {
+    _gameRotationVectorEvents ??=
+        _gameRotationVectorEventChannel.receiveBroadcastStream().map((dynamic event) {
+          final list = event.cast<double>();
+          return GameRotationVectorEvent(list[0]!, list[1]!, list[2]!,list[3]!);
+        });
+    return _gameRotationVectorEvents!;
   }
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: sensors_plus_platform_interface
-description: A common platform interface for the sensors_plus plugin.
-version: 1.1.3
+description: A common platform interface for the sensors_plus plugin. add game rotation vector
+version: 1.1.4
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

Add objects necessary to use the game rotation vector.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.*

*e.g.*
- *Fix #123*
- *Related #456*

## Checklist

- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

