### PR TITLE
feat(sensors_plus): Remove deprecated VALID_ARCHS iOS property

### DIFF
--- a/packages/sensors_plus/sensors_plus/ios/sensors_plus.podspec
+++ b/packages/sensors_plus/sensors_plus/ios/sensors_plus.podspec
@@ -18,5 +18,5 @@ Flutter plugin to access the accelerometer, gyroscope, and magnetometer sensors.
   s.dependency 'Flutter'
 
   s.platform = :ios, '11.0'
-  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end


### PR DESCRIPTION
## Description

Same as rest of ARM related PRs today

## Related Issues

#1467 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

