### PR TITLE
fix(share_plus): reset isCalledBack on android correctly after closing share-sheet

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
@@ -40,6 +40,7 @@ internal class MethodCallHandler(
                     isWithResult,
                 )
 
+                manager.signalShareSheetCalledBack()
                 if (!isWithResult) {
                     if (isResultRequested) {
                         result.success("dev.fluttercommunity.plus/share/unavailable")
@@ -62,6 +63,7 @@ internal class MethodCallHandler(
                         isWithResult,
                     )
 
+                    manager.signalShareSheetCalledBack()
                     if (!isWithResult) {
                         if (isResultRequested) {
                             result.success("dev.fluttercommunity.plus/share/unavailable")

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
@@ -35,6 +35,14 @@ internal class ShareSuccessManager(private val context: Context) : ActivityResul
     }
 
     /**
+     * Set the `isCalledBack` to `true`. Must be called in every share-sheet calling method
+     * before returning.
+     */
+    fun signalShareSheetCalledBack(){
+        isCalledBack.set(true)
+    }
+
+    /**
      * Must be called if `.startActivityForResult` is not available to avoid deadlocking.
      */
     fun unavailable() {


### PR DESCRIPTION
## Description
If the share is done to the same app(self) in android device, this plugin opens the share-sheet only once and throws the following exception for the subsequent method calls:
```
Capture exception - PlatformException(Share callback error, prior share-sheet did not call back, did you await it? Maybe use non-result variant, null, null)
```
It however works once again after the app has been closed and re-opened again. I could reproduce it every single time when I try to share a media file to the same app(self).

In android code, I found that the `isCalledBack` variable is set to true only on initialisation and not after share-sheet has been called back successfully. The reason being `onActivityResult` method doesn't work, either because of [this flutter issue]() OR [it is not fully supported for](https://stackoverflow.com/questions/51835134/android-share-text-to-other-application-with-action-send#comment90624948_51835346) `ACTION_SEND`, `ACTION_SENDTO` intent.

## Related Issues

- *Fix https://github.com/fluttercommunity/plus_plugins/issues/1936*
- *Fix https://github.com/fluttercommunity/plus_plugins/issues/1351*
- *Fix https://github.com/fluttercommunity/plus_plugins/issues/1612*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

