### PR TITLE
chore(device_info_plus): Switch CI runners to M1

### DIFF
--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   android_example_build:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -37,7 +37,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     strategy:
       matrix:
@@ -64,7 +64,7 @@ jobs:
           script: ./.github/workflows/scripts/integration-test.sh android device_info_plus_example
 
   ios_example_build:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -77,7 +77,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh ios ./lib/main.dart
 
   ios_integration_test:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -96,7 +96,7 @@ jobs:
         run: ./.github/workflows/scripts/integration-test.sh ios device_info_plus_example
 
   macos_example_build:
-    runs-on: macos-latest
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -109,7 +109,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh macos ./lib/main.dart
 
   macos_integration_test:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -37,7 +37,8 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-14
+    # Use non M1 machine till https://github.com/ReactiveCircus/android-emulator-runner/issues/350 is resolved
+    runs-on: macos-13
     timeout-minutes: 30
     strategy:
       matrix:

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -58,7 +58,7 @@ jobs:
           api-level: ${{ matrix.android-api-level }}
           cores: 3
           target: google_apis
-          arch: x86_64
+          arch: arm64-v8a
           force-avd-creation: false
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android device_info_plus_example

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -59,7 +59,7 @@ jobs:
           api-level: ${{ matrix.android-api-level }}
           cores: 3
           target: google_apis
-          arch: arm64-v8a
+          arch: x86_64
           force-avd-creation: false
           profile: Nexus 5X
           script: ./.github/workflows/scripts/integration-test.sh android device_info_plus_example


### PR DESCRIPTION
## Description

Testing how new M1 runners work

https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/