### PR TITLE
fix(share_plus): Add missing call to result for shareUri on iOS

### DIFF
--- a/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
@@ -358,6 +358,8 @@ TopViewControllerForViewController(UIViewController *viewController) {
                     atSource:originRect
                     toResult:result
                   withResult:withResult];
+          if (!withResult)
+            result(nil);
         } else {
           result(FlutterMethodNotImplemented);
         }


### PR DESCRIPTION
## Description

- The code was never completing when being awaited.
- This is due to the missing call to `result(nil)`.
- Tested on iOS simulator using example project.

## Related Issues

- Fix #2609 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

