### PR TITLE
build(network_info_plus): Update to target and compile SDK 34 on Android

### DIFF
--- a/packages/network_info_plus/network_info_plus/android/build.gradle
+++ b/packages/network_info_plus/network_info_plus/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     namespace 'dev.fluttercommunity.plus.network_info'
 
@@ -39,7 +39,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 19
+        minSdk 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/network_info_plus/network_info_plus/example/android/app/build.gradle
+++ b/packages/network_info_plus/network_info_plus/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 34
+    compileSdk 34
 
     namespace 'dev.fluttercommunity.plus.network_info_plus_example'
 
@@ -49,8 +49,8 @@ android {
 
     defaultConfig {
         applicationId "dev.fluttercommunity.plus.network_info_plus_example"
-        minSdkVersion 19
-        targetSdkVersion 33
+        minSdk 19
+        targetSdk 33
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Description

Same as #2701 but for `network_info_plus`

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

