### PR TITLE
chore(package_info_plus): Change group name

### DIFF
--- a/packages/package_info_plus/package_info_plus/android/build.gradle
+++ b/packages/package_info_plus/package_info_plus/android/build.gradle
@@ -1,4 +1,4 @@
-group 'io.flutter.plugins.packageinfo'
+group 'dev.fluttercommunity.plus.packageinfo'
 version '1.0-SNAPSHOT'
 
 buildscript {


### PR DESCRIPTION
## Description

The group name is inconsistent with the name in `pubspec.yaml`, as well as the namespace and the folder structure in `android/src/main`.

Similar to https://github.com/fluttercommunity/plus_plugins/pull/2109.

## Related Issues

https://github.com/fluttercommunity/plus_plugins/issues/2091.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

