### PR TITLE
fix(package_info_plus): proper version.json url for files with special characters

### DIFF
--- a/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_web_test.dart
+++ b/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_web_test.dart
@@ -139,6 +139,16 @@ void main() {
             plugin.versionJsonUrl('https://example.com/a/b/c/wrapper.html', 1),
             Uri.parse('https://example.com/a/b/c/version.json?cachebuster=1'),
           );
+          expect(
+            plugin.versionJsonUrl(
+                'https://example.com/my-special-file.html', 1),
+            Uri.parse('https://example.com/version.json?cachebuster=1'),
+          );
+          expect(
+            plugin.versionJsonUrl(
+                'https://example.com/a/b/c/my-special-file.html', 1),
+            Uri.parse('https://example.com/a/b/c/version.json?cachebuster=1'),
+          );
         },
       );
 

--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
@@ -23,7 +23,7 @@ class PackageInfoPlusWebPlugin extends PackageInfoPlatform {
   /// Get version.json full url.
   Uri versionJsonUrl(String baseUrl, int cacheBuster) {
     final baseUri = Uri.parse(baseUrl);
-    final regExp = RegExp(r'\w+\.html.*');
+    final regExp = RegExp(r'[^/]+\.html.*');
     final originPath =
         '${baseUri._origin}${baseUri.path.replaceAll(regExp, '')}';
     final versionJson = 'version.json?cachebuster=$cacheBuster';


### PR DESCRIPTION
## Description

Changes the regex that matches the URL for the version.json path generation.
The previous regex did not correctly recognize non-word characters in URLs and created a wrong version.json path.

## Related Issues

- *Fix #1891*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

