### PR TITLE
feat(device_info_plus): Remove deprecated VALID_ARCHS iOS property

### DIFF
--- a/packages/device_info_plus/device_info_plus/ios/device_info_plus.podspec
+++ b/packages/device_info_plus/device_info_plus/ios/device_info_plus.podspec
@@ -18,6 +18,6 @@ Downloaded by pub (not CocoaPods).
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.platform = :ios, '11.0'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end
 


### PR DESCRIPTION
## Description

~~Found out that some plugins have explicit exception to only allow x86_64 arches which didn't allow to run builds on ARM Macs natively.
Note, I currently don't have any ARM Mac to validate that this doesn't break anything, so would appreciate checking out if iOS builds correctly after this change.~~

Removed deprecated properties.

## Related Issues

#1467

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

