### PR TITLE
docs: Added ios simulators note for testing

### DIFF
--- a/packages/network_info_plus/network_info_plus/README.md
+++ b/packages/network_info_plus/network_info_plus/README.md
@@ -61,6 +61,10 @@ To successfully get WiFi Name or Wi-Fi BSSID starting with Android 1O, ensure al
 >
 > This package does not provide the ACCESS_FINE_LOCATION nor the ACCESS_COARSE_LOCATION permission by default
 
+> **Note**
+>
+> Unlike Android, It is not possible to get wifi info in IOS simulators and It is going to be always `null`.
+
 #### iOS 12
 
 To use `.getWifiBSSID()` and `.getWifiName()` on iOS >= 12, the `Access WiFi information capability` in XCode must be enabled. Otherwise, both methods will return null.

--- a/packages/network_info_plus/network_info_plus/README.md
+++ b/packages/network_info_plus/network_info_plus/README.md
@@ -63,7 +63,8 @@ To successfully get WiFi Name or Wi-Fi BSSID starting with Android 1O, ensure al
 
 > **Note**
 >
-> Unlike Android, It is not possible to get wifi info in IOS simulators and It is going to be always `null`.
+> On iOS simulators wifi info will always return `null`.
+> Android emulators have no such issue.
 
 #### iOS 12
 


### PR DESCRIPTION
Since I didn't see that network info plus doesn't work in IOS simulators and I got null every time I made this PR to add that note to readme and avoid wasting time.
