### PR TITLE
fix(device_info_plus): remove unnecessary print

### DIFF
--- a/packages/device_info_plus/device_info_plus/macos/Classes/CwlSysctl.swift
+++ b/packages/device_info_plus/device_info_plus/macos/Classes/CwlSysctl.swift
@@ -37,7 +37,6 @@ public struct Sysctl {
 			let preFlightResult = Darwin.sysctl(UnsafeMutablePointer<Int32>(mutating: keysPointer.baseAddress), UInt32(keys.count), nil, &requiredSize, nil, 0)
 			if preFlightResult != 0 {
 				throw POSIXErrorCode(rawValue: errno).map {
-					print($0.rawValue)
 					return Error.posixError($0)
 				} ?? Error.unknown
 			}


### PR DESCRIPTION
## Description

removed one print line

## Related Issues

- Fix #2526

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

