### PR TITLE
ci(all): Update Google Java Format tool

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
-          curl -sL https://github.com/google/google-java-format/releases/download/google-java-format-1.3/google-java-format-1.3-all-deps.jar -o $HOME/google-java-format.jar
+          curl -sL https://github.com/google/google-java-format/releases/download/v1.21.0/google-java-format-1.21.0-all-deps.jar -o $HOME/google-java-format.jar
       - name: "Bootstrap Workspace"
         run: melos bootstrap
       - name: "Validate Dart formatting"

--- a/packages/android_alarm_manager_plus/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_alarm_manager_plus/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 05 10:00:26 EEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/FlutterBackgroundExecutor.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/FlutterBackgroundExecutor.java
@@ -27,6 +27,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.json.JSONException;
 import org.json.JSONObject;
+
 /**
  * An background execution abstraction which handles initializing a background isolate running a
  * callback dispatcher, used to invoke Dart callbacks while backgrounded.

--- a/packages/android_alarm_manager_plus/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_alarm_manager_plus/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 05 12:15:50 EEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/android_intent_plus/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_intent_plus/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/AndroidIntentPlugin.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/AndroidIntentPlugin.java
@@ -20,7 +20,7 @@ public final class AndroidIntentPlugin implements FlutterPlugin, ActivityAware {
    * <p>See {@code io.flutter.plugins.androidintentexample.MainActivity} for an example.
    */
   public AndroidIntentPlugin() {
-    sender = new IntentSender(/*activity=*/ null, /*applicationContext=*/ null);
+    sender = new IntentSender(/* activity= */ null, /* applicationContext= */ null);
     impl = new MethodCallHandlerImpl(sender);
   }
 

--- a/packages/android_intent_plus/example/android/app/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_intent_plus/example/android/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/Connectivity.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/Connectivity.java
@@ -60,7 +60,8 @@ public class Connectivity {
         types.add(CONNECTIVITY_NONE);
       }
     } else {
-      // For legacy versions, return a single type as before or adapt similarly if multiple types need to be supported
+      // For legacy versions, return a single type as before or adapt similarly if multiple types
+      // need to be supported
       return getNetworkTypesLegacy();
     }
 


### PR DESCRIPTION
## Description

Just found out that we had version 1.3 of Google Java Format tool, which was released in 2017. Updated to the latest one.
Probably, some new issues would appear with formatting as I expect rules changes during all these years.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

