### PR TITLE
fix(sensors_plus): Close stream controllers on cancel on web

### DIFF
--- a/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
@@ -95,6 +95,10 @@ class WebSensorsPlugin extends SensorsPlatform {
       );
       _accelerometerResultStream =
           _accelerometerStreamController!.stream.asBroadcastStream();
+
+      _accelerometerStreamController!.onCancel = () {
+        _accelerometerStreamController!.close();
+      };
     }
 
     return _accelerometerResultStream;
@@ -197,6 +201,10 @@ class WebSensorsPlugin extends SensorsPlatform {
       );
       _userAccelerometerResultStream =
           _userAccelerometerStreamController!.stream.asBroadcastStream();
+
+      _userAccelerometerStreamController!.onCancel = () {
+        _userAccelerometerStreamController!.close();
+      };
     }
 
     return _userAccelerometerResultStream;


### PR DESCRIPTION
## Description

[pub points](https://pub.dev/packages/sensors_plus/score) is reduced.
```
40/50 points: code has no errors, warnings, lints, or formatting issues
Found 3 issues. Showing the first 2:

INFO: Unclosed instance of 'Sink'.
INFO: Unclosed instance of 'Sink'.
```

## Related Issues

N/A

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

