### PR TITLE
build(package_info_plus): Update to target and compile SDK 34 on Android

### DIFF
--- a/packages/package_info_plus/package_info_plus/android/build.gradle
+++ b/packages/package_info_plus/package_info_plus/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     namespace 'dev.fluttercommunity.plus.packageinfo'
 
@@ -40,7 +40,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 19
+        minSdk 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/package_info_plus/package_info_plus/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/package_info_plus/package_info_plus/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/package_info_plus/package_info_plus/example/android/app/build.gradle
+++ b/packages/package_info_plus/package_info_plus/example/android/app/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     namespace 'io.flutter.plugins.packageinfoexample'
 
@@ -49,8 +49,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.packageinfoexample"
-        minSdkVersion 19
-        targetSdkVersion 33
+        minSdk 19
+        targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"


### PR DESCRIPTION
## Description

Same as #2701 but for `package_info_plus`

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

