### PR TITLE
fix(package_info_plus)!: allow no page extension in versionJsonUrl on web

### DIFF
--- a/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_web_test.dart
+++ b/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_web_test.dart
@@ -104,9 +104,10 @@ void main() {
             Uri.parse('https://example.com/a/b/c/version.json?cachebuster=1'),
           );
           expect(
+            // 'c' here is to be considered as a page, not a folder
             plugin.versionJsonUrl(
                 'https://example.com/a/b/c?hello_world=true#/my-page', 1),
-            Uri.parse('https://example.com/a/b/c/version.json?cachebuster=1'),
+            Uri.parse('https://example.com/a/b/version.json?cachebuster=1'),
           );
         },
       );

--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
@@ -24,12 +24,17 @@ class PackageInfoPlusWebPlugin extends PackageInfoPlatform {
   Uri versionJsonUrl(String baseUrl, int cacheBuster) {
     final baseUri = Uri.parse(baseUrl);
     final regExp = RegExp(r'[^/]+\.html.*');
-    final originPath =
-        '${baseUri._origin}${baseUri.path.replaceAll(regExp, '')}';
-    final versionJson = 'version.json?cachebuster=$cacheBuster';
-    return Uri.parse(originPath.endsWith('/')
-        ? '$originPath$versionJson'
-        : '$originPath/$versionJson');
+    final String originPath = '${baseUri._origin}${baseUri.path.replaceAll(regExp, '')}';
+
+    // Remove fragment and query
+    Uri uri = Uri.parse(originPath).replace(fragment: '', query: '');
+
+    // Remove file or last part since it's not a folder
+    final String basePath = uri.toString();
+    if (!basePath.endsWith('/')) uri = Uri.parse(basePath.substring(0, basePath.lastIndexOf('/')));
+
+    // Add file and cachebuster query
+    return uri.replace(query: 'cachebuster=$cacheBuster', pathSegments: [...uri.pathSegments, 'version.json']);
   }
 
   @override


### PR DESCRIPTION
## Description

This PR aims at fixing a scenario where we get `version.json` from the app page with no file extension on the web. Such an url would previously break the `version.json` url when trying to get it.

## Related Issues
- *Fixes #2282*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

There is a small breaking change as an url not ending with a slash would previously have been recognized as a folder, resulting in a different url. For exemple, given an app url "https://example.com/a/b/c?hello_world=true#/my-page", the version.json path would be:
- Before change: "https://example.com/a/b/c/version.json?cachebuster=1" (notice the "c/" in url)
- After change: "https://example.com/a/b/version.json?cachebuster=1"

