### PR TITLE
build(android_alarm_manager_plus): Update to target and compile SDK 34 on Android

### DIFF
--- a/packages/android_alarm_manager_plus/android/build.gradle
+++ b/packages/android_alarm_manager_plus/android/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     namespace 'dev.fluttercommunity.plus.androidalarmmanager'
 
@@ -39,7 +39,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 19
+        minSdk 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -51,5 +51,5 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.6.1'
-    api 'androidx.core:core:1.10.1'
+    api 'androidx.core:core-ktx:1.12.0'
 }

--- a/packages/android_alarm_manager_plus/example/android/app/build.gradle
+++ b/packages/android_alarm_manager_plus/example/android/app/build.gradle
@@ -26,13 +26,17 @@ apply plugin: 'kotlin-android'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 33
+    compileSdk 34
 
     namespace 'com.example.example'
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = 17
     }
 
     sourceSets {
@@ -46,8 +50,8 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
-        minSdkVersion 21
-        targetSdkVersion 31
+        minSdk 21
+        targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         multiDexEnabled true

--- a/packages/android_alarm_manager_plus/example/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/example/pubspec.yaml
@@ -9,11 +9,11 @@ dependencies:
   flutter:
     sdk: flutter
   android_alarm_manager_plus: ^3.0.4
-  shared_preferences: ^2.1.0
-  path_provider: ^2.0.14
+  permission_handler: ^11.3.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
-  espresso: ^0.3.0+4
+  espresso: ^0.3.0+7
   flutter_test:
     sdk: flutter
   integration_test:


### PR DESCRIPTION
## Description

Moving the plugin to target and compile against SDK 34 (Android 14).

Decided to also rework the example app a bit to let users request SCHEDULE_EXACT_ALARM permission. When app has no such permission schedule alarm button is disabled and request permission buttons is enabled. When user provides the permission schedule button becomes enabled while request permission button disables.
Additionally improved texts to improve UX by explaining what is currently happening.

<img src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/96e0686e-41f9-48d3-a9a6-f5bdbd93041d" width=40%>
<img src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/6f073c3f-3adc-4790-bebe-7ba9823d757c" width=40%>

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

