### PR TITLE
fix(sensors_plus): Add try-catch for release builds

### DIFF
--- a/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
@@ -51,6 +51,12 @@ class WebSensorsPlugin extends SensorsPlatform {
           developer.log('Unknown error happened, rethrowing.');
           throw Exception('${e.name}: ${e.message}');
       }
+    } on Error catch (_) {
+      // DOMException is not caught as in release build
+      // so we need to catch it as Error
+      if (onError != null) {
+        onError();
+      }
     }
   }
 


### PR DESCRIPTION
## Description

link https://github.com/fluttercommunity/plus_plugins/pull/2709#issuecomment-2002369298

This PR fix a problem in the release build where DOMException cannot be try-catch.
The problem occurs in Desktop browsers where the Sensors API is not available.

## Related Issues

- Related #2602

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

