### PR TITLE
feat(package_info_plus): Remove deprecated VALID_ARCHS iOS property

### DIFF
--- a/packages/package_info_plus/package_info_plus/ios/package_info_plus.podspec
+++ b/packages/package_info_plus/package_info_plus/ios/package_info_plus.podspec
@@ -15,6 +15,6 @@ Downloaded by pub (not CocoaPods).
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.platform = :ios, '11.0'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
 end


### PR DESCRIPTION
## Description

Same as #2022 

## Related Issues

#1467 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

