### PR TITLE
feat(battery_plus)!: Introduce connected_not_charging state on MacOS

### DIFF
--- a/packages/battery_plus/battery_plus/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/battery_plus/battery_plus/example/macos/Runner.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1430;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {

--- a/packages/battery_plus/battery_plus/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/battery_plus/battery_plus/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1430"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/battery_plus/battery_plus_platform_interface/lib/src/enums.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/src/enums.dart
@@ -1,17 +1,19 @@
 /// Indicates the current battery state.
 enum BatteryState {
-  /// The battery is completely full of energy.
+  /// The battery is fully charged.
   full,
 
-  /// The battery is currently storing energy.
+  /// The battery is currently charging.
   charging,
+
+  /// Device is connected to external power source, but not charging the battery.
+  /// Usually happens when device has charge limit enabled and this limit is reached.
+  /// Available on MacOS and Android platforms only.
+  connectedNotCharging,
 
   /// The battery is currently losing energy.
   discharging,
 
-  /// The battery is not charging.
-  notCharging,
-
   /// The state of the battery is unknown.
-  unknown
+  unknown;
 }

--- a/packages/battery_plus/battery_plus_platform_interface/lib/src/utils.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/src/utils.dart
@@ -9,8 +9,8 @@ BatteryState parseBatteryState(String state) {
       return BatteryState.charging;
     case 'discharging':
       return BatteryState.discharging;
-    case 'not_charging':
-      return BatteryState.notCharging;
+    case 'connected_not_charging':
+      return BatteryState.connectedNotCharging;
     case 'unknown':
       return BatteryState.unknown;
     default:


### PR DESCRIPTION
## Description

Adding new `connected_not_charging` state to MacOS as follow-up to #2275 which introduced such state on Android.
Renamed the state from the initial name suggested in #2275 to be more explicit.

Marking as a breaking change to bring attention to the new state in platform interface and because I have reimplemented MacOS states definition.

Looks like this state can be added for Linux as well, so will open one more PR for Linux platform.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

