### PR TITLE
feat(device_info_plus): LinuxDeviceInfo toString method

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/model/linux_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/linux_device_info.dart
@@ -160,4 +160,9 @@ class LinuxDeviceInfo implements BaseDeviceInfo {
       'machineId': machineId,
     };
   }
+
+  @override
+  String toString() {
+    return 'LinuxDeviceInfo(name: $name, version: $version, id: $id, idLike: $idLike, versionCodename: $versionCodename, versionId: $versionId, prettyName: $prettyName, buildId: $buildId, variant: $variant, variantId: $variantId, machineId: $machineId)';
+  }
 }

--- a/packages/device_info_plus/device_info_plus/test/model/linux_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/linux_device_info_test.dart
@@ -34,5 +34,26 @@ void main() {
         'machineId': 'machineId',
       });
     });
+
+    test('toString should return string representation', () {
+      final linuxDeviceInfo = LinuxDeviceInfo(
+        name: 'name',
+        version: 'version',
+        id: 'id',
+        idLike: ['idLike'],
+        versionCodename: 'versionCodename',
+        versionId: 'versionId',
+        prettyName: 'prettyName',
+        buildId: 'buildId',
+        variant: 'variant',
+        variantId: 'variantId',
+        machineId: 'machineId',
+      );
+
+      expect(
+        linuxDeviceInfo.toString(),
+        'LinuxDeviceInfo(name: name, version: version, id: id, idLike: [idLike], versionCodename: versionCodename, versionId: versionId, prettyName: prettyName, buildId: buildId, variant: variant, variantId: variantId, machineId: machineId)',
+      );
+    });
   });
 }


### PR DESCRIPTION
## Description

Adds `toString` for `LinuxDeviceInfo`. This is useful when debugging apps on Linux distros.

## Related Issues

N/A

## Checklist

- [X] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.