### PR TITLE
fix(device_info_plus): Update exports to avoid web compatibility issues

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/device_info_plus.dart
+++ b/packages/device_info_plus/device_info_plus/lib/device_info_plus.dart
@@ -25,7 +25,8 @@ export 'src/model/macos_device_info.dart';
 export 'src/model/web_browser_info.dart';
 export 'src/model/windows_device_info.dart';
 
-export 'src/device_info_plus_linux.dart';
+export 'src/device_info_plus_linux.dart'
+    if (dart.library.html) 'src/device_info_plus_web.dart';
 export 'src/device_info_plus_windows.dart'
     if (dart.library.html) 'src/device_info_plus_web.dart';
 


### PR DESCRIPTION
## Description

According to #1651 `device_info_plus` might cause some analyzer issues to other packages which use the plugin. After looking at code it looks like we already had a conditional export for windows part, so this PR adds the same condition to linux part to be sure that there are no unsupported libraries used for web (at least from package analyzer point of view). 

## Related Issues

Fixes #1651 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

