### PR TITLE
fix(sensors_plus): Revert bump compileSDK to 34

### DIFF
--- a/packages/sensors_plus/sensors_plus/android/build.gradle
+++ b/packages/sensors_plus/sensors_plus/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.sensors'
 

--- a/packages/sensors_plus/sensors_plus/example/android/app/build.gradle
+++ b/packages/sensors_plus/sensors_plus/example/android/app/build.gradle
@@ -26,13 +26,17 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
 
     namespace 'io.flutter.plugins.sensorsexample'
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
 
     sourceSets {

--- a/packages/sensors_plus/sensors_plus/example/android/build.gradle
+++ b/packages/sensors_plus/sensors_plus/example/android/build.gradle
@@ -6,7 +6,6 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.android.tools.build:gradle:8.1.2'
     }


### PR DESCRIPTION
## Description

Same as #2232

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

