### PR TITLE
docs(share_plus): Fix usage code snippets

### DIFF
--- a/docs/share_plus/usage.mdx
+++ b/docs/share_plus/usage.mdx
@@ -42,7 +42,7 @@ if (result.status == ShareResultStatus.success) {
 To share one or multiple files, invoke the static `shareXFiles` method anywhere in your Dart code. The method returns a `ShareResult`. Optionally, you can pass `subject`, `text` and `sharePositionOrigin`.
 
 ```dart
-final result = await Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
+final result = await Share.shareXFiles(['XFile(${directory.path}/image.jpg')], text: 'Great picture');
 
 if (result.status == ShareResultStatus.success) {
     print('Thank you for sharing the picture!');
@@ -50,7 +50,7 @@ if (result.status == ShareResultStatus.success) {
 ```
 
 ```dart
-final result = await Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
+final result = await Share.shareXFiles(['XFile(${directory.path}/image1.jpg'), XFile('${directory.path}/image2.jpg')]);
 
 if (result.status == ShareResultStatus.dismissed) {
     print('Did you not like the pictures?');

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -62,7 +62,7 @@ if (result.status == ShareResultStatus.success) {
 To share one or multiple files, invoke the static `shareXFiles` method anywhere in your Dart code. The method returns a `ShareResult`. Optionally, you can pass `subject`, `text` and `sharePositionOrigin`.
 
 ```dart
-final result = await Share.shareXFiles(['${directory.path}/image.jpg'], text: 'Great picture');
+final result = await Share.shareXFiles([XFile('${directory.path}/image.jpg')], text: 'Great picture');
 
 if (result.status == ShareResultStatus.success) {
     print('Thank you for sharing the picture!');
@@ -70,7 +70,7 @@ if (result.status == ShareResultStatus.success) {
 ```
 
 ```dart
-final result = await Share.shareXFiles(['${directory.path}/image1.jpg', '${directory.path}/image2.jpg']);
+final result = await Share.shareXFiles([XFile('${directory.path}/image1.jpg'), XFile('${directory.path}/image2.jpg')]);
 
 if (result.status == ShareResultStatus.dismissed) {
     print('Did you not like the pictures?');


### PR DESCRIPTION
## Description

Saw that usage examples have invalid code snippets, so this PR fixes found issues both in README and on plugins website.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

