### PR TITLE
feat(battery_plus)!: Migrate to package:web

### DIFF
--- a/packages/battery_plus/battery_plus/example/lib/main.dart
+++ b/packages/battery_plus/battery_plus/example/lib/main.dart
@@ -42,9 +42,24 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-    _battery.batteryState.then(_updateBatteryState);
-    _batteryStateSubscription =
-        _battery.onBatteryStateChanged.listen(_updateBatteryState);
+    try {
+      _battery.batteryState.then(
+        _updateBatteryState,
+        onError: (e) {
+          _showError('onError: batteryState: $e');
+          _updateBatteryState(BatteryState.unknown);
+        },
+      );
+      _batteryStateSubscription = _battery.onBatteryStateChanged.listen(
+        _updateBatteryState,
+        onError: (e) {
+          _showError('onError: onBatteryStateChanged: $e');
+          _updateBatteryState(BatteryState.unknown);
+        },
+      );
+    } on Error catch (e) {
+      _showError('catch: batteryState: $e');
+    }
   }
 
   void _updateBatteryState(BatteryState state) {
@@ -52,6 +67,16 @@ class _MyHomePageState extends State<MyHomePage> {
     setState(() {
       _batteryState = state;
     });
+  }
+
+  void _showError(String message) {
+    // see https://github.com/fluttercommunity/plus_plugins/pull/2720
+    // The exception may not be caught in the package and an exception may occur in the caller, so use try-catch as needed.
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+      ),
+    );
   }
 
   @override
@@ -77,55 +102,69 @@ class _MyHomePageState extends State<MyHomePage> {
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () {
-                _battery.batteryLevel.then(
-                  (batteryLevel) {
-                    showDialog<void>(
-                      context: context,
-                      builder: (_) => AlertDialog(
-                        content: Text('Battery: $batteryLevel%'),
-                        actions: <Widget>[
-                          TextButton(
-                            onPressed: () {
-                              Navigator.pop(context);
-                            },
-                            child: const Text('OK'),
-                          )
-                        ],
-                      ),
-                    );
-                  },
-                );
+                try {
+                  _battery.batteryLevel.then(
+                    (batteryLevel) {
+                      showDialog<void>(
+                        context: context,
+                        builder: (_) => AlertDialog(
+                          content: Text('Battery: $batteryLevel%'),
+                          actions: <Widget>[
+                            TextButton(
+                              onPressed: () {
+                                Navigator.pop(context);
+                              },
+                              child: const Text('OK'),
+                            )
+                          ],
+                        ),
+                      );
+                    },
+                    onError: (e) {
+                      _showError('onError: batteryLevel: $e');
+                    },
+                  );
+                } on Error catch (e) {
+                  _showError('catch: batteryLevel: $e');
+                }
               },
               child: const Text('Get battery level'),
             ),
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () {
-                _battery.isInBatterySaveMode.then(
-                  (isInPowerSaveMode) {
-                    showDialog<void>(
-                      context: context,
-                      builder: (_) => AlertDialog(
-                        title: const Text(
-                          'Is in Battery Save mode?',
-                          style: TextStyle(fontSize: 20),
+                try {
+                  _battery.isInBatterySaveMode.then(
+                    (isInPowerSaveMode) {
+                      showDialog<void>(
+                        context: context,
+                        builder: (_) => AlertDialog(
+                          title: const Text(
+                            'Is in Battery Save mode?',
+                            style: TextStyle(fontSize: 20),
+                          ),
+                          content: Text(
+                            "$isInPowerSaveMode",
+                            style: const TextStyle(fontSize: 18),
+                          ),
+                          actions: <Widget>[
+                            TextButton(
+                              onPressed: () {
+                                Navigator.pop(context);
+                              },
+                              child: const Text('Close'),
+                            )
+                          ],
                         ),
-                        content: Text(
-                          "$isInPowerSaveMode",
-                          style: const TextStyle(fontSize: 18),
-                        ),
-                        actions: <Widget>[
-                          TextButton(
-                            onPressed: () {
-                              Navigator.pop(context);
-                            },
-                            child: const Text('Close'),
-                          )
-                        ],
-                      ),
-                    );
-                  },
-                );
+                      );
+                    },
+                    onError: (e) {
+                      _showError('onError: isInBatterySaveMode: $e');
+                    },
+                  );
+                } on Error catch (e) {
+                  _showError('catch: isInBatterySaveMode: $e');
+                }
               },
               child: const Text('Is in Battery Save mode?'),
             )

--- a/packages/battery_plus/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/example/pubspec.yaml
@@ -2,7 +2,8 @@ name: battery_plus_example
 description: Demonstrates how to use the battery_plus plugin.
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
+  flutter: '>=3.19.0'
 
 dependencies:
   flutter:

--- a/packages/battery_plus/battery_plus/lib/src/battery_plus_web.dart
+++ b/packages/battery_plus/battery_plus/lib/src/battery_plus_web.dart
@@ -6,6 +6,11 @@ import 'package:flutter_web_plugins/flutter_web_plugins.dart';
 import 'package:web/web.dart' as web;
 
 /// The web implementation of the BatteryPlatform of the Battery plugin.
+///
+/// The Battery Status API is not supported by Firefox and Safari.
+/// Therefore, when using this plugin, recommend that test not only in Chrome but also in Firefox and Safari.
+/// In some environments, accessing this plugin from Firefox or Safari will cause unexpected exception.
+/// If an unexpected Exception occurs, try-catch at the point where the method is being called.
 class BatteryPlusWebPlugin extends BatteryPlatform {
   /// Constructs a BatteryPlusPlugin.
   BatteryPlusWebPlugin();
@@ -16,6 +21,9 @@ class BatteryPlusWebPlugin extends BatteryPlatform {
       return await web.window.navigator.getBattery().toDart;
     } on NoSuchMethodError catch (_) {
       // BatteryManager API is not supported this User Agent.
+      return null;
+    } on Object catch (_) {
+      // Unexpected exception occurred.
       return null;
     }
   }

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   battery_plus_platform_interface: ^2.0.0
   meta: ^1.8.0
   upower: ^0.7.0
+  web: ^0.5.0
 
 dev_dependencies:
   flutter_test:
@@ -41,5 +42,5 @@ dev_dependencies:
   plugin_platform_interface: ^2.1.4
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"


### PR DESCRIPTION
## Description

Migration to the `web` package and add missing API.

https://developer.mozilla.org/en-US/docs/Web/API/BatteryManager#browser_compatibility

BatteryManager API is only supported Chrome or Edge.
Safari and Firefox are not supported, so status is expected to be unknown.

## Related Issues

- Related #2653

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

