### PR TITLE
fix(connectivity_plus): Return valid connection type when only one available

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/example/lib/main.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/lib/main.dart
@@ -92,11 +92,32 @@ class _MyHomePageState extends State<MyHomePage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Connectivity example app'),
+        title: const Text('Connectivity Plus Example'),
         elevation: 4,
       ),
-      body: Center(
-          child: Text('Connection Status: ${_connectionStatus.toString()}')),
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Spacer(flex: 2),
+          Text(
+            'Active connection types:',
+            style: Theme.of(context).textTheme.headlineMedium,
+          ),
+          const Spacer(),
+          ListView(
+            shrinkWrap: true,
+            children: List.generate(
+                _connectionStatus.length,
+                (index) => Center(
+                      child: Text(
+                        _connectionStatus[index].toString(),
+                        style: Theme.of(context).textTheme.headlineSmall,
+                      ),
+                    )),
+          ),
+          const Spacer(flex: 2),
+        ],
+      ),
     );
   }
 }

--- a/packages/connectivity_plus/connectivity_plus_platform_interface/lib/method_channel_connectivity.dart
+++ b/packages/connectivity_plus/connectivity_plus_platform_interface/lib/method_channel_connectivity.dart
@@ -29,7 +29,8 @@ class MethodChannelConnectivity extends ConnectivityPlatform {
   Stream<List<ConnectivityResult>> get onConnectivityChanged {
     _onConnectivityChanged ??= eventChannel
         .receiveBroadcastStream()
-        .map((dynamic result) => List<String>.from(result))
+        .map((dynamic result) =>
+            result is String ? [result] : List<String>.from(result))
         .map(parseConnectivityResults);
     return _onConnectivityChanged!;
   }


### PR DESCRIPTION
## Description

I was working on updates for example app to show newly added multiple [connection types feature](#2599) in a more nice way and found a bug that when only one connection type is available there is an exception in the platform interface as returned result isn't a list, but a String:
<img width="1063" alt="Screenshot 2024-03-10 at 13 48 22" src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/79c257aa-fffb-465c-930c-541402b8414a">

This PR fixes mentioned bug and also updates the example UI to look better:
<details>
<summary>Before</summary>

![photo_2024-03-10 14 18 31](https://github.com/fluttercommunity/plus_plugins/assets/13467769/471a4e9d-74bc-4203-a46a-c37e20b96fcd)
</details>

<details>
<summary>After</summary>

![photo_2024-03-10 14 18 29](https://github.com/fluttercommunity/plus_plugins/assets/13467769/013b6128-850f-4de7-9a95-03e6337a81b3)
</details>


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

