### PR TITLE
fix(device_info_plus): Fix deprecation warning on MacOS

### DIFF
--- a/packages/device_info_plus/device_info_plus/macos/Classes/SystemUUID.swift
+++ b/packages/device_info_plus/device_info_plus/macos/Classes/SystemUUID.swift
@@ -4,13 +4,14 @@ public struct SystemUUID {
     
     public static func getSystemUUID() -> String? {
         let dev = IOServiceMatching("IOPlatformExpertDevice")
+        
         var platformExpert: io_service_t
-
         if #available(macOS 12, *) {
             platformExpert = IOServiceGetMatchingService(kIOMainPortDefault, dev)
         } else {
             platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault, dev)
         }
+        
         let serialNumberAsCFString = IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformUUIDKey as CFString, kCFAllocatorDefault, 0)
         IOObjectRelease(platformExpert)
         let ser: CFTypeRef? = serialNumberAsCFString?.takeUnretainedValue()

--- a/packages/device_info_plus/device_info_plus/macos/Classes/SystemUUID.swift
+++ b/packages/device_info_plus/device_info_plus/macos/Classes/SystemUUID.swift
@@ -4,7 +4,7 @@ public struct SystemUUID {
     
     public static func getSystemUUID() -> String? {
         let dev = IOServiceMatching("IOPlatformExpertDevice")
-        let platformExpert: io_service_t = IOServiceGetMatchingService(kIOMasterPortDefault, dev)
+        let platformExpert: io_service_t = IOServiceGetMatchingService(kIOMainPortDefault, dev)
         let serialNumberAsCFString = IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformUUIDKey as CFString, kCFAllocatorDefault, 0)
         IOObjectRelease(platformExpert)
         let ser: CFTypeRef? = serialNumberAsCFString?.takeUnretainedValue()

--- a/packages/device_info_plus/device_info_plus/macos/Classes/SystemUUID.swift
+++ b/packages/device_info_plus/device_info_plus/macos/Classes/SystemUUID.swift
@@ -4,10 +4,12 @@ public struct SystemUUID {
     
     public static func getSystemUUID() -> String? {
         let dev = IOServiceMatching("IOPlatformExpertDevice")
+        var platformExpert: io_service_t
+
         if #available(macOS 12, *) {
-            let platformExpert: io_service_t = IOServiceGetMatchingService(kIOMainPortDefault, dev)
+            platformExpert = IOServiceGetMatchingService(kIOMainPortDefault, dev)
         } else {
-            let platformExpert: io_service_t = IOServiceGetMatchingService(kIOMasterPortDefault, dev)
+            platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault, dev)
         }
         let serialNumberAsCFString = IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformUUIDKey as CFString, kCFAllocatorDefault, 0)
         IOObjectRelease(platformExpert)

--- a/packages/device_info_plus/device_info_plus/macos/Classes/SystemUUID.swift
+++ b/packages/device_info_plus/device_info_plus/macos/Classes/SystemUUID.swift
@@ -4,7 +4,11 @@ public struct SystemUUID {
     
     public static func getSystemUUID() -> String? {
         let dev = IOServiceMatching("IOPlatformExpertDevice")
-        let platformExpert: io_service_t = IOServiceGetMatchingService(kIOMainPortDefault, dev)
+        if #available(macOS 12, *) {
+            let platformExpert: io_service_t = IOServiceGetMatchingService(kIOMainPortDefault, dev)
+        } else {
+            let platformExpert: io_service_t = IOServiceGetMatchingService(kIOMasterPortDefault, dev)
+        }
         let serialNumberAsCFString = IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformUUIDKey as CFString, kCFAllocatorDefault, 0)
         IOObjectRelease(platformExpert)
         let ser: CFTypeRef? = serialNumberAsCFString?.takeUnretainedValue()


### PR DESCRIPTION
## Description

Fix macOS warning for device_info_plus

## Related Issues

- *Fix #2376*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

