### PR TITLE
chore(all): Adjust dependabot settings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,22 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
+  - package-ecosystem: "gradle"
+    directory: "/packages/android_alarm_manager_plus/android"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/android_alarm_manager_plus/example/android"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
   - package-ecosystem: "pub"
     directory: "/packages/android_alarm_manager_plus/example"
     schedule:
@@ -71,6 +87,22 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/android_intent_plus/android"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/android_intent_plus/example/android"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   # Battery Plus dependencies updates config
 
@@ -157,6 +189,22 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/connectivity_plus/connectivity_plus/android"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "gradle"
+    directory: "/packages/connectivity_plus/connectivity_plus/example/android"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
 
   # Device Info Plus dependencies updates config
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,7 +18,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/website"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     commit-message:
       prefix: "chore"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,6 +33,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/android_alarm_manager_plus/example"
@@ -41,6 +44,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   # Android Intent Plus dependencies updates config
 
@@ -51,6 +57,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/android_intent_plus/example"
@@ -59,6 +68,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   # Battery Plus dependencies updates config
 
@@ -69,6 +81,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/battery_plus/battery_plus/example"
@@ -77,6 +92,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/battery_plus/battery_plus_platform_interface"
@@ -85,6 +103,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "gradle"
     directory: "/packages/battery_plus/battery_plus/android"
@@ -111,6 +132,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/connectivity_plus/connectivity_plus/example"
@@ -119,6 +143,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/connectivity_plus/connectivity_plus_platform_interface"
@@ -127,6 +154,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   # Device Info Plus dependencies updates config
 
@@ -137,6 +167,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/device_info_plus/device_info_plus/example"
@@ -145,6 +178,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/device_info_plus/device_info_plus_platform_interface"
@@ -153,6 +189,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "gradle"
     directory: "/packages/device_info_plus/device_info_plus/android"
@@ -179,6 +218,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/network_info_plus/network_info_plus/example"
@@ -187,6 +229,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/network_info_plus/network_info_plus_platform_interface"
@@ -195,6 +240,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "gradle"
     directory: "/packages/network_info_plus/network_info_plus/android"
@@ -221,6 +269,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/package_info_plus/package_info_plus/example"
@@ -229,6 +280,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/package_info_plus/package_info_plus_platform_interface"
@@ -237,6 +291,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "gradle"
     directory: "/packages/package_info_plus/package_info_plus/android"
@@ -263,6 +320,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/sensors_plus/sensors_plus/example"
@@ -271,6 +331,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/sensors_plus/sensors_plus_platform_interface"
@@ -279,6 +342,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "gradle"
     directory: "/packages/sensors_plus/sensors_plus/android"
@@ -305,6 +371,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/share_plus/share_plus/example"
@@ -313,6 +382,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "pub"
     directory: "/packages/share_plus/share_plus_platform_interface"
@@ -321,6 +393,9 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "gradle"
     directory: "/packages/share_plus/share_plus/android"


### PR DESCRIPTION
## Description

As partly discussed in [this PR](https://github.com/fluttercommunity/plus_plugins/pull/1989#issuecomment-1655610449).

## Related Issues

Our dependabot update policy continuously tightens the constraints, updating every single patch release - making the latest versions of plus_plugins less compatible with the rest of the ecosystem.

I'll just open this PR and leave it to discussion whether any included changes make sense for `plug_plugins`.

Following the changes plus my understanding of the benefit:
1. Ignore dependabot pub updates for minor and patch releases:
If a plugin declares a dependency x of `1.0.0`, it's potentially compatible with version `1.0.0` up to `<2.0.0` and apps using the same dependency itself, or other packages using it (within the range `>=1.0.0 <2.0.0`). Updating to i.e. `1.2.4` tightens the constraints of all apps and packages using the plugin, making it less compatible with other packages, while bringing no benefit other than forcing users or other package maintainers to update their dependencies, which should not be our goal (unless there is an incompatibility with an older version, in which case the dependency should be manually updated to exclude lower versions).
2. Change the website dependency check from `weekly` to `monthly`. Idk if the overhead of almost weekly updating a lint dependency for the website brings a benefit.
3. Add dependabot gradle checks (please let me know if they were missing for a reason).

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

