### PR TITLE
chore: ignore pubspec_overrides.yaml in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .dart_tool/
 pubspec.lock
 flutter_export_environment.sh
+**/pubspec_overrides.yaml
 
 examples/all_plugins/pubspec.yaml
 


### PR DESCRIPTION
## Description

- Adds the `pubspec_overrides.yaml` configuration file to `.gitignore` at the project root.
- This file is created by the `melos bootstrap` command when configuring the project.
- We avoid committing it by mistake.

## Related Issues

- none

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

