### PR TITLE
chore: Update docs and commands for e2e tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,12 +28,12 @@ Ideally an expert in that platform will have to review the change to make sure i
 
 ### 🔴 Cannot be accepted
 
-- New features covering only one platform 
- 
-New features should cover at least the mobile platforms (Android and iOS) to be considered, 
+- New features covering only one platform
+
+New features should cover at least the mobile platforms (Android and iOS) to be considered,
 and a plan for the rest must be provided.
 
-- New plugins 
+- New plugins
 
 We don't have the capacity to accept new plugins.
 
@@ -123,19 +123,35 @@ flutter test
 E2e tests are those which directly communicate with Flutter, whose results cannot be mocked. **These tests run directly from
 an example application.**
 
-To run e2e tests, run the `flutter drive` command from the plugins main `example` directory, targeting the
-entry e2e test file.
+To run e2e tests, run the `flutter test` command from the plugins main `example` directory, and provide the path to the
+e2e test file. For example, to run the `sensors_plus` e2e tests:
+
+#### Mobile
 
 ```bash
 cd packages/sensors_plus/sensors_plus/example
-flutter drive --target=./test_driver/sensors_plus_e2e.dart
+flutter test integration_test/sensors_plus_test.dart
 ```
 
-To run tests against web environments, run the command as a release build:
+#### Web
+
+To run tests against web environments, you will need to have Chrome and ChromeDriver installed and use the `flutter drive` command.
+
+First start ChromeDriver on port 4444:
 
 ```bash
-cd packages/sensors_plus/sensors_plus/example
-flutter drive --target=./test_driver/sensors_plus_e2e.dart --release -d chrome
+chromedriver --port=4444
+```
+
+Then go to the `example` directory of the plugin you want to test and run the `flutter drive` command
+with the specific driver and `*_web_test.dart` target. For example, to run the `package_info_plus` web tests:
+
+```bash
+cd packages/package_info_plus/package_info_plus/example
+flutter drive \
+  --driver ./integration_test/driver.dart \
+  --target ./integration_test/package_info_plus_web_test.dart \
+  -d chrome
 ```
 
 ### Using Melos
@@ -273,4 +289,3 @@ Some things to keep in mind before publishing the release:
 9. After successful review and merge of the pull request, switch to main branch locally, & run `git pull origin main`.
 10. Run `melos publish --no-dry-run --git-tag-version` to now publish to Pub.dev.
 11. Run `git push --tags` to push tags to repository.
-

--- a/melos.yaml
+++ b/melos.yaml
@@ -177,19 +177,19 @@ scripts:
   test:mobile_e2e:
     run: |
       melos exec -c 1 --fail-fast -- \
-        "flutter drive --target=./test_driver/MELOS_PARENT_PACKAGE_NAME_e2e.dart"
+        "flutter test ./integration_test/MELOS_PARENT_PACKAGE_NAME_test.dart"
     description: |
       Run all Android or iOS test driver e2e tests in a specific example app.
       - Requires an Android emulator or iOS simulator.
     packageFilters:
       dirExists:
-        - test_driver
+        - integration_test
       scope: "*example*"
 
   test:web_e2e:
     run: |
       melos exec -c 1 --fail-fast -- \
-        "flutter drive --device-id=web-server --no-pub --target=./test_driver/MELOS_PARENT_PACKAGE_NAME_e2e.dart"
+        "flutter drive --device-id=web-server --no-pub --driver=./integration_test/driver.dart --target=./integration_test/MELOS_PARENT_PACKAGE_NAME_web_test.dart"
     description: |
       Run all Web test driver e2e tests in a specific example app.
        - Requires `flutter channel stable`.
@@ -197,13 +197,15 @@ scripts:
     packageFilters:
       dirExists:
         - web
-        - test_driver
+        - integration_test
+      fileExists:
+        - integration_test/driver.dart
       scope: "*example*"
 
   test:linux_e2e:
     run: |
       melos exec -c 1 --fail-fast -- \
-        "flutter drive -d linux --no-pub --target=./test_driver/MELOS_PARENT_PACKAGE_NAME_e2e.dart"
+        "flutter test -d linux ./integration_test/MELOS_PARENT_PACKAGE_NAME_test.dart"
     description: |
       Run all Linux test driver e2e tests in a specific example app.
        - Requires `flutter channel stable`.
@@ -211,13 +213,13 @@ scripts:
     packageFilters:
       dirExists:
         - linux
-        - test_driver
+        - integration_test
       scope: "*example*"
 
   test:macos_e2e:
     run: |
       melos exec -c 1 --fail-fast -- \
-        "flutter drive -d macos --no-pub --target=./test_driver/MELOS_PARENT_PACKAGE_NAME_e2e.dart"
+        "flutter test -d macos ./integration_test/MELOS_PARENT_PACKAGE_NAME_test.dart"
     description: |
       Run all MacOS test driver e2e tests in a specific example app.
        - Requires `flutter channel stable`.
@@ -225,7 +227,7 @@ scripts:
     packageFilters:
       dirExists:
         - macos
-        - test_driver
+        - integration_test
       scope: "*example*"
 
   # Coverage


### PR DESCRIPTION
## Description

Since the end-to-end tests migration from Flutter driver to integration tests, the documentation and local melos commands were not updated accordingly.

## Related Issues

- *Related #2217*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

