### PR TITLE
fix(sensors_plus): Close magnetometerStreamController on web

### DIFF
--- a/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
@@ -265,6 +265,10 @@ class WebSensorsPlugin extends SensorsPlatform {
       );
       _magnetometerResultStream =
           _magnetometerStreamController!.stream.asBroadcastStream();
+
+      _magnetometerStreamController!.onCancel = () {
+        _magnetometerStreamController!.close();
+      };
     }
 
     return _magnetometerResultStream;


### PR DESCRIPTION
## Description

On web magnetometer stream wasn't closed and this issue was catched by pub.dev score checker.
<img width="797" alt="Screenshot 2023-12-13 at 12 28 01" src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/3ee179a2-9851-4f2c-b718-141048ffa6bc">

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

