### PR TITLE
fix(battery_plus): Return correct state enum value on Android for not charging state

### DIFF
--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -192,7 +192,7 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
             BatteryManager.BATTERY_STATUS_CHARGING -> "charging"
             BatteryManager.BATTERY_STATUS_FULL -> "full"
             BatteryManager.BATTERY_STATUS_DISCHARGING -> "discharging"
-            BatteryManager.BATTERY_STATUS_NOT_CHARGING -> "not_charging"
+            BatteryManager.BATTERY_STATUS_NOT_CHARGING -> "connected_not_charging"
             BatteryManager.BATTERY_STATUS_UNKNOWN -> "unknown"
             else -> null
         }


### PR DESCRIPTION
## Description

Fix for a forgotten renaming in Android implementation.

## Related Issues

Fixes #2450

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

