### PR TITLE
chore(battery_plus): Update compileSDK for example app to 34

### DIFF
--- a/packages/battery_plus/battery_plus/example/android/app/build.gradle
+++ b/packages/battery_plus/battery_plus/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     namespace 'io.flutter.plugins.batteryexample.example'
 


### PR DESCRIPTION
## Description

Bumping compileSDK to 34 to merge #2175 and be on par with latest Android version.

## Related Issues

-

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

