### PR TITLE
fix(share_plus): Ensure subject is not null before calling putExtra(Intent.EXTRA_SUBJECT, subject)

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -60,7 +60,9 @@ internal class Share(
             action = Intent.ACTION_SEND
             type = "text/plain"
             putExtra(Intent.EXTRA_TEXT, text)
-            putExtra(Intent.EXTRA_SUBJECT, subject)
+            if (subject != null) {
+                putExtra(Intent.EXTRA_SUBJECT, subject)
+            }
         }
         // If we dont want the result we use the old 'createChooser'
         val chooserIntent = if (withResult) {


### PR DESCRIPTION
## Description

My friend who would share links via `share_plus` through Verizon's Message+ app, faced an issue where there would always be an additional null message alongside the shared link:

<img width="168" alt="Screenshot 2024-01-10 at 3 14 34 PM" src="https://github.com/fluttercommunity/plus_plugins/assets/56136732/3f458188-47aa-441a-98e3-0f3e45c1c54e">

After doing a lot of digging and trying different things to try to fix this, I noticed that `Intent.EXTRA_SUBJECT` is always set to null when a subject is not specified. I suspected that this was the issue, given it was only happening for this one messaging platform, which may not filter out a null subject like most others do. Sure enough, after using my fork in place of the official `share_plus` package and having my friend send me a link again, this issue was fixed. I suspect that there may be other platforms affected by this as well.

## Related Issues

N/A

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.


