### PR TITLE
fix(share_plus): Resolve deprecation warning in Android part

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/SharePlusPendingIntent.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/SharePlusPendingIntent.kt
@@ -2,6 +2,7 @@ package dev.fluttercommunity.plus.share
 
 import android.content.*
 import android.os.Build
+import androidx.annotation.RequiresApi
 
 /**
  * This helper class allows us to use FLAG_MUTABLE on the PendingIntent used in the Share class,
@@ -21,6 +22,7 @@ internal class SharePlusPendingIntent: BroadcastReceiver() {
     /**
      * Handler called after an action was chosen. Called only on success.
      */
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP_MR1)
     override fun onReceive(context: Context, intent: Intent) {
         // Extract chosen ComponentName
         val chosenComponent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -29,7 +31,7 @@ internal class SharePlusPendingIntent: BroadcastReceiver() {
         } else {
             // Deprecated in API level 33
             @Suppress("DEPRECATION")
-            intent.getParcelableExtra<ComponentName>(Intent.EXTRA_CHOSEN_COMPONENT)
+            intent.getParcelableExtra(Intent.EXTRA_CHOSEN_COMPONENT)
         }
 
         // Unambiguously identify the chosen action


### PR DESCRIPTION
## Description

Minor change to see less warnings during the build. As we use that broadcast receiver only when use `withResult`, which works only for Android API 22 and newer, this annotation effects nothing except of dropping lint warning which appears due to `Intent.EXTRA_CHOSEN_COMPONENT` otherwise.

In the #2519 there is one more deprecation mentioned, but it was valid only for compile SDK 33 as in 34 this warning doesn't appear.

## Related Issues

Closes #2519

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

