### PR TITLE
feat(sensors_plus)!: Add support for platform timestamp in event

### DIFF
--- a/packages/sensors_plus/sensors_plus/example/lib/main.dart
+++ b/packages/sensors_plus/sensors_plus/example/lib/main.dart
@@ -267,7 +267,7 @@ class _MyHomePageState extends State<MyHomePage> {
     _streamSubscriptions.add(
       userAccelerometerEventStream(samplingPeriod: sensorInterval).listen(
         (UserAccelerometerEvent event) {
-          final now = DateTime.now();
+          final now = event.timestamp;
           setState(() {
             _userAccelerometerEvent = event;
             if (_userAccelerometerUpdateTime != null) {
@@ -296,7 +296,7 @@ class _MyHomePageState extends State<MyHomePage> {
     _streamSubscriptions.add(
       accelerometerEventStream(samplingPeriod: sensorInterval).listen(
         (AccelerometerEvent event) {
-          final now = DateTime.now();
+          final now = event.timestamp;
           setState(() {
             _accelerometerEvent = event;
             if (_accelerometerUpdateTime != null) {
@@ -325,7 +325,7 @@ class _MyHomePageState extends State<MyHomePage> {
     _streamSubscriptions.add(
       gyroscopeEventStream(samplingPeriod: sensorInterval).listen(
         (GyroscopeEvent event) {
-          final now = DateTime.now();
+          final now = event.timestamp;
           setState(() {
             _gyroscopeEvent = event;
             if (_gyroscopeUpdateTime != null) {
@@ -354,7 +354,7 @@ class _MyHomePageState extends State<MyHomePage> {
     _streamSubscriptions.add(
       magnetometerEventStream(samplingPeriod: sensorInterval).listen(
         (MagnetometerEvent event) {
-          final now = DateTime.now();
+          final now = event.timestamp;
           setState(() {
             _magnetometerEvent = event;
             if (_magnetometerUpdateTime != null) {
@@ -383,7 +383,7 @@ class _MyHomePageState extends State<MyHomePage> {
     _streamSubscriptions.add(
       barometerEventStream(samplingPeriod: sensorInterval).listen(
         (BarometerEvent event) {
-          final now = DateTime.now();
+          final now = event.timestamp;
           setState(() {
             _barometerEvent = event;
             if (_barometerUpdateTime != null) {

--- a/packages/sensors_plus/sensors_plus/ios/Classes/FPPStreamHandlerPlus.swift
+++ b/packages/sensors_plus/sensors_plus/ios/Classes/FPPStreamHandlerPlus.swift
@@ -14,6 +14,8 @@ public protocol MotionStreamHandler: FlutterStreamHandler {
     var samplingPeriod: Int { get set }
 }
 
+let timestampMicroAtBoot = (Date().timeIntervalSince1970 - ProcessInfo.processInfo.systemUptime) * 1000000
+
 func _initMotionManager() {
     if (_motionManager == nil) {
         _motionManager = CMMotionManager()
@@ -24,14 +26,15 @@ func _initMotionManager() {
     }
 }
 
-func sendTriplet(x: Float64, y: Float64, z: Float64, sink: @escaping FlutterEventSink) {
+func sendFlutter(x: Float64, y: Float64, z: Float64, timestamp: TimeInterval, sink: @escaping FlutterEventSink) {
     if _isCleanUp {
         return
     }
     // Even after [detachFromEngineForRegistrar] some events may still be received
     // and fired until fully detached.
     DispatchQueue.main.async {
-        let triplet = [x, y, z]
+        let timestampSince1970Micro = timestampMicroAtBoot + (timestamp * 1000000)
+        let triplet = [x, y, z, timestampSince1970Micro]
         triplet.withUnsafeBufferPointer { buffer in
             sink(FlutterStandardTypedData.init(float64: Data(buffer: buffer)))
         }
@@ -67,10 +70,11 @@ class FPPAccelerometerStreamHandlerPlus: NSObject, MotionStreamHandler {
             // Multiply by gravity, and adjust sign values to
             // align with Android.
             let acceleration = data!.acceleration
-            sendTriplet(
+            sendFlutter(
                     x: -acceleration.x * GRAVITY,
                     y: -acceleration.y * GRAVITY,
                     z: -acceleration.z * GRAVITY,
+                    timestamp: data!.timestamp,
                     sink: sink
             )
         }
@@ -116,10 +120,11 @@ class FPPUserAccelStreamHandlerPlus: NSObject, MotionStreamHandler {
             // Multiply by gravity, and adjust sign values to
             // align with Android.
             let acceleration = data!.userAcceleration
-            sendTriplet(
+            sendFlutter(
                     x: -acceleration.x * GRAVITY,
                     y: -acceleration.y * GRAVITY,
                     z: -acceleration.z * GRAVITY,
+                    timestamp: data!.timestamp,
                     sink: sink
             )
         }
@@ -163,7 +168,13 @@ class FPPGyroscopeStreamHandlerPlus: NSObject, MotionStreamHandler {
                 return
             }
             let rotationRate = data!.rotationRate
-            sendTriplet(x: rotationRate.x, y: rotationRate.y, z: rotationRate.z, sink: sink)
+            sendFlutter(
+                x: rotationRate.x,
+                y: rotationRate.y,
+                z: rotationRate.z,
+                timestamp: data!.timestamp,
+                sink: sink
+            )
         }
         return nil
     }
@@ -205,7 +216,13 @@ class FPPMagnetometerStreamHandlerPlus: NSObject, MotionStreamHandler {
                 return
             }
             let magneticField = data!.magneticField
-            sendTriplet(x: magneticField.x, y: magneticField.y, z: magneticField.z, sink: sink)
+            sendFlutter(
+                x: magneticField.x,
+                y: magneticField.y,
+                z: magneticField.z,
+                timestamp: data!.timestamp,
+                sink: sink
+            )
         }
         return nil
     }

--- a/packages/sensors_plus/sensors_plus/ios/Classes/FPPStreamHandlerPlus.swift
+++ b/packages/sensors_plus/sensors_plus/ios/Classes/FPPStreamHandlerPlus.swift
@@ -274,7 +274,8 @@ class FPPBarometerStreamHandlerPlus: NSObject, MotionStreamHandler {
                 }
                 let pressure = data!.pressure.doubleValue * 10.0 // kPa to hPa (hectopascals)
                 DispatchQueue.main.async {
-                let pressureArray: [Double] = [pressure]
+                let timestampSince1970Micro = timestampMicroAtBoot + (data!.timestamp * 1000000)
+                let pressureArray: [Double] = [pressure, timestampSince1970Micro]
                 pressureArray.withUnsafeBufferPointer { buffer in
                     sink(FlutterStandardTypedData.init(float64: Data(buffer: buffer)))
                     }

--- a/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
@@ -85,6 +85,7 @@ class WebSensorsPlugin extends SensorsPlatform {
                 accelerometer.x,
                 accelerometer.y,
                 accelerometer.z,
+                DateTime.now(),
               ),
             );
           }.toJS;
@@ -99,7 +100,8 @@ class WebSensorsPlugin extends SensorsPlatform {
         apiName: 'Accelerometer()',
         permissionName: 'accelerometer',
         onError: () {
-          _accelerometerStreamController!.add(AccelerometerEvent(0, 0, 0));
+          _accelerometerStreamController!
+              .add(AccelerometerEvent(0, 0, 0, DateTime.now()));
         },
       );
       _accelerometerResultStream =
@@ -138,6 +140,7 @@ class WebSensorsPlugin extends SensorsPlatform {
                 gyroscope.x,
                 gyroscope.y,
                 gyroscope.z,
+                DateTime.now(),
               ),
             );
           }.toJS;
@@ -152,7 +155,8 @@ class WebSensorsPlugin extends SensorsPlatform {
         apiName: 'Gyroscope()',
         permissionName: 'gyroscope',
         onError: () {
-          _gyroscopeEventStreamController!.add(GyroscopeEvent(0, 0, 0));
+          _gyroscopeEventStreamController!
+              .add(GyroscopeEvent(0, 0, 0, DateTime.now()));
         },
       );
       _gyroscopeEventResultStream =
@@ -192,6 +196,7 @@ class WebSensorsPlugin extends SensorsPlatform {
                 linearAccelerationSensor.x,
                 linearAccelerationSensor.y,
                 linearAccelerationSensor.z,
+                DateTime.now(),
               ),
             );
           }.toJS;
@@ -207,7 +212,7 @@ class WebSensorsPlugin extends SensorsPlatform {
         permissionName: 'accelerometer',
         onError: () {
           _userAccelerometerStreamController!
-              .add(UserAccelerometerEvent(0, 0, 0));
+              .add(UserAccelerometerEvent(0, 0, 0, DateTime.now()));
         },
       );
       _userAccelerometerResultStream =
@@ -247,6 +252,7 @@ class WebSensorsPlugin extends SensorsPlatform {
                 magnetometerSensor.x,
                 magnetometerSensor.y,
                 magnetometerSensor.z,
+                DateTime.now(),
               ),
             );
           }.toJS;
@@ -261,7 +267,8 @@ class WebSensorsPlugin extends SensorsPlatform {
         apiName: 'Magnetometer()',
         permissionName: 'magnetometer',
         onError: () {
-          _magnetometerStreamController!.add(MagnetometerEvent(0, 0, 0));
+          _magnetometerStreamController!
+              .add(MagnetometerEvent(0, 0, 0, DateTime.now()));
         },
       );
       _magnetometerResultStream =

--- a/packages/sensors_plus/sensors_plus/test/sensors_test.dart
+++ b/packages/sensors_plus/sensors_plus/test/sensors_test.dart
@@ -13,7 +13,13 @@ void main() {
 
   test('accelerometerEvents are streamed', () async {
     const channelName = 'dev.fluttercommunity.plus/sensors/accelerometer';
-    const sensorData = <double>[1.0, 2.0, 3.0];
+    final date = DateTime.now();
+    final sensorData = <double>[
+      1.0,
+      2.0,
+      3.0,
+      date.microsecondsSinceEpoch.toDouble(),
+    ];
     _initializeFakeMethodChannel('setAccelerationSamplingPeriod');
     _initializeFakeSensorChannel(channelName, sensorData);
 
@@ -22,11 +28,18 @@ void main() {
     expect(event.x, sensorData[0]);
     expect(event.y, sensorData[1]);
     expect(event.z, sensorData[2]);
+    expect(event.timestamp, date);
   });
 
   test('gyroscopeEvents are streamed', () async {
     const channelName = 'dev.fluttercommunity.plus/sensors/gyroscope';
-    const sensorData = <double>[3.0, 4.0, 5.0];
+    final date = DateTime.now();
+    final sensorData = <double>[
+      3.0,
+      4.0,
+      5.0,
+      date.microsecondsSinceEpoch.toDouble(),
+    ];
     _initializeFakeMethodChannel('setGyroscopeSamplingPeriod');
     _initializeFakeSensorChannel(channelName, sensorData);
 
@@ -35,11 +48,18 @@ void main() {
     expect(event.x, sensorData[0]);
     expect(event.y, sensorData[1]);
     expect(event.z, sensorData[2]);
+    expect(event.timestamp, date);
   });
 
   test('userAccelerometerEvents are streamed', () async {
     const channelName = 'dev.fluttercommunity.plus/sensors/user_accel';
-    const sensorData = <double>[6.0, 7.0, 8.0];
+    final date = DateTime.now();
+    final sensorData = <double>[
+      6.0,
+      7.0,
+      8.0,
+      date.microsecondsSinceEpoch.toDouble(),
+    ];
     _initializeFakeMethodChannel('setUserAccelerometerSamplingPeriod');
     _initializeFakeSensorChannel(channelName, sensorData);
 
@@ -48,11 +68,18 @@ void main() {
     expect(event.x, sensorData[0]);
     expect(event.y, sensorData[1]);
     expect(event.z, sensorData[2]);
+    expect(event.timestamp, date);
   });
 
   test('magnetometerEvents are streamed', () async {
     const channelName = 'dev.fluttercommunity.plus/sensors/magnetometer';
-    const sensorData = <double>[8.0, 9.0, 10.0];
+    final date = DateTime.now();
+    final sensorData = <double>[
+      8.0,
+      9.0,
+      10.0,
+      date.microsecondsSinceEpoch.toDouble(),
+    ];
     _initializeFakeMethodChannel('setMagnetometerSamplingPeriod');
     _initializeFakeSensorChannel(channelName, sensorData);
 
@@ -61,6 +88,7 @@ void main() {
     expect(event.x, sensorData[0]);
     expect(event.y, sensorData[1]);
     expect(event.z, sensorData[2]);
+    expect(event.timestamp, date);
   });
 }
 

--- a/packages/sensors_plus/sensors_plus/test/sensors_test.dart
+++ b/packages/sensors_plus/sensors_plus/test/sensors_test.dart
@@ -93,13 +93,18 @@ void main() {
 
   test('barometerEvents are streamed', () async {
     const channelName = 'dev.fluttercommunity.plus/sensors/barometer';
-    const sensorData = <double>[1000.0];
+    final date = DateTime.now();
+    final sensorData = <double>[
+      1000.0,
+      date.microsecondsSinceEpoch.toDouble(),
+    ];
     _initializeFakeMethodChannel('setBarometerSamplingPeriod');
     _initializeFakeSensorChannel(channelName, sensorData);
 
     final event = await barometerEventStream().first;
 
     expect(event.pressure, sensorData[0]);
+    expect(event.timestamp, date);
   });
 }
 

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/accelerometer_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/accelerometer_event.dart
@@ -8,7 +8,7 @@
 /// a particular direction.
 class AccelerometerEvent {
   /// Constructs an instance with the given [x], [y], and [z] values.
-  AccelerometerEvent(this.x, this.y, this.z);
+  AccelerometerEvent(this.x, this.y, this.z, this.timestamp);
 
   /// Acceleration force along the x axis (including gravity) measured in m/s^2.
   ///
@@ -29,6 +29,14 @@ class AccelerometerEvent {
   /// upright and facing the user, positive values mean the device is moving
   /// towards the user and negative mean it is moving away from them.
   final double z;
+
+  /// timestamp of the event
+  ///
+  /// This is the timestamp of the event in microseconds, as provided by the
+  /// underlying platform. For Android, this is the uptimeMillis provided by
+  /// the SensorEvent. For iOS, this is the timestamp provided by the CMDeviceMotion.
+
+  final DateTime timestamp;
 
   @override
   String toString() => '[AccelerometerEvent (x: $x, y: $y, z: $z)]';

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/accelerometer_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/accelerometer_event.dart
@@ -39,5 +39,5 @@ class AccelerometerEvent {
   final DateTime timestamp;
 
   @override
-  String toString() => '[AccelerometerEvent (x: $x, y: $y, z: $z)]';
+  String toString() => '[AccelerometerEvent (x: $x, y: $y, z: $z, timestamp: $timestamp)]';
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/accelerometer_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/accelerometer_event.dart
@@ -39,5 +39,6 @@ class AccelerometerEvent {
   final DateTime timestamp;
 
   @override
-  String toString() => '[AccelerometerEvent (x: $x, y: $y, z: $z, timestamp: $timestamp)]';
+  String toString() =>
+      '[AccelerometerEvent (x: $x, y: $y, z: $z, timestamp: $timestamp)]';
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/barometer_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/barometer_event.dart
@@ -16,11 +16,19 @@ class BarometerEvent {
   /// Constructs a new instance with the given [pressure] value.
   ///
   /// See [BarometerEvent] for more information.
-  BarometerEvent(this.pressure);
+  BarometerEvent(this.pressure, this.timestamp);
 
   /// The atmospheric pressure surrounding the sensor in hectopascals ***hPa***.
   final double pressure;
 
+  /// timestamp of the event
+  ///
+  /// This is the timestamp of the event in microseconds, as provided by the
+  /// underlying platform. For Android, this is the uptimeMillis provided by
+  /// the SensorEvent. For iOS, this is the timestamp provided by the CMDeviceMotion.
+
+  final DateTime timestamp;
+
   @override
-  String toString() => '[BarometerEvent (pressure: $pressure hPa)]';
+  String toString() => '[BarometerEvent (pressure: $pressure hPa, timestamp: $timestamp)]';
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/barometer_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/barometer_event.dart
@@ -30,5 +30,6 @@ class BarometerEvent {
   final DateTime timestamp;
 
   @override
-  String toString() => '[BarometerEvent (pressure: $pressure hPa, timestamp: $timestamp)]';
+  String toString() =>
+      '[BarometerEvent (pressure: $pressure hPa, timestamp: $timestamp)]';
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/gyroscope_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/gyroscope_event.dart
@@ -6,7 +6,7 @@
 /// the device in 3D space.
 class GyroscopeEvent {
   /// Constructs an instance with the given [x], [y], and [z] values.
-  GyroscopeEvent(this.x, this.y, this.z);
+  GyroscopeEvent(this.x, this.y, this.z, this.timestamp);
 
   /// Rate of rotation around the x axis measured in rad/s.
   ///
@@ -29,6 +29,14 @@ class GyroscopeEvent {
   /// forward, but the orientation will change from portrait to landscape and so
   /// on.
   final double z;
+
+  /// timestamp of the event
+  ///
+  /// This is the timestamp of the event in microseconds, as provided by the
+  /// underlying platform. For Android, this is the uptimeMillis provided by
+  /// the SensorEvent. For iOS, this is the timestamp provided by the CMDeviceMotion.
+
+  final DateTime timestamp;
 
   @override
   String toString() => '[GyroscopeEvent (x: $x, y: $y, z: $z)]';

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/gyroscope_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/gyroscope_event.dart
@@ -39,5 +39,6 @@ class GyroscopeEvent {
   final DateTime timestamp;
 
   @override
-  String toString() => '[GyroscopeEvent (x: $x, y: $y, z: $z, timestamp: $timestamp)]';
+  String toString() =>
+      '[GyroscopeEvent (x: $x, y: $y, z: $z, timestamp: $timestamp)]';
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/gyroscope_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/gyroscope_event.dart
@@ -39,5 +39,5 @@ class GyroscopeEvent {
   final DateTime timestamp;
 
   @override
-  String toString() => '[GyroscopeEvent (x: $x, y: $y, z: $z)]';
+  String toString() => '[GyroscopeEvent (x: $x, y: $y, z: $z, timestamp: $timestamp)]';
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/magnetometer_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/magnetometer_event.dart
@@ -27,5 +27,6 @@ class MagnetometerEvent {
   final DateTime timestamp;
 
   @override
-  String toString() => '[MagnetometerEvent (x: $x, y: $y, z: $z, timestamp: $timestamp)]';
+  String toString() =>
+      '[MagnetometerEvent (x: $x, y: $y, z: $z, timestamp: $timestamp)]';
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/magnetometer_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/magnetometer_event.dart
@@ -12,11 +12,19 @@ class MagnetometerEvent {
   /// Constructs a new instance with the given [x], [y], and [z] values.
   ///
   /// See [MagnetometerEvent] for more information.
-  MagnetometerEvent(this.x, this.y, this.z);
+  MagnetometerEvent(this.x, this.y, this.z, this.timestamp);
 
   /// The ambient magnetic field in this axis surrounding the sensor in
   /// microteslas ***μT***.
   final double x, y, z;
+
+  /// timestamp of the event
+  ///
+  /// This is the timestamp of the event in microseconds, as provided by the
+  /// underlying platform. For Android, this is the uptimeMillis provided by
+  /// the SensorEvent. For iOS, this is the timestamp provided by the CMDeviceMotion.
+
+  final DateTime timestamp;
 
   @override
   String toString() => '[MagnetometerEvent (x: $x, y: $y, z: $z)]';

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/magnetometer_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/magnetometer_event.dart
@@ -27,5 +27,5 @@ class MagnetometerEvent {
   final DateTime timestamp;
 
   @override
-  String toString() => '[MagnetometerEvent (x: $x, y: $y, z: $z)]';
+  String toString() => '[MagnetometerEvent (x: $x, y: $y, z: $z, timestamp: $timestamp)]';
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/method_channel_sensors.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/method_channel_sensors.dart
@@ -178,7 +178,10 @@ class MethodChannelSensors extends SensorsPlatform {
     _barometerEvents ??=
         _barometerEventChannel.receiveBroadcastStream().map((dynamic event) {
       final list = event.cast<double>();
-      return BarometerEvent(list[0]!);
+      return BarometerEvent(
+        list[0]!,
+        DateTime.fromMicrosecondsSinceEpoch(list[1]!.toInt()),
+      );
     });
     return _barometerEvents!;
   }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/method_channel_sensors.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/method_channel_sensors.dart
@@ -52,7 +52,12 @@ class MethodChannelSensors extends SensorsPlatform {
         .receiveBroadcastStream()
         .map((dynamic event) {
       final list = event.cast<double>();
-      return AccelerometerEvent(list[0]!, list[1]!, list[2]!);
+      return AccelerometerEvent(
+        list[0]!,
+        list[1]!,
+        list[2]!,
+        DateTime.fromMicrosecondsSinceEpoch(list[3]!.toInt()),
+      );
     });
     return _accelerometerEvents!;
   }
@@ -77,7 +82,12 @@ class MethodChannelSensors extends SensorsPlatform {
     _gyroscopeEvents ??=
         _gyroscopeEventChannel.receiveBroadcastStream().map((dynamic event) {
       final list = event.cast<double>();
-      return GyroscopeEvent(list[0]!, list[1]!, list[2]!);
+      return GyroscopeEvent(
+        list[0]!,
+        list[1]!,
+        list[2]!,
+        DateTime.fromMicrosecondsSinceEpoch(list[3]!.toInt()),
+      );
     });
     return _gyroscopeEvents!;
   }
@@ -104,7 +114,12 @@ class MethodChannelSensors extends SensorsPlatform {
         .receiveBroadcastStream()
         .map((dynamic event) {
       final list = event.cast<double>();
-      return UserAccelerometerEvent(list[0]!, list[1]!, list[2]!);
+      return UserAccelerometerEvent(
+        list[0]!,
+        list[1]!,
+        list[2]!,
+        DateTime.fromMicrosecondsSinceEpoch(list[3]!.toInt()),
+      );
     });
     return _userAccelerometerEvents!;
   }
@@ -129,7 +144,12 @@ class MethodChannelSensors extends SensorsPlatform {
     _magnetometerEvents ??=
         _magnetometerEventChannel.receiveBroadcastStream().map((dynamic event) {
       final list = event.cast<double>();
-      return MagnetometerEvent(list[0]!, list[1]!, list[2]!);
+      return MagnetometerEvent(
+        list[0]!,
+        list[1]!,
+        list[2]!,
+        DateTime.fromMicrosecondsSinceEpoch(list[3]!.toInt()),
+      );
     });
     return _magnetometerEvents!;
   }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/user_accelerometer_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/user_accelerometer_event.dart
@@ -7,7 +7,7 @@
 /// [AccelerometerEvent], this event does not include the effects of gravity.
 class UserAccelerometerEvent {
   /// Constructs an instance with the given [x], [y], and [z] values.
-  UserAccelerometerEvent(this.x, this.y, this.z);
+  UserAccelerometerEvent(this.x, this.y, this.z, this.timestamp);
 
   /// Acceleration force along the x axis (excluding gravity) measured in m/s^2.
   ///
@@ -29,6 +29,18 @@ class UserAccelerometerEvent {
   /// towards the user and negative mean it is moving away from them.
   final double z;
 
+  /// timestamp of the event
+  ///
+  /// This is the timestamp of the event in microseconds, as provided by the
+  /// underlying platform. For Android, this is the timestamp in the event in
+  /// nanoseconds from the `android.os.SystemClock.elapsedRealtimeNanos` API,
+  /// and synchronized with SystemClock.uptimeMillis() to be in the same time.
+  /// For iOS, this is the TimeInterval in the event synchronized with
+  /// [NSDate timeIntervalSince1970] to be in the same time.
+
+  final DateTime timestamp;
+
   @override
-  String toString() => '[UserAccelerometerEvent (x: $x, y: $y, z: $z)]';
+  String toString() =>
+      '[UserAccelerometerEvent (x: $x, y: $y, z: $z, timestamp: $timestamp)]';
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
@@ -53,7 +53,13 @@ void main() {
 
   test('accelerometerEvents are streamed', () async {
     const channelName = 'dev.fluttercommunity.plus/sensors/accelerometer';
-    const sensorData = <double>[1.0, 2.0, 3.0];
+    final date = DateTime.now();
+    final sensorData = <double>[
+      1.0,
+      2.0,
+      3.0,
+      date.microsecondsSinceEpoch.toDouble(),
+    ];
     _initializeFakeMethodChannel('setAccelerationSamplingPeriod');
     _initializeFakeSensorChannel(channelName, sensorData);
 
@@ -62,11 +68,18 @@ void main() {
     expect(event.x, sensorData[0]);
     expect(event.y, sensorData[1]);
     expect(event.z, sensorData[2]);
+    expect(event.timestamp, date);
   });
 
   test('gyroscopeEvents are streamed', () async {
     const channelName = 'dev.fluttercommunity.plus/sensors/gyroscope';
-    const sensorData = <double>[3.0, 4.0, 5.0];
+    final date = DateTime.now();
+    final sensorData = <double>[
+      3.0,
+      4.0,
+      5.0,
+      date.microsecondsSinceEpoch.toDouble(),
+    ];
     _initializeFakeMethodChannel('setGyroscopeSamplingPeriod');
     _initializeFakeSensorChannel(channelName, sensorData);
 
@@ -75,11 +88,18 @@ void main() {
     expect(event.x, sensorData[0]);
     expect(event.y, sensorData[1]);
     expect(event.z, sensorData[2]);
+    expect(event.timestamp, date);
   });
 
   test('userAccelerometerEvents are streamed', () async {
     const channelName = 'dev.fluttercommunity.plus/sensors/user_accel';
-    const sensorData = <double>[6.0, 7.0, 8.0];
+    final date = DateTime.now();
+    final sensorData = <double>[
+      6.0,
+      7.0,
+      8.0,
+      date.microsecondsSinceEpoch.toDouble(),
+    ];
     _initializeFakeMethodChannel('setUserAccelerometerSamplingPeriod');
     _initializeFakeSensorChannel(channelName, sensorData);
 
@@ -88,11 +108,18 @@ void main() {
     expect(event.x, sensorData[0]);
     expect(event.y, sensorData[1]);
     expect(event.z, sensorData[2]);
+    expect(event.timestamp, date);
   });
 
   test('magnetometerEvents are streamed', () async {
     const channelName = 'dev.fluttercommunity.plus/sensors/magnetometer';
-    const sensorData = <double>[8.0, 9.0, 10.0];
+    final date = DateTime.now();
+    final sensorData = <double>[
+      8.0,
+      9.0,
+      10.0,
+      date.microsecondsSinceEpoch.toDouble(),
+    ];
     _initializeFakeMethodChannel('setMagnetometerSamplingPeriod');
     _initializeFakeSensorChannel(channelName, sensorData);
 
@@ -101,6 +128,7 @@ void main() {
     expect(event.x, sensorData[0]);
     expect(event.y, sensorData[1]);
     expect(event.z, sensorData[2]);
+    expect(event.timestamp, date);
   });
 }
 

--- a/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
@@ -142,13 +142,18 @@ void main() {
 
   test('barometerEvents are streamed', () async {
     const channelName = 'dev.fluttercommunity.plus/sensors/barometer';
-    const sensorData = <double>[1000.0];
+    final date = DateTime.now();
+    final sensorData = <double>[
+      1000.0,
+      date.microsecondsSinceEpoch.toDouble(),
+    ];
     _initializeFakeMethodChannel('setBarometerSamplingPeriod');
     _initializeFakeSensorChannel(channelName, sensorData);
 
     final event = await barometerEventStream().first;
 
     expect(event.pressure, sensorData[0]);
+    expect(event.timestamp, date);
   });
 }
 


### PR DESCRIPTION
## Description

Add timestamp to events from plateform instead of using DateTime.now() at event arrival that can suffer from jitter.
This can be useful to make fft or signal analysis.

I would start this PR as a discussion about the usefulness of this feature or how to implement it

I will provide the iOS implementation in the next few days

## Related Issues

- Fix https://github.com/flutter/flutter/issues/26078 event if it is not the same repo the problem is the same

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.
- The API change but most sensor streams users won't need to change anything (if you don't create events like `UserAccelerometerEvent`)
