### PR TITLE
feat(package_info_plus)!: Migrate to js_interop for conditional export

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -9,7 +9,7 @@ import 'package:package_info_plus_platform_interface/package_info_platform_inter
 
 export 'src/package_info_plus_linux.dart';
 export 'src/package_info_plus_windows.dart'
-    if (dart.library.html) 'src/package_info_plus_web.dart';
+    if (dart.library.js_interop) 'src/package_info_plus_web.dart';
 
 /// Application metadata. Provides application bundle information on iOS and
 /// application package information on Android.

--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
@@ -4,7 +4,7 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:http/http.dart';
 import 'package:package_info_plus_platform_interface/package_info_data.dart';
 import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
-import 'package:web/helpers.dart' as web;
+import 'package:web/web.dart' as web;
 
 /// The web implementation of [PackageInfoPlatform].
 ///


### PR DESCRIPTION
## Description

I removed html for conditional import and used js_interop to support WASM
## Related Issues

-  Fix https://github.com/fluttercommunity/plus_plugins/issues/2623

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

