### PR TITLE
fix (network_info_plus): Added getWifiIPv6, getWifiSubmask, getWifiBroadcast and getWifiGatewayIP functions for Windows and fixed getWifiName and getWifiBSSID.

### DIFF
--- a/packages/network_info_plus/network_info_plus/example/lib/main.dart
+++ b/packages/network_info_plus/network_info_plus/example/lib/main.dart
@@ -148,36 +148,28 @@ class _MyHomePageState extends State<MyHomePage> {
     }
 
     try {
-      if (!Platform.isWindows) {
-        wifiIPv6 = await _networkInfo.getWifiIPv6();
-      }
+      wifiIPv6 = await _networkInfo.getWifiIPv6();
     } on PlatformException catch (e) {
       developer.log('Failed to get Wifi IPv6', error: e);
       wifiIPv6 = 'Failed to get Wifi IPv6';
     }
 
     try {
-      if (!Platform.isWindows) {
-        wifiSubmask = await _networkInfo.getWifiSubmask();
-      }
+      wifiSubmask = await _networkInfo.getWifiSubmask();
     } on PlatformException catch (e) {
       developer.log('Failed to get Wifi submask address', error: e);
       wifiSubmask = 'Failed to get Wifi submask address';
     }
 
     try {
-      if (!Platform.isWindows) {
-        wifiBroadcast = await _networkInfo.getWifiBroadcast();
-      }
+      wifiBroadcast = await _networkInfo.getWifiBroadcast();
     } on PlatformException catch (e) {
       developer.log('Failed to get Wifi broadcast', error: e);
       wifiBroadcast = 'Failed to get Wifi broadcast';
     }
 
     try {
-      if (!Platform.isWindows) {
-        wifiGatewayIP = await _networkInfo.getWifiGatewayIP();
-      }
+      wifiGatewayIP = await _networkInfo.getWifiGatewayIP();
     } on PlatformException catch (e) {
       developer.log('Failed to get Wifi gateway address', error: e);
       wifiGatewayIP = 'Failed to get Wifi gateway address';

--- a/packages/network_info_plus/network_info_plus/lib/src/network_info_plus_windows.dart
+++ b/packages/network_info_plus/network_info_plus/lib/src/network_info_plus_windows.dart
@@ -62,19 +62,22 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
 
         const opCode = 7; // wlan_intf_opcode_current_connection
         final pdwDataSize = calloc<DWORD>();
-        final pAttributes = calloc<WLAN_CONNECTION_ATTRIBUTES>();
+        final ppAttributes = calloc<Pointer<WLAN_CONNECTION_ATTRIBUTES>>();
 
         try {
           hr = WlanQueryInterface(clientHandle, pInterfaceGuid, opCode, nullptr,
-              pdwDataSize, pAttributes.cast(), nullptr);
+              pdwDataSize, ppAttributes.cast(), nullptr);
           if (hr != ERROR_SUCCESS) break;
-          if (pAttributes.ref.isState != 0) {
-            return query(pInterfaceGuid, pAttributes);
+          if (ppAttributes.value.ref.isState != 0) {
+            return query(pInterfaceGuid, ppAttributes.value);
           }
         } finally {
           free(pInterfaceGuid);
           free(pdwDataSize);
-          free(pAttributes);
+          if (ppAttributes.value != nullptr) {
+            WlanFreeMemory(ppAttributes.value);
+          }
+          free(ppAttributes);
         }
       }
       return null;

--- a/packages/network_info_plus/network_info_plus/lib/src/windows_structs.dart
+++ b/packages/network_info_plus/network_info_plus/lib/src/windows_structs.dart
@@ -1,0 +1,42 @@
+// ignore_for_file: camel_case_types, non_constant_identifier_names
+
+// Created structs for SOCKADDR_IN and SOCKADDR_IN6 that are missing in win32 library.
+
+import 'dart:ffi';
+
+/// The SOCKADDR_IN structure specifies a transport address and port for the AF_INET address family.
+///
+/// {@category struct}
+class SOCKADDR_IN extends Struct {
+  @Uint16()
+  external int sin_family;
+
+  @Uint16()
+  external int sin_port;
+
+  @Uint32()
+  external int sin_addr;
+
+  @Array(8)
+  external Array<Uint8> sin_zero;
+}
+
+/// The SOCKADDR_IN6 structure specifies a transport address and port for the AF_INET6 address family.
+///
+/// {@category struct}
+class SOCKADDR_IN6 extends Struct {
+  @Uint16()
+  external int sin6_family;
+
+  @Uint16()
+  external int sin6_port;
+
+  @Uint32()
+  external int sin6_flowinfo;
+
+  @Array(16)
+  external Array<Uint8> sin6_addr;
+
+  @Uint32()
+  external int sin6_scope_id;
+}

--- a/packages/network_info_plus/network_info_plus/test/network_info_plus_windows_test.dart
+++ b/packages/network_info_plus/network_info_plus/test/network_info_plus_windows_test.dart
@@ -14,7 +14,7 @@ void main() {
   test('Test BSSID', () async {
     final plugin = NetworkInfoPlusWindowsPlugin();
     final bssID = await plugin.getWifiBSSID();
-    expect(bssID, equals('00:00:00:00:00:00'));
+    expect(bssID, matches(r'^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$'));
   });
 
   test('Wifi name', () async {


### PR DESCRIPTION
## Description

These functions were available for other platforms but not for Windows:

- `getWifiIPv6`
- `getWifiSubmask`
- `getWifiBroadcast`
- `getWifiGatewayIP`

I have added these functions to `network_info_plus_windows.dart` and created win32 structs required for it in file `windows_structs.dart`. 

I have created some helper functions and modified existing functions:
- `formatIPAddress` (modified): It will use `SOCKADDR` pointer as parameter and is able to format both IPv4 and IPv6.
- `getIPAddr` (new helper): Moved functionality of previous `getWifiIP` function here and generalized it for IPv4 and IPv6.
- `getWifiIP` (modified): changed to call `getIPAddr` with IPv4 as parameter.
- `getWifiIPv6` (new feature): Call `getIPAddr` to return IPv6 address of network.
- `extractSubnet` (new helper): Gets prefix length from adapter addresses struct and creates and return a string for subnet mask.
- `getWifiSubmask` (new feature): Use extractSubnet to return subnet mask of the network.
- `getWifiBroadcast` (new feature): Use `getWifiIP` and `getWifiSubmask` to get broadcast IP for the network.
- `getWifiGatewayIP` (new feature): Returns gateway IP for the network. Implementation similar to `getIPAddr`.

`getWifiName` was returning empty string and `getWifiBSSID` was returing all zeroes. 
I have fixed this by changing `pAttributes` (`Pointer<WLAN_CONNECTION_ATTRIBUTES>`) to `ppAttributes` (`Pointer<Pointer<WLAN_CONNECTION_ATTRIBUTES>>`) in `query` function and made related changes.

## Related Issues

- #2665 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

