### PR TITLE
chore(device_info_plus): Update compileSDK to 34 for example

### DIFF
--- a/packages/device_info_plus/device_info_plus/example/android/app/build.gradle
+++ b/packages/device_info_plus/device_info_plus/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     namespace 'io.flutter.plugins.deviceinfoexample.example'
 


### PR DESCRIPTION
## Description

Same as #2207 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

