### PR TITLE
fix(battery_plus): battery state always unknown (iOS only)

### DIFF
--- a/packages/battery_plus/battery_plus/ios/Classes/FPPBatteryPlusPlugin.m
+++ b/packages/battery_plus/battery_plus/ios/Classes/FPPBatteryPlusPlugin.m
@@ -70,7 +70,9 @@
 }
 
 - (NSString *)getBatteryState {
-  UIDeviceBatteryState state = [[UIDevice currentDevice] batteryState];
+  UIDevice *device = UIDevice.currentDevice;
+  device.batteryMonitoringEnabled = YES;
+  UIDeviceBatteryState state = [device batteryState];
   switch (state) {
   case UIDeviceBatteryStateUnknown:
     return @"unknown";


### PR DESCRIPTION
## Description

If battery percentage never read battery state is always unknown

## Related Issues

None

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

