### PR TITLE
feat(battery_plus): Introduce not_charging state on Linux

### DIFF
--- a/packages/battery_plus/battery_plus/lib/src/battery_plus_linux.dart
+++ b/packages/battery_plus/battery_plus/lib/src/battery_plus_linux.dart
@@ -9,10 +9,17 @@ extension _ToBatteryState on UPowerDeviceState {
     switch (this) {
       case UPowerDeviceState.charging:
         return BatteryState.charging;
+
       case UPowerDeviceState.discharging:
+      case UPowerDeviceState.pendingDischarge:
         return BatteryState.discharging;
+
       case UPowerDeviceState.fullyCharged:
         return BatteryState.full;
+
+      case UPowerDeviceState.pendingCharge:
+        return BatteryState.connectedNotCharging;
+
       default:
         return BatteryState.unknown;
     }

--- a/packages/battery_plus/battery_plus_platform_interface/lib/src/enums.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/src/enums.dart
@@ -7,8 +7,11 @@ enum BatteryState {
   charging,
 
   /// Device is connected to external power source, but not charging the battery.
+  ///
   /// Usually happens when device has charge limit enabled and this limit is reached.
-  /// Available on MacOS and Android platforms only.
+  /// Also, battery might be in this state if connected power source isn't powerful enough to charge the battery.
+  ///
+  /// Available on Android, MacOS and Linux platforms only.
   connectedNotCharging,
 
   /// The battery is currently losing energy.


### PR DESCRIPTION
## Description

Feature similar to #2399 and #2275 

Had hard time trying to find out what is `pending discharge` state and made an assumption that it is similar to `discharging` as it was done here, for example: https://yarp.it/git-master/upowerBattery_8cpp_source.html

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

