### PR TITLE
docs(connectivity_plus): fix var name in usage.mdx 

### DIFF
--- a/docs/connectivity_plus/usage.mdx
+++ b/docs/connectivity_plus/usage.mdx
@@ -75,7 +75,7 @@ The broadcast is only useful when your application is in the **foreground**.
 
 ``` dart
 // Initialize a variable with [none] status to avoid nulls at startup
-ConnectivityResult connectivityResult = ConnectivityResult.none;
+ConnectivityResult _connectivityResult = ConnectivityResult.none;
 
 @override
 void initState() {
@@ -97,7 +97,7 @@ The listener will update the connectivity status.
 ``` dart
 Future<void> _updateConnectionStatus(ConnectivityResult result) async {
   setState((){
-      _connectionResult = result;
+      _connectivityResult = result;
   });
 }
 ```


### PR DESCRIPTION
## Description

Fixed variable name in documentation of connectivity_plus (usage)

## Checklist

- [ x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ x] All existing and new tests are passing.
- [ x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ x] No, this is *not* a breaking change.

