### PR TITLE
fix(device_info_plus)!: return type of isPhysicalDevice as boolean for ios

### DIFF
--- a/packages/device_info_plus/device_info_plus/ios/Classes/FPPDeviceInfoPlusPlugin.m
+++ b/packages/device_info_plus/device_info_plus/ios/Classes/FPPDeviceInfoPlusPlugin.m
@@ -21,7 +21,8 @@
     struct utsname un;
     uname(&un);
 
-    NSNumber *isPhysicalNumber = [NSNumber numberWithBool:[self isDevicePhysical]];
+    NSNumber *isPhysicalNumber =
+        [NSNumber numberWithBool:[self isDevicePhysical]];
     NSString *machine;
     if ([self isDevicePhysical]) {
       machine = @(un.machine);
@@ -54,9 +55,9 @@
 
 // return value is false if code is run on a simulator
 - (BOOL)isDevicePhysical {
-    BOOL isPhysicalDevice = NO;
+  BOOL isPhysicalDevice = NO;
 #if TARGET_OS_SIMULATOR
-    isPhysicalDevice = NO;
+  isPhysicalDevice = NO;
 #else
   isPhysicalDevice = YES;
 #endif

--- a/packages/device_info_plus/device_info_plus/ios/Classes/FPPDeviceInfoPlusPlugin.m
+++ b/packages/device_info_plus/device_info_plus/ios/Classes/FPPDeviceInfoPlusPlugin.m
@@ -21,8 +21,9 @@
     struct utsname un;
     uname(&un);
 
+    NSNumber *isPhysicalNumber = [NSNumber numberWithBool:[self isDevicePhysical]];
     NSString *machine;
-    if ([[self isDevicePhysical] isEqualToString:@"true"]) {
+    if ([self isDevicePhysical]) {
       machine = @(un.machine);
     } else {
       machine = [[NSProcessInfo processInfo]
@@ -37,7 +38,7 @@
       @"localizedModel" : [device localizedModel],
       @"identifierForVendor" : [[device identifierForVendor] UUIDString]
           ?: [NSNull null],
-      @"isPhysicalDevice" : [self isDevicePhysical],
+      @"isPhysicalDevice" : isPhysicalNumber,
       @"utsname" : @{
         @"sysname" : @(un.sysname),
         @"nodename" : @(un.nodename),
@@ -52,11 +53,12 @@
 }
 
 // return value is false if code is run on a simulator
-- (NSString *)isDevicePhysical {
+- (BOOL)isDevicePhysical {
+    BOOL isPhysicalDevice = NO;
 #if TARGET_OS_SIMULATOR
-  NSString *isPhysicalDevice = @"false";
+    isPhysicalDevice = NO;
 #else
-  NSString *isPhysicalDevice = @"true";
+  isPhysicalDevice = YES;
 #endif
 
   return isPhysicalDevice;

--- a/packages/device_info_plus/device_info_plus/lib/src/model/ios_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/ios_device_info.dart
@@ -65,7 +65,7 @@ class IosDeviceInfo extends BaseDeviceInfo {
       model: map['model'],
       localizedModel: map['localizedModel'],
       identifierForVendor: map['identifierForVendor'],
-      isPhysicalDevice: map['isPhysicalDevice'] == 'true',
+      isPhysicalDevice: map['isPhysicalDevice'],
       utsname:
           IosUtsname._fromMap(map['utsname']?.cast<String, dynamic>() ?? {}),
     );

--- a/packages/device_info_plus/device_info_plus/test/model/ios_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/ios_device_info_test.dart
@@ -19,7 +19,7 @@ void main() {
         'model': 'model',
         'utsname': iosUtsnameMap,
         'systemName': 'systemName',
-        'isPhysicalDevice': 'true',
+        'isPhysicalDevice': true,
         'systemVersion': 'systemVersion',
         'localizedModel': 'localizedModel',
         'identifierForVendor': 'identifierForVendor',


### PR DESCRIPTION
## Description

For iOS devices `isPhysicalDevice` was returned as `String` from native platform, now it is returning boolean from native platform.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.*

*e.g.*
- *Fix #2483  *
- *Related N/A*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

