### PR TITLE
chore(all): Fix lint, cleanup .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,4 +53,3 @@ build/
 **/*.env
 
 lcov.info
-pubspec_overrides.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,3 @@ build/
 
 lcov.info
 pubspec_overrides.yaml
-!/pubspec.lock

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,4 +4,5 @@ environment:
   sdk: ">=2.18.0 <4.0.0"
 
 dev_dependencies:
+  flutter_lints: ^2.0.1
   melos: ^3.1.0


### PR DESCRIPTION
## Description

- Add `flutter_lints` to `pubspec.yaml` to get rid of a lint:
<img width="1013" alt="Screenshot 2023-06-26 at 08 53 40" src="https://github.com/fluttercommunity/plus_plugins/assets/43643339/5bcaf8f8-44f1-4971-92ed-490fcdf14cea">

- Remove `pubspec_overrides.yaml` from `.gitignore`, which was added in https://github.com/fluttercommunity/plus_plugins/pull/1619

- Remove exemption that keeps `pubspec.lock`, which was introduced in https://github.com/fluttercommunity/plus_plugins/pull/1686, but the `pubspec.lock` was deleted in https://github.com/fluttercommunity/plus_plugins/pull/1772 with the reason https://dart.dev/guides/libraries/private-files#pubspeclock (at the moment, calling pub get in the root folder adds the lockfile newly to git - so either add it, or remove the exemption):
<img width="150" alt="Screenshot 2023-06-26 at 08 54 06" src="https://github.com/fluttercommunity/plus_plugins/assets/43643339/ef2959d7-74dc-43a8-9972-8f85cae17a45">

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

