### PR TITLE
feat(share_plus): Remove deprecated VALID_ARCHS iOS property

### DIFF
--- a/packages/share_plus/share_plus/ios/share_plus.podspec
+++ b/packages/share_plus/share_plus/ios/share_plus.podspec
@@ -20,6 +20,6 @@ Downloaded by pub (not CocoaPods).
   s.ios.weak_framework = 'LinkPresentation'
 
   s.platform = :ios, '11.0'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end
 


### PR DESCRIPTION
## Description

Same as #2023 

## Related Issues

#1467

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

