### PR TITLE
docs: Update Kotlin version in android/build.gradle doc

### DIFF
--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -28,6 +28,8 @@ Sharing files is not supported on Windows and Linux.
 
 To use this plugin, add `share_plus` as a [dependency in your pubspec.yaml file](https://plus.fluttercommunity.dev/docs/overview).
 
+Make sure to set the `ext.kotlin_version` in `android/build.gradle` to at least `1.8.10`.
+
 ## Example
 
 Import the library.


### PR DESCRIPTION
## Description

Added documentation to the readme.md to clarify the required kotlin_version. This might help people save time when they use this package.

## Related Issues

*e.g.*
- *Related #2018 *
- *Related #2084 *

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

