### PR TITLE
fix(alarm_manager_plus): Revert bump compileSDK 34

### DIFF
--- a/packages/android_alarm_manager_plus/android/build.gradle
+++ b/packages/android_alarm_manager_plus/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
 
     namespace 'dev.fluttercommunity.plus.androidalarmmanager'
 
@@ -43,5 +43,5 @@ android {
 
 dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    api 'androidx.core:core:1.12.0'
+    api 'androidx.core:core:1.10.1'
 }

--- a/packages/android_alarm_manager_plus/example/android/app/build.gradle
+++ b/packages/android_alarm_manager_plus/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 34
+    compileSdkVersion 33
 
     namespace 'com.example.example'
 

--- a/packages/android_alarm_manager_plus/example/android/build.gradle
+++ b/packages/android_alarm_manager_plus/example/android/build.gradle
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
## Description

Same as #2234 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

