### PR TITLE
fix(device_info_plus): Ensure use of Activity Context to obtain WindowManager

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
@@ -36,12 +36,12 @@ class DeviceInfoPlusPlugin : FlutterPlugin, ActivityAware {
 
     override fun onDetachedFromActivityForConfigChanges() {
         // Set an empty method channel when the activity is detached
-        methodChannel.setMethodCallHandler { _, _ ->  }
+        methodChannel.setMethodCallHandler { _, _ -> }
     }
 
     override fun onDetachedFromActivity() {
         // Set an empty method channel when the activity is detached
-        methodChannel.setMethodCallHandler { _, _ ->  }
+        methodChannel.setMethodCallHandler { _, _ -> }
     }
 
     private fun configureMethodCallHandler(binding: ActivityPluginBinding) {

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
@@ -35,13 +35,11 @@ class DeviceInfoPlusPlugin : FlutterPlugin, ActivityAware {
     }
 
     override fun onDetachedFromActivityForConfigChanges() {
-        // Set an empty method channel when the activity is detached
-        methodChannel.setMethodCallHandler { _, _ -> }
+        methodChannel.setMethodCallHandler(null)
     }
 
     override fun onDetachedFromActivity() {
-        // Set an empty method channel when the activity is detached
-        methodChannel.setMethodCallHandler { _, _ -> }
+        methodChannel.setMethodCallHandler(null)
     }
 
     private fun configureMethodCallHandler(binding: ActivityPluginBinding) {

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
@@ -4,27 +4,54 @@ import android.content.Context
 import android.content.pm.PackageManager
 import android.view.WindowManager
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodChannel
 
 /** DeviceInfoPlusPlugin  */
-class DeviceInfoPlusPlugin : FlutterPlugin {
+class DeviceInfoPlusPlugin : FlutterPlugin, ActivityAware {
 
     private lateinit var methodChannel: MethodChannel
 
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
-        setupMethodChannel(binding.binaryMessenger, binding.applicationContext)
+        setupMethodChannel(binding.binaryMessenger)
     }
 
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         methodChannel.setMethodCallHandler(null)
     }
 
-    private fun setupMethodChannel(messenger: BinaryMessenger, context: Context) {
+    private fun setupMethodChannel(messenger: BinaryMessenger) {
         methodChannel = MethodChannel(messenger, "dev.fluttercommunity.plus/device_info")
+    }
+
+    override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+        configureMethodCallHandler(binding)
+    }
+
+    override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+        configureMethodCallHandler(binding)
+    }
+
+    override fun onDetachedFromActivityForConfigChanges() {
+        // Set an empty method channel when the activity is detached
+        methodChannel.setMethodCallHandler { _, _ ->  }
+    }
+
+    override fun onDetachedFromActivity() {
+        // Set an empty method channel when the activity is detached
+        methodChannel.setMethodCallHandler { _, _ ->  }
+    }
+
+    private fun configureMethodCallHandler(binding: ActivityPluginBinding) {
+        val context = binding.activity as Context
         val packageManager: PackageManager = context.packageManager
-        val windowManager: WindowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+        // WindowManager must be obtained from Activity Context
+        val windowManager: WindowManager =
+            context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
         val handler = MethodCallHandlerImpl(packageManager, windowManager)
         methodChannel.setMethodCallHandler(handler)
     }
+
 }

--- a/packages/device_info_plus/device_info_plus/example/android/app/build.gradle
+++ b/packages/device_info_plus/device_info_plus/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     namespace 'io.flutter.plugins.deviceinfoexample.example'
 

--- a/packages/device_info_plus/device_info_plus/example/android/app/src/main/kotlin/io/flutter/plugins/deviceinfoexample/example/MainActivity.kt
+++ b/packages/device_info_plus/device_info_plus/example/android/app/src/main/kotlin/io/flutter/plugins/deviceinfoexample/example/MainActivity.kt
@@ -15,7 +15,7 @@ class MainActivity: FlutterActivity() {
                 .penaltyLog()
                 .penaltyDeath()
                 .build())
-        };
+        }
         super.onCreate(savedInstanceState)
     }
 }

--- a/packages/device_info_plus/device_info_plus/example/android/app/src/main/kotlin/io/flutter/plugins/deviceinfoexample/example/MainActivity.kt
+++ b/packages/device_info_plus/device_info_plus/example/android/app/src/main/kotlin/io/flutter/plugins/deviceinfoexample/example/MainActivity.kt
@@ -1,5 +1,21 @@
 package io.flutter.plugins.deviceinfoexample.example
 
+import android.os.Build
+import android.os.Bundle
+import android.os.StrictMode
 import io.flutter.embedding.android.FlutterActivity
 
-class MainActivity: FlutterActivity()
+class MainActivity: FlutterActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            // Ensures correct use of Activity Context to obtain the WindowManager
+            StrictMode.setVmPolicy(StrictMode.VmPolicy.Builder()
+                .detectIncorrectContextUse()
+                .penaltyLog()
+                .penaltyDeath()
+                .build())
+        };
+        super.onCreate(savedInstanceState)
+    }
+}

--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -21,7 +21,7 @@ void main() {
 }
 
 class MyApp extends StatefulWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   @override
   State<MyApp> createState() => _MyAppState();

--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -148,7 +148,7 @@ class _MyAppState extends State<MyApp> {
 
   Map<String, dynamic> _readWebBrowserInfo(WebBrowserInfo data) {
     return <String, dynamic>{
-      'browserName': describeEnum(data.browserName),
+      'browserName': data.browserName.name,
       'appCodeName': data.appCodeName,
       'appName': data.appName,
       'appVersion': data.appVersion,


### PR DESCRIPTION
## Description

- Ensure that the `WindowManager` is obtained from the `Activity Context` instead of `Application Context`
- Use `ActivityAware` to obtain `Activity` binding in `DeviceInfoPlusPlugin` class.
- Set a null MethodHandler when the activity is detached (doing the same as in the `onDetachedFromEngine` method).
- Add the Strict Mode configuration to example project Android code to ensure the `Activity Context` use is correct.
- Tested on Pixel 5.

## Related Issues

- Fixes #2687

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

