### PR TITLE
fix(share_plus): fix shareUri method adding sharePositionOrigin parameter.

### DIFF
--- a/packages/share_plus/share_plus/example/lib/image_previews.dart
+++ b/packages/share_plus/share_plus/example/lib/image_previews.dart
@@ -13,8 +13,7 @@ class ImagePreviews extends StatelessWidget {
 
   /// Creates a widget for preview of images. [imagePaths] can not be empty
   /// and all contained paths need to be non empty.
-  const ImagePreviews(this.imagePaths, {Key? key, this.onDelete})
-      : super(key: key);
+  const ImagePreviews(this.imagePaths, {super.key, this.onDelete});
 
   @override
   Widget build(BuildContext context) {
@@ -41,8 +40,7 @@ class _ImagePreview extends StatelessWidget {
   final String imagePath;
   final VoidCallback? onDelete;
 
-  const _ImagePreview(this.imagePath, {Key? key, this.onDelete})
-      : super(key: key);
+  const _ImagePreview(this.imagePath, {this.onDelete});
 
   @override
   Widget build(BuildContext context) {

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -22,7 +22,7 @@ void main() {
 }
 
 class DemoApp extends StatefulWidget {
-  const DemoApp({Key? key}) : super(key: key);
+  const DemoApp({super.key});
 
   @override
   DemoAppState createState() => DemoAppState();
@@ -197,7 +197,8 @@ class DemoAppState extends State<DemoApp> {
     final box = context.findRenderObject() as RenderBox?;
 
     if (uri.isNotEmpty) {
-      await Share.shareUri(Uri.parse(uri));
+      await Share.shareUri(Uri.parse(uri),
+          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
     } else if (imagePaths.isNotEmpty) {
       final files = <XFile>[];
       for (var i = 0; i < imagePaths.length; i++) {

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -25,10 +25,21 @@ class Share {
   /// on iOS. [shareUri] will trigger the iOS system to fetch the html page
   /// (if available), and the website icon will be extracted and displayed on
   /// the iOS share sheet.
+  ///
+  /// The optional `sharePositionOrigin` parameter can be used to specify a global
+  /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
+  /// on other devices.
+  ///
+  /// May throw [PlatformException]
+  /// from [MethodChannel].
   static Future<void> shareUri(
-    Uri uri,
-  ) async {
-    return _platform.shareUri(uri);
+    Uri uri, {
+    Rect? sharePositionOrigin,
+  }) async {
+    return _platform.shareUri(
+      uri,
+      sharePositionOrigin: sharePositionOrigin,
+    );
   }
 
   /// Summons the platform's share sheet to share text.

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -24,8 +24,19 @@ class MethodChannelShare extends SharePlatform {
       MethodChannel('dev.fluttercommunity.plus/share');
 
   @override
-  Future<void> shareUri(Uri uri) {
+  Future<void> shareUri(
+    Uri uri, {
+    Rect? sharePositionOrigin,
+  }) {
     final params = <String, dynamic>{'uri': uri.toString()};
+
+    if (sharePositionOrigin != null) {
+      params['originX'] = sharePositionOrigin.left;
+      params['originY'] = sharePositionOrigin.top;
+      params['originWidth'] = sharePositionOrigin.width;
+      params['originHeight'] = sharePositionOrigin.height;
+    }
+
     return channel.invokeMethod<void>('shareUri', params);
   }
 

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -31,7 +31,16 @@ class SharePlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  Future<void> shareUri(Uri uri) => _instance.shareUri(uri);
+  /// Share uri.
+  Future<void> shareUri(
+    Uri uri, {
+    Rect? sharePositionOrigin,
+  }) {
+    return _instance.shareUri(
+      uri,
+      sharePositionOrigin: sharePositionOrigin,
+    );
+  }
 
   /// Share text.
   Future<void> share(

--- a/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
+++ b/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
@@ -62,6 +62,18 @@ void main() {
   });
 
   test('sharing origin sets the right params', () async {
+    await sharePlatform.shareUri(
+      Uri.parse('https://pub.dev/packages/share_plus'),
+      sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
+    );
+    verify(mockChannel.invokeMethod<void>('shareUri', <String, dynamic>{
+      'uri': 'https://pub.dev/packages/share_plus',
+      'originX': 1.0,
+      'originY': 2.0,
+      'originWidth': 3.0,
+      'originHeight': 4.0,
+    }));
+
     await sharePlatform.share(
       'some text to share',
       subject: 'some subject to share',


### PR DESCRIPTION
## Description

**share_plus** requires iPad users to provide the **sharePositionOrigin** parameter. This parameter is not available in the **shareUri** method.

When the **sharePositionOrigin**  parameter is not provided on iPads you will see the following error: 
```
PlatformException (PlatformException(error, sharePositionOrigin: argument must be set, {{0, 0}, {0, 0}} must be non-zero and within coordinate space of source view: {{0, 0}, {1024, 1366}}, null, null))
```
This PR also:
- Updates the tests. **shareUri** method was not included in the tests.
- Updates and fixes the example.

## Related Issues

- Fix #2464

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

