### PR TITLE
build(battery_plus): Update to target and compile SDK 34 on Android

### DIFF
--- a/packages/battery_plus/battery_plus/android/build.gradle
+++ b/packages/battery_plus/battery_plus/android/build.gradle
@@ -24,7 +24,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     namespace 'dev.fluttercommunity.plus.battery'
 
@@ -38,9 +38,10 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 19
+        minSdk 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
+
     lintOptions {
         disable 'InvalidPackage'
     }

--- a/packages/battery_plus/battery_plus/example/android/app/build.gradle
+++ b/packages/battery_plus/battery_plus/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     namespace 'io.flutter.plugins.batteryexample.example'
 
@@ -50,8 +50,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.plugins.batteryexample.example"
-        minSdkVersion 19
-        targetSdkVersion 33
+        minSdk 19
+        targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }


### PR DESCRIPTION
## Description

Same as #2701 but for `battery_plus`

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

