### PR TITLE
chore(all): Update GitHub Action for Dart Analyzer

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: "Bootstrap Workspace"
         run: melos bootstrap
       - name: "Run Dart Analyze"
-        uses: invertase/github-action-dart-analyzer@v2.0.0
+        uses: invertase/github-action-dart-analyzer@v3
         with:
           fatal-infos: false
           fatal-warnings: true


### PR DESCRIPTION
## Description

Bumping to v3 to use Node 20 to be in line with Github's changes: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Currently, we also have warnings after CI runs due to usage of Node 16:
<img width="1056" alt="Screenshot 2024-02-28 at 10 19 03" src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/0795f5e6-10d3-482f-b9f9-d9d24c9603ca">

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

