### PR TITLE
feat(package_info_plus): Use js_interop instead of html to support compilation to WASM

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -9,7 +9,7 @@ import 'package:package_info_plus_platform_interface/package_info_platform_inter
 
 export 'src/package_info_plus_linux.dart';
 export 'src/package_info_plus_windows.dart'
-    if (dart.library.html) 'src/package_info_plus_web.dart';
+    if (dart.library.js_interop) 'src/package_info_plus_web.dart';
 
 /// Application metadata. Provides application bundle information on iOS and
 /// application package information on Android.


### PR DESCRIPTION
## Description

Opening as a replacement for #2622 as there the author couldn't explain clearly why that change was needed in the PR description.

Despite the fact that `package_info_plus` already migrated to package `web` in November in #2316 it was still not fully compatible with WASM according to point 1 here: https://dart.dev/interop/js-interop/package-web#package-web-vs-dart-html

There is a suggestion on how imports need to be modified to support WASM compilation: https://dart.dev/interop/js-interop/package-web#conditional-imports

Change in this PR is based on that suggestion.

## Related Issues

It was briefly mentioned in #2623 but had poor title and explanation.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

