### PR TITLE
fix(connectivity_plus)!: Bump min iOS to 12 to support XCode 15

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/connectivity_plus/connectivity_plus/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/packages/connectivity_plus/connectivity_plus/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/connectivity_plus/connectivity_plus/example/ios/Runner.xcodeproj/project.pbxproj
@@ -105,7 +105,6 @@
 				CC3B43C8CED1D022483DD294 /* Pods-RunnerTests.release.xcconfig */,
 				AA3CF93A0B4C03146682AA3A /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -470,6 +469,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -648,6 +648,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -670,6 +671,7 @@
 				CURRENT_PROJECT_VERSION = "$(FLUTTER_BUILD_NUMBER)";
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = Runner/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus.podspec
+++ b/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus.podspec
@@ -18,7 +18,7 @@ Downloaded by pub (not CocoaPods).
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'ReachabilitySwift'
-  s.platform = :ios, '11.0'
+  s.platform = :ios, '12.0'
   s.swift_version = '5.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end


### PR DESCRIPTION
## Description

We have multiple bug reports about issues when `connectivity_plus` plugin is used in a project build with Xcode 15. Apparently, after some investigation found out that Xcode 15 supports [only iOS 12 and newer](https://developer.apple.com/documentation/xcode-release-notes/xcode-15-release-notes#Overview) and not all APIs work fine.
Here is an example of similar solution: https://stackoverflow.com/a/77151438/7339798
In order to support Xcode 15 I am bumping min iOS version for the plugin to 12, so users won't have to modify their build configs on iOS. 
Marking as a breaking change to be sure I don't break projects for somebody who still supports <12 iOS versions.

## Related Issues

Supposed to close quite a lot of issues:

Fixes #1955
Fixes #2136
Fixes #2154
Fixes #2155
Fixes #2159
Fixes #2162 
Fixes #2166 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

