### PR TITLE
chore: update minimum iOS version to 12.1 for build error

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus.podspec
+++ b/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus.podspec
@@ -18,7 +18,7 @@ Downloaded by pub (not CocoaPods).
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'ReachabilitySwift'
-  s.platform = :ios, '12.0'
+  s.platform = :ios, '12.1'
   s.swift_version = '5.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 end


### PR DESCRIPTION
## Description

Flutter (Channel stable, 3.16.0, on macOS 14.0 23A344 darwin-arm64, locale tr-TR)
Android toolchain - develop for Android devices (Android SDK version 34.0.0)
Xcode - develop for iOS and macOS (Xcode 15.0.1)
connectivity_plus: 5.0.1

Cannot build on iOS with iOS: 12 with this error:

```
Launching lib/main.dart on iPhone 15 Pro Max in debug mode...
main.dart:1
Xcode build done.                                           34,6s
Failed to build iOS app
Swift Compiler Error (Xcode): Compiling for iOS 12.0, but module 'Reachability' has a minimum deployment target of iOS 12.1: /Users/marlonjd/dev/monolibMobile/packages/monolibmobile/build/ios/Debug-iphonesimulator/ReachabilitySwift/Reachability.framework/Modules/Reachability.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
/Users/marlonjd/.pub-cache/hosted/pub.dev/connectivity_plus-5.0.1/ios/Classes/ReachabilityConnectivityProvider.swift:1:7

Could not build the application for the simulator.
Error launching application on iPhone 15 Pro Max.
```

**For this reason I changed to minimum target, but it's your call whether increasing or not iOS minimum deployment target.**

## Checklist

- [X] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

_It can be breaking change if your minimum target is 12.0_

- [X] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.

