### PR TITLE
ci(all): Update Java version for integration tests, update Android APIs

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [21, 26, 32]
+        android-api-level: [22, 26, 31]
 
     steps:
       - name: "Checkout repository"
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"

--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 21, 26, 32 ]
+        android-api-level: [ 22, 26, 31 ]
 
     steps:
       - name: "Checkout repository"
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 21, 26, 32 ]
+        android-api-level: [ 22, 26, 31 ]
 
     steps:
       - name: "Checkout repository"
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 22, 26, 31 ]
+        android-api-level: [ 21, 26, 31 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 21, 26, 32 ]
+        android-api-level: [ 22, 26, 31 ]
 
     steps:
       - name: "Checkout repository"
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 21, 26, 32 ]
+        android-api-level: [ 22, 26, 31 ]
 
     steps:
       - name: "Checkout repository"
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 21, 26, 32 ]
+        android-api-level: [ 22, 26, 31 ]
 
     steps:
       - name: "Checkout repository"
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 21, 26, 32 ]
+        android-api-level: [ 22, 26, 31 ]
 
     steps:
       - name: "Checkout repository"
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
@@ -43,7 +43,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 21, 26, 32 ]
+        android-api-level: [ 22, 26, 31 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -47,7 +47,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 21, 26, 32 ]
+        android-api-level: [ 22, 26, 31 ]
 
     steps:
       - name: "Checkout repository"
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           distribution: "temurin"
-          java-version: "11"
+          java-version: "17"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"


### PR DESCRIPTION
## Description

I missed the fact that Java version is set in 2 places in workflow files and didn't update Java for integration tests in #2055

Additionally I looked at a few other repos that use Android emulators Action that we use and found out that a few of such repos identify 21 and 32 as flaky emulators, which is something we often experience ourselves. As a result I changed min Android API to 22 and max to 31 in attempt to get lower number of failed CI tests due to flakiness of some emulators.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

