### PR TITLE
fix(android_alarm_manager_plus): Fix integration test

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -28,7 +28,7 @@ jobs:
         run: ./.github/workflows/scripts/install-flutter.sh stable
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
-        
+
       - name: "Build Example"
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
@@ -37,7 +37,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [22, 26, 31]
+        android-api-level: [21, 26, 31]
 
     steps:
       - name: "Checkout repository"


### PR DESCRIPTION
## Description

The integration test for the lower Android API level fails since it was recently changed from 21 to 22.

The test already failed in the [PR](https://github.com/fluttercommunity/plus_plugins/pull/2057) changing the version, and since then in [all](https://github.com/fluttercommunity/plus_plugins/actions/workflows/android_alarm_manager_plus.yaml) workflow runs using the new API level. In a current PR, the test failed [seven](https://github.com/fluttercommunity/plus_plugins/actions/runs/6020568481/job/16339956921?pr=2112) times in a row. Unless we find the actual cause, it makes sense to revert the API level change.

This PR changes the version to the one that worked fine before.

In the future, I would suggest only merging PRs with successful tests (if they worked before), so we limit regressions on `main` and fix the issue when it arises, which is easier than finding the cause afterwards and having issues in unrelated PRs.

This change was already included in https://github.com/fluttercommunity/plus_plugins/pull/2112 to check if it helps. Suggestion is to first merge this one, rebase, and merge the other one.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

