### PR TITLE
chore(network_info_plus): Update compileSDK to 34 for example

### DIFF
--- a/packages/network_info_plus/network_info_plus/example/android/app/build.gradle
+++ b/packages/network_info_plus/network_info_plus/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     namespace 'dev.fluttercommunity.plus.network_info_plus_example'
 


### PR DESCRIPTION
## Description

Same as #2208 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

