### PR TITLE
chore(android_intent_plus): using super.key parameter to resolve linting issues

### DIFF
--- a/packages/android_intent_plus/example/lib/main.dart
+++ b/packages/android_intent_plus/example/lib/main.dart
@@ -13,7 +13,7 @@ void main() {
 
 /// A sample app for launching intents.
 class MyApp extends StatelessWidget {
-  const MyApp({Key? key}) : super(key: key);
+  const MyApp({super.key});
 
   // This widget is the root of your application.
   @override
@@ -35,7 +35,7 @@ class MyApp extends StatelessWidget {
 
 /// Holds the different intent widgets.
 class MyHomePage extends StatelessWidget {
-  const MyHomePage({Key? key}) : super(key: key);
+  const MyHomePage({super.key});
 
   void _createAlarm() {
     const intent = AndroidIntent(


### PR DESCRIPTION
## Description

Using the recommended super.key parameter instead of the super() constructor in Widgets.

They do not pose any issue while using the package, but while fixing another issue in one of the packages I saw these linting warnings and thought of fixing them.

## Related Issues

Trivial changes so doesn't need an issue.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

