### PR TITLE
chore(package_info_plus): support web 0.5.0

### DIFF
--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
   meta: ^1.8.0
   path: ^1.8.2
   package_info_plus_platform_interface: ^2.0.1
-  web: '>=0.3.0 <0.5.0'
+  web: ">=0.3.0 <0.6.0"
 
   # win32 is compatible across v4 and v5 for Win32 only (not COM)
   win32: ">=4.0.0 <6.0.0"
@@ -46,4 +46,4 @@ dev_dependencies:
 
 environment:
   sdk: ^3.2.0
-  flutter: '>=3.6.0'
+  flutter: ">=3.6.0"


### PR DESCRIPTION
## Description

Allow the latest 0.5.0 release of the web package.
Other packages like http already require a minimum version of 0.5.0 (changelog)[https://pub.dev/packages/http/changelog#121].

## Related Issues
none

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR. (issues are already present on main)

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

