### PR TITLE
fix(package_info_plus): migrate to pkg:web from dart:html

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
@@ -12,7 +12,7 @@ import 'dart:io';
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
-class LANGANDCODEPAGE extends Struct {
+base class LANGANDCODEPAGE extends Struct {
   @WORD()
   external int wLanguage;
 

--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
-import 'dart:html';
 
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:http/http.dart';
 import 'package:package_info_plus_platform_interface/package_info_data.dart';
 import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
+import 'package:web/helpers.dart' as web;
 
 /// The web implementation of [PackageInfoPlatform].
 ///
@@ -51,8 +51,8 @@ class PackageInfoPlusWebPlugin extends PackageInfoPlatform {
   @override
   Future<PackageInfoData> getAll() async {
     final cacheBuster = DateTime.now().millisecondsSinceEpoch;
-    final url = versionJsonUrl(window.document.baseUri!, cacheBuster);
-    final response = _client == null ? await get(url) : await _client!.get(url);
+    final url = versionJsonUrl(web.window.document.baseURI, cacheBuster);
+    final response = _client == null ? await get(url) : await _client.get(url);
     final versionMap = _getVersionMap(response);
 
     return PackageInfoData(

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -46,3 +46,4 @@ dev_dependencies:
 
 environment:
   sdk: ^3.2.0
+  flutter: '>=3.6.0'

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -33,6 +33,7 @@ dependencies:
   meta: ^1.8.0
   path: ^1.8.2
   package_info_plus_platform_interface: ^2.0.1
+  web: '>=0.3.0 <0.5.0'
 
   # win32 is compatible across v4 and v5 for Win32 only (not COM)
   win32: ">=4.0.0 <6.0.0"
@@ -44,5 +45,4 @@ dev_dependencies:
   test: ^1.22.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ^3.2.0


### PR DESCRIPTION
## Description

Change from using `dart:html` to `package:web`. This will allow this plugin to be used from Wasm.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

