### PR TITLE
fix(sensors_plus): Add iOS Privacy Info

### DIFF
--- a/packages/sensors_plus/sensors_plus/ios/PrivacyInfo.xcprivacy
+++ b/packages/sensors_plus/sensors_plus/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/sensors_plus/sensors_plus/ios/sensors_plus.podspec
+++ b/packages/sensors_plus/sensors_plus/ios/sensors_plus.podspec
@@ -21,4 +21,5 @@ Flutter plugin to access the accelerometer, gyroscope, and magnetometer sensors.
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
   s.swift_version = '5.0'
+  s.resource_bundles = {'sensors_plus_privacy' => ['PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
## Description

- Add PrivacyInfo to podspec of **Sensors Plus**

## Related Issues

- Part of #2447

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

