### PR TITLE
fix(device_info_plus): fix crash on non-standard Digital Product IDs

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
@@ -54,6 +54,7 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
       final digitalProductIdValue =
           currentVersionKey.getValue('DigitalProductId');
       final digitalProductId = digitalProductIdValue != null
+          && digitalProductIdValue.data is Uint8List
           ? digitalProductIdValue.data as Uint8List
           : [] as Uint8List;
       final displayVersion =

--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
@@ -53,8 +53,8 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
       final buildLabEx = currentVersionKey.getValueAsString('BuildLabEx') ?? '';
       final digitalProductIdValue =
           currentVersionKey.getValue('DigitalProductId');
-      final digitalProductId = digitalProductIdValue != null
-          && digitalProductIdValue.data is Uint8List
+      final digitalProductId = digitalProductIdValue != null &&
+              digitalProductIdValue.data is Uint8List
           ? digitalProductIdValue.data as Uint8List
           : [] as Uint8List;
       final displayVersion =


### PR DESCRIPTION
## Description

Fixes a crash in DIP when the Digital product ID on Windows is malformed.

By the way, the analyzer is in fact failing on my machine on this PR, but this is due to already existing errors within all modules.
I will not fix them here as they are unrelated to this PR.
If you think, I can also fix (at least the DIP-related ones) in this PR, I will of course do so.

## Related Issues

- Fixes #2270

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

