### PR TITLE
feat(connectivity_plus): Remove deprecated VALID_ARCHS iOS property

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus.podspec
+++ b/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus.podspec
@@ -20,5 +20,5 @@ Downloaded by pub (not CocoaPods).
   s.dependency 'ReachabilitySwift'
   s.platform = :ios, '11.0'
   s.swift_version = '5.0'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end


### PR DESCRIPTION
## Description

~~Found out that some plugins have explicit exception to only allow x86_64 arches which didn't allow to run builds on ARM Macs natively.
Note, I currently don't have any ARM Mac to validate that this doesn't break anything, so would appreciate checking out if iOS builds correctly after this change.~~

Removed deprecated iOS build config property.

## Related Issues

#1467

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

