### PR TITLE
chore(github): Update templates to mention checkbox about searching through repository issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG.yaml
@@ -103,6 +103,8 @@ body:
       label: Checklist before submitting a bug
       description: Please verify all the following items before submitting a bug. All options must be selected.
       options:
+        - label: I searched issues in this repository and couldn't find such bug/problem
+          required: true
         - label: I Google'd a solution and I couldn't find it
           required: true
         - label: I searched on StackOverflow for a solution and I couldn't find it

--- a/.github/ISSUE_TEMPLATE/QUESTION.yaml
+++ b/.github/ISSUE_TEMPLATE/QUESTION.yaml
@@ -28,6 +28,8 @@ body:
       label: Checklist before submitting a question
       description: Please verify all the following items before submitting a question. All options must be selected.
       options:
+        - label: I searched issues in this repository and couldn't find such bug/problem
+          required: true
         - label: I Google'd a solution and I couldn't find it
           required: true
         - label: I searched on StackOverflow for a solution and I couldn't find it


### PR DESCRIPTION
## Description

Additional checkbox about searching through Github Issues in this repository first. I don't have high hopes for this change, but maybe it would improve situation a bit.
