### PR TITLE
docs(package_info_plus): Add explanation for known issue on Windows

### DIFF
--- a/docs/package_info_plus/usage.mdx
+++ b/docs/package_info_plus/usage.mdx
@@ -55,3 +55,10 @@ See [CFBundleVersion docs](https://developer.apple.com/documentation/bundleresou
 
 Calling to `PackageInfo.fromPlatform()` before the `runApp()` call will cause an exception.
 See https://github.com/fluttercommunity/plus_plugins/issues/309
+
+### Windows
+
+#### Plugin returns wrong version
+
+There was an [issue](https://github.com/flutter/flutter/issues/73652) in Flutter, which is already resolved since Flutter 3.3.
+If your project was created before Flutter 3.3 you need to migrate the project according to [this guide] (https://docs.flutter.dev/release/breaking-changes/windows-version-information) first to get correct version with `package_info_plus`

--- a/packages/package_info_plus/package_info_plus/README.md
+++ b/packages/package_info_plus/package_info_plus/README.md
@@ -64,6 +64,13 @@ string in `pubspec.yaml`. Clean the Xcode build folder with:
 Calling to `PackageInfo.fromPlatform()` before the `runApp()` call will cause an exception.
 See https://github.com/fluttercommunity/plus_plugins/issues/309
 
+### Windows
+
+#### I see wrong version on Windows platform
+
+There was an [issue](https://github.com/flutter/flutter/issues/73652) in Flutter, which is already resolved since Flutter 3.3.
+If your project was created before Flutter 3.3 you need to migrate the project according to [this guide] (https://docs.flutter.dev/release/breaking-changes/windows-version-information) first to get correct version with `package_info_plus`
+
 ## Learn more
 
 - [API Documentation](https://pub.dev/documentation/package_info_plus/latest/package_info_plus/package_info_plus-library.html)


### PR DESCRIPTION
## Description

Added explanation on why sometimes users might get wrong version from the `package_info_plus` plugins on Windows. More info available in #343.

## Related Issues

Closes #343

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

