### PR TITLE
feat(battery_plus): Added power source type of how the device is powered.

### DIFF
--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -58,6 +58,9 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
                     result.error("UNAVAILABLE", "Battery level not available.", null)
                 }
             }
+            "getPowerSourceType" -> {
+                result.success(getPowerSourceType())
+            }
 
             "getBatteryState" -> {
                 val currentBatteryStatus = getBatteryStatus()
@@ -108,6 +111,20 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
         }
         return convertBatteryStatus(status)
     }
+
+    private fun getPowerSourceType(): String? {
+            val intent = ContextWrapper(applicationContext).registerReceiver(null, IntentFilter(Intent.ACTION_BATTERY_CHANGED))
+            val source = intent!!.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
+           return when (source) {
+                -1 -> "unknown"
+                0 -> "battery"
+                BatteryManager.BATTERY_PLUGGED_AC -> "ac"
+                BatteryManager.BATTERY_PLUGGED_DOCK -> "dock"
+                BatteryManager.BATTERY_PLUGGED_USB -> "usb"
+                BatteryManager.BATTERY_PLUGGED_WIRELESS -> "wireless"
+                else -> null
+            }
+    } 
 
     private fun getBatteryLevel(): Int {
         return if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {

--- a/packages/battery_plus/battery_plus/lib/battery_plus.dart
+++ b/packages/battery_plus/battery_plus/lib/battery_plus.dart
@@ -44,6 +44,20 @@ class Battery {
     return _platform.isInBatterySaveMode;
   }
 
+  /// get the current power source type.
+  ///
+  /// When the [BatteryState] is in a state of
+  /// [BatteryState.connectedNotCharging],[BatteryState.charging]
+  /// or [BatteryState.full], the [PowerSourceType] can be determined
+  /// and see how the device gets it's power.
+  ///
+  /// when the device is mobile and has the [BatteryState] of
+  /// [BatteryState.discharging] or [BatteryState.unknown] the power source can 
+  /// not be determined
+  Future<PowerSourceType> get powerSourceType {
+    return _platform.powerSourceType;
+  }
+
   /// Get battery state
   Future<BatteryState> get batteryState {
     return _platform.batteryState;

--- a/packages/battery_plus/battery_plus/lib/battery_plus.dart
+++ b/packages/battery_plus/battery_plus/lib/battery_plus.dart
@@ -7,7 +7,7 @@ import 'dart:async';
 import 'package:battery_plus_platform_interface/battery_plus_platform_interface.dart';
 
 export 'package:battery_plus_platform_interface/battery_plus_platform_interface.dart'
-    show BatteryState;
+    show BatteryState, PowerSourceType;
 
 export 'src/battery_plus_linux.dart';
 
@@ -52,7 +52,7 @@ class Battery {
   /// and see how the device gets it's power.
   ///
   /// when the device is mobile and has the [BatteryState] of
-  /// [BatteryState.discharging] or [BatteryState.unknown] the power source can 
+  /// [BatteryState.discharging] or [BatteryState.unknown] the power source can
   /// not be determined
   Future<PowerSourceType> get powerSourceType {
     return _platform.powerSourceType;

--- a/packages/battery_plus/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/battery_plus_platform_interface.dart
@@ -52,6 +52,10 @@ abstract class BatteryPlatform extends PlatformInterface {
     throw UnimplementedError('batteryState() has not been implemented.');
   }
 
+  Future<PowerSourceType> get powerSourceType {
+    throw UnimplementedError('powerSourceType() has not been implemented.');
+  }
+
   /// Returns a Stream of BatteryState changes.
   Stream<BatteryState> get onBatteryStateChanged {
     throw UnimplementedError(

--- a/packages/battery_plus/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/method_channel_battery_plus.dart
@@ -42,6 +42,13 @@ class MethodChannelBattery extends BatteryPlatform {
       .invokeMethod<String>('getBatteryState')
       .then<BatteryState>((dynamic result) => parseBatteryState(result));
 
+  @override
+  Future<PowerSourceType> get powerSourceType => methodChannel
+      .invokeMethod<String>('getPowerSourceType')
+      .then<PowerSourceType>(
+        (dynamic result) => PowerSourceType.parsePowerSource(result),
+      );
+
   /// Fires whenever the battery state changes.
   @override
   Stream<BatteryState> get onBatteryStateChanged {

--- a/packages/battery_plus/battery_plus_platform_interface/lib/src/enums.dart
+++ b/packages/battery_plus/battery_plus_platform_interface/lib/src/enums.dart
@@ -20,3 +20,42 @@ enum BatteryState {
   /// The state of the battery is unknown.
   unknown;
 }
+
+/// Indicates the current power source type.
+///
+/// When the [BatteryState] is in a state of
+///  [connectedNotCharging],[charging] or [full].
+///
+/// We can get some extra info battery info on how it is powered.
+enum PowerSourceType {
+  /// Power source is an AC charger.
+  ac('ac'),
+
+  /// Power source is dock.
+  dock('dock'),
+
+  /// Power source is a USB port.
+  usb('usb'),
+
+  /// Power source is wireless.
+  wireless('wireless'),
+
+  /// Power source is battery
+  battery('battery'),
+
+  /// Power source could not be determined.
+  unknown('unknown');
+
+  /// The known string value communicated from the channel.
+  final String _state;
+
+  const PowerSourceType(this._state);
+
+  /// Parse the power source string value to the given power source type.
+  static PowerSourceType parsePowerSource(String? value) {
+    return PowerSourceType.values.firstWhere(
+      (sourceType) => sourceType._state == value,
+      orElse: () => PowerSourceType.unknown,
+    );
+  }
+}


### PR DESCRIPTION
## Description

This PR updates the battery_plus plugin to handle power source type fetching on mobile. 
When you request the PowerSource type from the plugin it will try to get the source type from the intent battery changed extras, to indicate if the power source is AC, USB, Wireless or by battery.

### Motivation
We work with mobile scanner devices that run on Android and are socketed in Cradles for their charging and release to the users. 
There is no communication between the cradle and the scanner to detect if the scanner is in the cradle except for its power state. With the current version of the battery_plus package, we can detect whether the system is charging. But for development purposes, as an example, it is possible to also have a USB cable attached to the device.
This will break the charging logic, and we require a second parameter to determine if the power source is our USB cable, the cradle, or the battery. 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

