### PR TITLE
build(connectivity_plus): Update to target and compile SDK 34 on Android

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/android/build.gradle
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     namespace 'dev.fluttercommunity.plus.connectivity'
 
@@ -32,7 +32,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 19
+        minSdk 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     namespace 'io.flutter.plugins.connectivityexample'
 
@@ -40,8 +40,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.connectivityexample"
-        minSdkVersion 19
-        targetSdkVersion 33
+        minSdk 19
+        targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Description

Bringing plugins up to date to compile against latest Android version. Picked `build` as prefix because `chore` won't end up in the release notes during Melos versioning and this change is something that needs to be in release notes.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

