### PR TITLE
docs(sensors_plus): Update README to mention how sampling rate works on Android

### DIFF
--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -111,6 +111,11 @@ magnetometerEvents.listen(
 
 Alternatively, every stream allows to specify the sampling rate for its sensor using one of predefined constants or using a custom value
 
+> [!NOTE]
+>
+> On Android it is not guaranteed that events from sensors will arrive with specified sampling rate as it is noted in [the official Android documentation](https://developer.android.com/reference/android/hardware/SensorManager.html#registerListener(android.hardware.SensorEventListener,%20android.hardware.Sensor,%20int)) (see the description for the `samplingPeriodUs` parameter). In reality delay varies depending on Android version, device hardware and vendor's OS customisations.
+
+
 ```dart
 magnetometerEvents(samplingPeriod: SensorInterval.normalInterval).listen(
   (MagnetometerEvent event) {


### PR DESCRIPTION
## Description

Following the discussion in the #2448 issue updating the plugin's README to mention that it is not guaranteed that specified sampling period will work on Android.

## Related Issues

#2448 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

