### PR TITLE
docs: Update README with an important note

### DIFF
--- a/packages/network_info_plus/network_info_plus/README.md
+++ b/packages/network_info_plus/network_info_plus/README.md
@@ -60,6 +60,9 @@ To successfully get WiFi Name or Wi-Fi BSSID starting with Android 1O, ensure al
 > **Note**
 >
 > This package does not provide the ACCESS_FINE_LOCATION nor the ACCESS_COARSE_LOCATION permission by default
+>
+> From android 8.0 onwards the GPS must be ON (high accuracy) in order to
+> be able to obtain the SSID.
 
 #### iOS 12
 


### PR DESCRIPTION
## Description

*Investigating the WiFi name retrieval issue took quite a bit of time. While reviewing the package code and comments, I discovered that active GPS is required for getWifiName to function so I updated network_info_plus readme and added a note that starting with Android 8.0, turning on GPS (high accuracy) is necessary to get the SSID (your Wi-Fi network name).*

## Related Issues

*WiFi name was not being received*

*e.g.*
- *Related #[99](https://github.com/fluttercommunity/plus_plugins/issues/99#issue-796186571)*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

