### PR TITLE
fix(battery_plus): Change Kotlin version from 1.9.10 to 1.7.22

### DIFF
--- a/packages/battery_plus/battery_plus/android/build.gradle
+++ b/packages/battery_plus/battery_plus/android/build.gradle
@@ -2,6 +2,7 @@ group 'dev.fluttercommunity.plus.battery'
 version '1.0-SNAPSHOT'
 
 buildscript {
+    ext.kotlin_version = '1.7.22'
     repositories {
         google()
         mavenCentral()

--- a/packages/battery_plus/battery_plus/example/android/build.gradle
+++ b/packages/battery_plus/battery_plus/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.7.22'
+    ext.kotlin_version = '1.8.20'
     repositories {
         google()
         mavenCentral()

--- a/packages/battery_plus/battery_plus/example/android/build.gradle
+++ b/packages/battery_plus/battery_plus/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.9.10'
+    ext.kotlin_version = '1.7.22'
     repositories {
         google()
         mavenCentral()


### PR DESCRIPTION
## Description

Same as #2256 

## Related Issues

#2251  

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

