### PR TITLE
ci(android_intent_plus): Remove Java installation step

### DIFF
--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -29,12 +29,6 @@ jobs:
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
-      # Required for Android builds
-      - uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
@@ -52,12 +46,6 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
-
-      # Required for Android builds
-      - uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "17"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"


### PR DESCRIPTION
## Description

According to Github documentation `macos-13` machine should already have Java 17 installed: https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md#java
Thus, I am curious if we can drop installation step in order to save a few seconds during workflow runs. In case this PR doesn't fail I will open similar ones for other plugins workflows.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

