### PR TITLE
chore(package_info_plus): change deprecated web/helpers to web/web import

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
@@ -4,7 +4,7 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:http/http.dart';
 import 'package:package_info_plus_platform_interface/package_info_data.dart';
 import 'package:package_info_plus_platform_interface/package_info_platform_interface.dart';
-import 'package:web/helpers.dart' as web;
+import 'package:web/web.dart' as web;
 
 /// The web implementation of [PackageInfoPlatform].
 ///


### PR DESCRIPTION
## Description

As suggested by the `package:web/helpers.dart` that it is deprecated and `package:web/web.dart` should be used instead as both these files export the same thing.

They do not pose any issue while using the package, but while fixing another issue in one of the packages I saw these linting warnings and thought of fixing them.

## Related Issues

Trivial changes so doesn't need an issue.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

