### PR TITLE
chore(share_plus): Workaround for failing integration tests

### DIFF
--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -22,19 +22,6 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*share_plus_example*"
 
 jobs:
-  android_build:
-    runs-on: macos-14
-    timeout-minutes: 30
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-      - name: "Install Flutter"
-        run: ./.github/workflows/scripts/install-flutter.sh stable
-      - name: "Install Tools"
-        run: ./.github/workflows/scripts/install-tools.sh
-      - name: "Build Example"
-        run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
-
   android_integration_test:
     # Use non M1 machine till https://github.com/ReactiveCircus/android-emulator-runner/issues/350 is resolved
     runs-on: macos-13
@@ -52,6 +39,16 @@ jobs:
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"
+        
+      # Workaround for the timeout problem with
+      # Android integration tests. 
+      # Based on https://github.com/flutter/flutter/issues/105913#issuecomment-1451585766
+      #
+      # Currently, it's not possible to increase the timeout for integration tests:
+      # https://github.com/flutter/flutter/issues/105913.
+      - name: "Build Example app"
+        run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
+        
       - name: "Android Integration Test"
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/packages/share_plus/share_plus/ios/PrivacyInfo.xcprivacy
+++ b/packages/share_plus/share_plus/ios/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/share_plus/share_plus/ios/share_plus.podspec
+++ b/packages/share_plus/share_plus/ios/share_plus.podspec
@@ -21,5 +21,6 @@ Downloaded by pub (not CocoaPods).
 
   s.platform = :ios, '11.0'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.resource_bundles = {'share_plus_privacy' => ['PrivacyInfo.xcprivacy']}
 end
 


### PR DESCRIPTION
## Description

This is the workaround that I mentioned during one of discussions. Found it here: https://github.com/flutter/flutter/issues/105913#issuecomment-1451585766

As build happens for integration tests anyway I think it makes no sense to build the app in a separate job, I believe, as ше ші just a waste of resources. Also, the drawback of this is that we won't be able to use M1 machine for this job till the issue with emulators which I mentioned in one of comments there is resolved.

In case it works I will open a similar PR for other plugins.
