### PR TITLE
ci(all): Update Java to 17

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart

--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart


### PR DESCRIPTION
## Description

Bumping Java version for all example build jobs to support upgrade to Gradle 8, so there are no issues like: https://github.com/fluttercommunity/plus_plugins/actions/runs/5923071232/job/16058055161?pr=2010

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

