### PR TITLE
docs(device_info_plus): Add note about arch returned value on MacOS

### DIFF
--- a/packages/device_info_plus/device_info_plus/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/device_info_plus/device_info_plus/example/macos/Runner.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {

--- a/packages/device_info_plus/device_info_plus/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/device_info_plus/device_info_plus/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/device_info_plus/device_info_plus/lib/src/model/macos_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/macos_device_info.dart
@@ -31,6 +31,7 @@ class MacOsDeviceInfo extends BaseDeviceInfo {
   final String hostName;
 
   /// Machine cpu architecture
+  /// Note, that on Apple Silicon Macs can return `x86_64` if app runs via Rosetta
   final String arch;
 
   /// Device model

--- a/packages/device_info_plus/device_info_plus/macos/Classes/CwlSysctl.swift
+++ b/packages/device_info_plus/device_info_plus/macos/Classes/CwlSysctl.swift
@@ -115,29 +115,14 @@ public struct Sysctl {
 		return try string(for: keys(for: name))
 	}
 
-	/// e.g. "MyComputer.local" (from System Preferences -> Sharing -> Computer Name) or
-	/// "My-Name-iPhone" (from Settings -> General -> About -> Name)
+	/// e.g. "MyComputer.local" (from System Preferences -> Sharing -> Computer Name)
 	public static var hostName: String { return (try? Sysctl.string(for: [CTL_KERN, KERN_HOSTNAME])) ?? "" }
 
-	/// e.g. "x86_64" or "N71mAP"
-	/// NOTE: this is *corrected* on iOS devices to fetch hw.model
-	public static var machine: String {
-		#if os(iOS) && !arch(x86_64) && !arch(i386)
-			return (try? Sysctl.string(for: [CTL_HW, HW_MODEL])) ?? ""
-		#else
-			return (try? Sysctl.string(for: [CTL_HW, HW_MACHINE])) ?? ""
-		#endif
-	}
+	/// e.g. "x86_64" or "arm64"
+	public static var machine: String { return (try? Sysctl.string(for: [CTL_HW, HW_MACHINE])) ?? "" }
 
-	/// e.g. "MacPro4,1" or "iPhone8,1"
-	/// NOTE: this is *corrected* on iOS devices to fetch hw.machine
-	public static var model: String {
-		#if os(iOS) && !arch(x86_64) && !arch(i386)
-			return (try? Sysctl.string(for: [CTL_HW, HW_MACHINE])) ?? ""
-		#else
-			return (try? Sysctl.string(for: [CTL_HW, HW_MODEL])) ?? ""
-		#endif
-	}
+	/// e.g. "MacBookPro18,2"
+	public static var model: String { return (try? Sysctl.string(for: [CTL_HW, HW_MODEL])) ?? "" }
 
 	/// e.g. "8" or "2"
 	public static var activeCPUs: Int32 { return (try? Sysctl.value(ofType: Int32.self, forKeys: [CTL_HW, HW_AVAILCPU])) ?? 0 }


### PR DESCRIPTION
## Description

Added an explanation that for apps running via Rosetta `arch` parameter` can be `x86_64` to avoid confusion like happened in #2213. Additionally removed a few conditions to check iOS properties as code from `macos` folder won't even run for iOS target.

## Related Issues

#2213 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

