### PR TITLE
feat(package_info_plus): Added toMap method

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -121,22 +121,14 @@ class PackageInfo {
   }
 
   Map<String, dynamic> _toMap() {
-    final values = <String, dynamic>{
+    return {
       'appName': appName,
       'buildNumber': buildNumber,
       'packageName': packageName,
       'version': version,
+      if (buildSignature.isNotEmpty) 'buildSignature': buildSignature,
+      if (installerStore?.isNotEmpty ?? false) 'installerStore': installerStore,
     };
-
-    if (buildSignature.isNotEmpty) {
-      values['buildSignature'] = buildSignature;
-    }
-
-    if (installerStore != null && installerStore!.isNotEmpty) {
-      values['installerStore'] = installerStore;
-    }
-
-    return values;
   }
 
   /// Gets a map representation of the [PackageInfo] instance.

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -119,4 +119,20 @@ class PackageInfo {
   String toString() {
     return 'PackageInfo(appName: $appName, buildNumber: $buildNumber, packageName: $packageName, version: $version, buildSignature: $buildSignature, installerStore: $installerStore)';
   }
+
+  /// Gets a map representation of the [PackageInfo] instance.
+  ///
+  /// This getter makes use of the [_toMap] method to obtain a map
+  /// representation of this instance.
+
+  Map<String, dynamic> toMap() {
+    return {
+      'appName': appName,
+      'buildNumber': buildNumber,
+      'packageName': packageName,
+      'version': version,
+      'buildSignature': buildSignature,
+      'installerStore': installerStore,
+    };
+  }
 }

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -127,7 +127,7 @@ class PackageInfo {
       'buildNumber': buildNumber,
       'packageName': packageName,
       'version': version,
-    }
+    };
 
     if (buildSignature.isNotEmpty) {
       values['buildSignature'] = buildSignature;

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -129,11 +129,11 @@ class PackageInfo {
       'version': version,
     }
 
-    if (buildSignature != null && buildSignature.isNotEmpty) {
+    if (buildSignature.isNotEmpty) {
       values['buildSignature'] = buildSignature;
     }
 
-    if (installerStore != null && installerStore.isNotEmpty) {
+    if (installerStore != null && installerStore!.isNotEmpty) {
       values['installerStore'] = installerStore;
     }
 

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -121,18 +121,22 @@ class PackageInfo {
   }
 
   /// Gets a map representation of the [PackageInfo] instance.
-  ///
-  /// This getter makes use of the [_toMap] method to obtain a map
-  /// representation of this instance.
-
   Map<String, dynamic> toMap() {
-    return {
+    Map<String, dynamic> values = {
       'appName': appName,
       'buildNumber': buildNumber,
       'packageName': packageName,
       'version': version,
-      'buildSignature': buildSignature,
-      'installerStore': installerStore,
-    };
+    }
+
+    if (buildSignature != null && buildSignature.isNotEmpty) {
+      values['buildSignature'] = buildSignature;
+    }
+
+    if (installerStore != null && installerStore.isNotEmpty) {
+      values['installerStore'] = installerStore;
+    }
+
+    return values;
   }
 }

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -120,8 +120,7 @@ class PackageInfo {
     return 'PackageInfo(appName: $appName, buildNumber: $buildNumber, packageName: $packageName, version: $version, buildSignature: $buildSignature, installerStore: $installerStore)';
   }
 
-  /// Gets a map representation of the [PackageInfo] instance.
-  Map<String, dynamic> toMap() {
+  Map<String, dynamic> _toMap() {
     final values = <String, dynamic>{
       'appName': appName,
       'buildNumber': buildNumber,
@@ -139,4 +138,7 @@ class PackageInfo {
 
     return values;
   }
+
+  /// Gets a map representation of the [PackageInfo] instance.
+  Map<String, dynamic> get data => _toMap();
 }

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -122,7 +122,7 @@ class PackageInfo {
 
   /// Gets a map representation of the [PackageInfo] instance.
   Map<String, dynamic> toMap() {
-    Map<String, dynamic> values = {
+    final values = <String, dynamic>{
       'appName': appName,
       'buildNumber': buildNumber,
       'packageName': packageName,

--- a/packages/package_info_plus/package_info_plus/test/package_info_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_test.dart
@@ -12,7 +12,8 @@ void main() {
   const channel = MethodChannel('dev.fluttercommunity.plus/package_info');
   final log = <MethodCall>[];
 
-  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+      .setMockMethodCallHandler(
     channel,
     (MethodCall methodCall) async {
       log.add(methodCall);
@@ -50,7 +51,8 @@ void main() {
       ],
     );
   }, onPlatform: {
-    'linux': const Skip('PackageInfoPlus on Linux does not use platform channels'),
+    'linux':
+        const Skip('PackageInfoPlus on Linux does not use platform channels'),
   });
 
   test('Mock initial values', () async {

--- a/packages/package_info_plus/package_info_plus/test/package_info_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_test.dart
@@ -12,8 +12,7 @@ void main() {
   const channel = MethodChannel('dev.fluttercommunity.plus/package_info');
   final log = <MethodCall>[];
 
-  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-      .setMockMethodCallHandler(
+  TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
     channel,
     (MethodCall methodCall) async {
       log.add(methodCall);
@@ -51,8 +50,7 @@ void main() {
       ],
     );
   }, onPlatform: {
-    'linux':
-        const Skip('PackageInfoPlus on Linux does not use platform channels'),
+    'linux': const Skip('PackageInfoPlus on Linux does not use platform channels'),
   });
 
   test('Mock initial values', () async {
@@ -75,51 +73,91 @@ void main() {
 
   test('equals checks for value equality', () async {
     final info1 = PackageInfo(
-        appName: 'package_info_example',
-        buildNumber: '1',
-        packageName: 'io.flutter.plugins.packageinfoexample',
-        version: '1.0',
-        buildSignature: '',
-        installerStore: null);
+      appName: 'package_info_example',
+      buildNumber: '1',
+      packageName: 'io.flutter.plugins.packageinfoexample',
+      version: '1.0',
+      buildSignature: '',
+      installerStore: null,
+    );
     final info2 = PackageInfo(
-        appName: 'package_info_example',
-        buildNumber: '1',
-        packageName: 'io.flutter.plugins.packageinfoexample',
-        version: '1.0',
-        buildSignature: '',
-        installerStore: null);
+      appName: 'package_info_example',
+      buildNumber: '1',
+      packageName: 'io.flutter.plugins.packageinfoexample',
+      version: '1.0',
+      buildSignature: '',
+      installerStore: null,
+    );
     expect(info1, info2);
   });
 
   test('hashCode checks for value equality', () async {
     final info1 = PackageInfo(
-        appName: 'package_info_example',
-        buildNumber: '1',
-        packageName: 'io.flutter.plugins.packageinfoexample',
-        version: '1.0',
-        buildSignature: '',
-        installerStore: null);
+      appName: 'package_info_example',
+      buildNumber: '1',
+      packageName: 'io.flutter.plugins.packageinfoexample',
+      version: '1.0',
+      buildSignature: '',
+      installerStore: null,
+    );
     final info2 = PackageInfo(
-        appName: 'package_info_example',
-        buildNumber: '1',
-        packageName: 'io.flutter.plugins.packageinfoexample',
-        version: '1.0',
-        buildSignature: '',
-        installerStore: null);
+      appName: 'package_info_example',
+      buildNumber: '1',
+      packageName: 'io.flutter.plugins.packageinfoexample',
+      version: '1.0',
+      buildSignature: '',
+      installerStore: null,
+    );
     expect(info1.hashCode, info2.hashCode);
   });
 
   test('toString returns a string representation', () async {
     final info = PackageInfo(
-        appName: 'package_info_example',
-        buildNumber: '1',
-        packageName: 'io.flutter.plugins.packageinfoexample',
-        version: '1.0',
-        buildSignature: '',
-        installerStore: null);
+      appName: 'package_info_example',
+      buildNumber: '1',
+      packageName: 'io.flutter.plugins.packageinfoexample',
+      version: '1.0',
+      buildSignature: '',
+      installerStore: null,
+    );
     expect(
       info.toString(),
       'PackageInfo(appName: package_info_example, buildNumber: 1, packageName: io.flutter.plugins.packageinfoexample, version: 1.0, buildSignature: , installerStore: null)',
     );
+  });
+
+  test('data returns a map representation', () async {
+    PackageInfo.setMockInitialValues(
+      appName: 'mock_package_info_example',
+      packageName: 'io.flutter.plugins.mockpackageinfoexample',
+      version: '1.1',
+      buildNumber: '2',
+      buildSignature: '',
+      installerStore: null,
+    );
+    final info1 = await PackageInfo.fromPlatform();
+    expect(info1.data, {
+      'appName': 'mock_package_info_example',
+      'packageName': 'io.flutter.plugins.mockpackageinfoexample',
+      'version': '1.1',
+      'buildNumber': '2',
+    });
+    PackageInfo.setMockInitialValues(
+      appName: 'mock_package_info_example',
+      packageName: 'io.flutter.plugins.mockpackageinfoexample',
+      version: '1.1',
+      buildNumber: '2',
+      buildSignature: 'deadbeef',
+      installerStore: 'testflight',
+    );
+    final info2 = await PackageInfo.fromPlatform();
+    expect(info2.data, {
+      'appName': 'mock_package_info_example',
+      'packageName': 'io.flutter.plugins.mockpackageinfoexample',
+      'version': '1.1',
+      'buildNumber': '2',
+      'buildSignature': 'deadbeef',
+      'installerStore': 'testflight',
+    });
   });
 }


### PR DESCRIPTION
## Description

This PR adds a `toMap()` function to the `PackageInfo` class in the `package_info_plus` plugin. Previously, this functionality was missing. The `toMap()` function returns a map representation of the `PackageInfo` instance. Notably, the `buildSignature` and `installerStore` fields are included in the map only if they are non-null and non-empty. This change ensures that the returned map only contains meaningful and useful data.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

