### PR TITLE
fix(connectivity_plus): Downgrade js version to work with Flutter 3.3.10

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   connectivity_plus_platform_interface: ^1.2.4
-  js: ^0.6.5
+  js: ^0.6.4
   meta: ^1.8.0
   nm: ^0.5.0
 
@@ -42,7 +42,7 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.3.3
   dbus: ^0.7.8
-  flutter_lints: ^2.0.1
+  flutter_lints: ^2.0.2
   mockito: ^5.4.0
-  plugin_platform_interface: ^2.1.4
+  plugin_platform_interface: ^2.1.5
   test: ^1.22.0


### PR DESCRIPTION
## Description

Made the plugin use older `js` version as there were issues with compatibility for older Flutter versions as reported in #1960

## Related Issues

Fixes #1960

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

