### PR TITLE
Remove absolute path for linux

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_linux.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_linux.dart
@@ -3,7 +3,6 @@ import 'dart:io';
 
 import 'package:package_info_plus_platform_interface/package_info_data.dart';
 import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
-import 'package:path/path.dart' as path;
 
 /// The Linux implementation of [PackageInfoPlatform].
 class PackageInfoPlusLinuxPlugin extends PackageInfoPlatform {
@@ -28,11 +27,7 @@ class PackageInfoPlusLinuxPlugin extends PackageInfoPlatform {
 
   Future<Map<String, dynamic>> _getVersionJson() async {
     try {
-      final exePath = await File('/proc/self/exe').resolveSymbolicLinks();
-      final appPath = path.dirname(exePath);
-      final assetPath = path.join(appPath, 'data', 'flutter_assets');
-      final versionPath = path.join(assetPath, 'version.json');
-      return jsonDecode(await File(versionPath).readAsString());
+      return jsonDecode(await File('version.json').readAsString());
     } catch (_) {
       return <String, dynamic>{};
     }


### PR DESCRIPTION
## Description

The Linux GTK has a registered Asset Manager for the flutter_assets folder.  This means you do not need to use an absolute path from Dart to access resources in the flutter_assets folder.  Also when using external embedders the absolute
 path to flutter_assets will not always be relative to the embedder executable.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.
