### PR TITLE
fix(connectivity_plus): Revert bump compileSDK to 34

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.connectivity'
 

--- a/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
 
     namespace 'io.flutter.plugins.connectivityexample'
 

--- a/packages/connectivity_plus/connectivity_plus/example/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/example/android/build.gradle
@@ -24,6 +24,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
## Description

Same as #2228 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

