### PR TITLE
refactor(network_info_plus)!: bump MACOSX_DEPLOYMENT_TARGET from 10.11 to 10.14

### DIFF
--- a/packages/network_info_plus/network_info_plus/macos/network_info_plus.podspec
+++ b/packages/network_info_plus/network_info_plus/macos/network_info_plus.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.dependency 'FlutterMacOS'
 
   s.platform = :osx
-  s.osx.deployment_target = '10.11'
+  s.osx.deployment_target = '10.14'
 end
 


### PR DESCRIPTION
## Description

Bump `MACOSX_DEPLOYMENT_TARGET` to Flutter minimum (10.14)

See #2529 for more details.

## Related Issues

Resolves #2529 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.