### PR TITLE
fix(android_intent_plus): Fix annotation dependency declaration

### DIFF
--- a/packages/android_intent_plus/android/build.gradle
+++ b/packages/android_intent_plus/android/build.gradle
@@ -46,7 +46,7 @@ android {
 }
 
 dependencies {
-    compileOnly 'androidx.annotation:annotation:1.7.0'
+    implementation 'androidx.annotation:annotation:1.7.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.5.0'
     testImplementation 'androidx.test:core:1.5.0'


### PR DESCRIPTION
## Description

With `compileOnly` I had the following issue while trying to add `android_intent_plus` to a new empty project:
<img width="1280" alt="Screenshot 2023-10-07 at 15 10 38" src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/35dcb29a-a979-45af-816a-e35148d0666f">

With `implementation` didn't see such issue, thus, changing declaration.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

