### PR TITLE
chore(android_intent_plus): fixes dangling dart doc comment linting issue

### DIFF
--- a/packages/android_intent_plus/lib/flag.dart
+++ b/packages/android_intent_plus/lib/flag.dart
@@ -1,11 +1,11 @@
+// ignore_for_file: constant_identifier_names
+
 /// Special flags that can be set on an intent to control how it is handled.
 ///
 /// See
 /// https://developer.android.com/reference/android/content/Intent.html#setFlags(int)
 /// for the official documentation on Intent flags. The constants here mirror
 /// the existing [android.content.Intent] ones.
-// ignore_for_file: constant_identifier_names
-
 class Flag {
   /// Specifies how an activity should be launched. Generally set by the system
   /// in conjunction with SINGLE_TASK.


### PR DESCRIPTION
## Description

Fixes the dangling dart doc comment linting issue by moving the ignore comment at top of file and adding one where not present. 

They do not pose any issue while using the package, but while fixing another issue in one of the packages I saw these linting warnings and thought of fixing them.

## Related Issues

Trivial changes so doesn't need an issue.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

