### PR TITLE
fix: add "MissingPermission" to lintOption of android gradle to elimi…

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/build.gradle
+++ b/packages/device_info_plus/device_info_plus/android/build.gradle
@@ -44,7 +44,7 @@ android {
     }
 
     lintOptions {
-        disable 'InvalidPackage'
+        disable 'InvalidPackage', 'MissingPermission'
     }
 
     dependencies {


### PR DESCRIPTION
…ur in kotlin version 1.8 or higher.

## Description

add "MissingPermission" to lintOption of android gradle to eliminate lint errors that occur in kotlin version 1.8 or higher.

## Related Issues



## Checklist

- [O] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [O] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [O] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [O] All existing and new tests are passing.
- [O] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [O] No, this is *not* a breaking change.

