### PR TITLE
chore(android_alarm_manager_plus): Partially switch CI runners to M1

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   android_example_build:
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -33,6 +33,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
+    # Use non M1 machine till https://github.com/ReactiveCircus/android-emulator-runner/issues/350 is resolved
     runs-on: macos-13
     timeout-minutes: 30
     strategy:


### PR DESCRIPTION
## Description

Switching to M1. Note, like the rest of plugins job to run Android integration tests doesn't migrate due to emulator Action not supporting ARMs at the moment.
