### PR TITLE
chore(release): prepare for release

### DIFF
--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.2.1
+
+ - **CHORE**(share_plus): Update share_plus_platform_interface for compatibility with uuid 4.x
+
 ## 7.2.0
 
 > Info: This release is a replacement for release 8.0.0, which was retracted due to issue ([#2251](https://github.com/fluttercommunity/plus_plugins/issues/2251)). As breaking change was reverted the major release was also reverted in favor of this one.

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the share_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  share_plus: ^7.2.0
+  share_plus: ^7.2.1
   image_picker: ^1.0.0
   file_selector: ^1.0.0
 

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 7.2.0
+version: 7.2.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/share_plus/share_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus
@@ -32,7 +32,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  share_plus_platform_interface: ^3.3.0
+  share_plus_platform_interface: ^3.3.1
   file: ">=6.1.4 <8.0.0"
   url_launcher_web: ^2.0.16
   url_launcher_windows: ^3.0.6

--- a/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
+++ b/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.3.1
+
+ - chore(deps): bump uuid from 3.0.7 to 4.0.0
+
 ## 3.3.0
 
  - **FEAT**(share_plus): Allow user to share URI with preview image on the iOS native share sheet ([#1779](https://github.com/fluttercommunity/plus_plugins/issues/1779)). ([c83b667e](https://github.com/fluttercommunity/plus_plugins/commit/c83b667eb12394feef69221eda0eab8716aa19d8))

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_platform_interface
 description: A common platform interface for the share_plus plugin.
-version: 3.3.0
+version: 3.3.1
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

New version of `share_plus_platform_interface` also needed to be published for compatibility with uuid 4.x 

## Related Issues

Remembered about uuid update thanks to this comment: https://github.com/fluttercommunity/plus_plugins/issues/2137#issuecomment-1763384644 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

