### PR TITLE
fix(battery_plus): Implement not charging battery state

### DIFF
--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -191,7 +191,8 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
         return when (status) {
             BatteryManager.BATTERY_STATUS_CHARGING -> "charging"
             BatteryManager.BATTERY_STATUS_FULL -> "full"
-            BatteryManager.BATTERY_STATUS_DISCHARGING, BatteryManager.BATTERY_STATUS_NOT_CHARGING -> "discharging"
+            BatteryManager.BATTERY_STATUS_DISCHARGING -> "discharging"
+            BatteryManager.BATTERY_STATUS_NOT_CHARGING -> "not_charging"
             BatteryManager.BATTERY_STATUS_UNKNOWN -> "unknown"
             else -> null
         }

--- a/packages/battery_plus/battery_plus_platform_interface/lib/src/enums.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/src/enums.dart
@@ -9,6 +9,9 @@ enum BatteryState {
   /// The battery is currently losing energy.
   discharging,
 
+  /// The battery is not charging.
+  notCharging,
+
   /// The state of the battery is unknown.
   unknown
 }

--- a/packages/battery_plus/battery_plus_platform_interface/lib/src/utils.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/src/utils.dart
@@ -9,6 +9,8 @@ BatteryState parseBatteryState(String state) {
       return BatteryState.charging;
     case 'discharging':
       return BatteryState.discharging;
+    case 'not_charging':
+      return BatteryState.notCharging;
     case 'unknown':
       return BatteryState.unknown;
     default:


### PR DESCRIPTION
## Description

Normally, there are 5 different states to define the battery state on the Android side:
https://developer.android.com/reference/android/os/BatteryManager#BATTERY_STATUS_CHARGING
`full`, `charging`, `discharging`, `not _charging`, `unknown`. But in the current code base, `discharging` and `not_charging` are considered the same, and both are parsed as `discharging`.
With this change, if the Android SDK has a `not_charging` state, the Flutter side will also see this state.

On Samsung phones, if we enable battery protection, the phone charges up to 85%. When it reaches 85%, the status changes from `charging` to `not_charging`. When I checked, the current used is almost 0 mA.

## Related Issues

Fix #2274 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.



