### PR TITLE
chore(deps): Update share_plus example

### DIFF
--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -58,7 +58,7 @@ class DemoAppState extends State<DemoApp> {
                 decoration: const InputDecoration(
                   border: OutlineInputBorder(),
                   labelText: 'Share text',
-                  hintText: 'Enter some text and/or link to share',
+                  hintText: 'Enter some text to share',
                 ),
                 maxLines: null,
                 onChanged: (String value) => setState(() {

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -5,7 +5,7 @@ dependencies:
   flutter:
     sdk: flutter
   share_plus: ^7.0.1
-  image_picker: ^1.0.0
+  image_picker: '>=0.8.9 <2.0.0'
   file_selector: ^0.9.2+4
 
 dev_dependencies:


### PR DESCRIPTION
## Description

Switched to a wider range of supported `image_picker` versions in share_plus example app as suggested in https://github.com/flutter/packages/blob/main/packages/image_picker/image_picker/CHANGELOG.md#100

Additionally did a small modification for example's text field hints.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

