### PR TITLE
chore(battery_plus): Switch CI runners to M1

### DIFF
--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   android_example_build:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -37,6 +37,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
+    # Use non M1 machine till https://github.com/ReactiveCircus/android-emulator-runner/issues/350 is resolved
     runs-on: macos-13
     timeout-minutes: 30
     strategy:
@@ -65,7 +66,7 @@ jobs:
           script: ./.github/workflows/scripts/integration-test.sh android battery_plus_example
 
   ios_example_build:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -78,7 +79,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh ios ./lib/main.dart
 
   ios_integration_test:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -97,7 +98,7 @@ jobs:
         run: ./.github/workflows/scripts/integration-test.sh ios battery_plus_example
 
   macos_example_build:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -111,7 +112,7 @@ jobs:
 
   macos_integration_test:
     if: false # Disabled as battery_plus APIs don't complete in github actions macos VMs.
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"


### PR DESCRIPTION
Switching the next plugin to M1
