### PR TITLE
fix(share_plus): Change Kotlin version from 1.9.10 to 1.7.22

### DIFF
--- a/packages/share_plus/share_plus/android/build.gradle
+++ b/packages/share_plus/share_plus/android/build.gradle
@@ -2,7 +2,7 @@ group 'dev.fluttercommunity.plus.share'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.7.22'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Description

Kotlin update to 1.9.10 was too fast as it brought some problems, like https://github.com/fluttercommunity/plus_plugins/pull/2134 and #2251
Due to #2134 I decided to make major release, but it was a mistake as there were more hidden problems from this Kotlin version, like requirement of Android Gradle Plugin 8.x for projects that use the plugin with this Kotlin version. And while I am a fan of using latest dependency versions in projects this is too much.
Thus, I retracted new breaking changes versions and will open a series of PRs downgrading Kotlin to release another update tomorrow.

Also, validated that downgrading Kotlin resolves the problem I reported in #2251 as that projects builds fine when `share_plus` is used from this branch.

## Related Issues

Fixes #2251 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

