### PR TITLE
chore(device_info_plus): ignores dangling dart doc comment linting issue for empty file

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_macos.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_macos.dart
@@ -1,1 +1,2 @@
+// ignore: dangling_library_doc_comments
 /// The platform interface handles the method channel calls. This file exists to silence errors on pub.


### PR DESCRIPTION
## Description

Ignores the dangling dart doc comment linting issue for an empty file with informative comment.

They do not pose any issue while using the package, but while fixing another issue in one of the packages I saw these linting warnings and thought of fixing them.

## Related Issues

Trivial changes so doesn't need an issue.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

