### PR TITLE
ci(android_alarm_manager): Remove Java installation step

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -28,13 +28,7 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
-
-        # Required for Android builds
-      - uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "17"
-
+        
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
@@ -52,12 +46,6 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
-
-        # Required for Android builds
-      - uses: actions/setup-java@v3
-        with:
-          distribution: "temurin"
-          java-version: "17"
 
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"


### PR DESCRIPTION
## Description

Same as #2092 
Will open a series of PRs to not wait CI runs for too long.