### PR TITLE
docs(share_plus): Fix supported platforms in README

### DIFF
--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -22,7 +22,7 @@ on iOS.
 
 Also compatible with Windows and Linux by using "mailto" to share text via Email.
 
-Sharing files is not supported on Windows and Linux.
+Sharing files is not supported on Linux.
 
 ## Usage
 


### PR DESCRIPTION
Updated file-sharing compatibility text for desktop platforms

## Description

The readme file had misleading info stating file sharing is not supported on Linux and Windows. But on Windows file sharing was working. This PR contains a fix for that.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

