### PR TITLE
fix(connectivity_plus): Emit event with types on Android when subscribing to onConnectivityChanged

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
@@ -64,6 +64,9 @@ public class ConnectivityBroadcastReceiver extends BroadcastReceiver
     } else {
       context.registerReceiver(this, new IntentFilter(CONNECTIVITY_ACTION));
     }
+    // Need to emit first event with connectivity types without waiting for first change in system
+    // that might happen much later
+    sendEvent();
   }
 
   @Override


### PR DESCRIPTION
## Description

Adding connectivity types check on Android when user subscribes to a stream of changes. This is needed for case with no active connections during subscription, like it is described in #2527. I checked it and indeed `NetworkCallback` triggers on subscription only when some connection is available. When device has everything off and user subscribes to connectivity types changes no events triggered. 

As I described in my comment in the issue I don't consider it a bug, but a specific of usage.
In any case added `sendEvent()` call in the `onListen()` function and it makes the stream emit an event with connection types right away on subscription.

Tested with example app by removing the call to [`checkConnectivity()`](https://github.com/fluttercommunity/plus_plugins/blob/main/packages/connectivity_plus/connectivity_plus/example/lib/main.dart#L52) and having no default value defined for [`_connectionStatus`](https://github.com/fluttercommunity/plus_plugins/blob/main/packages/connectivity_plus/connectivity_plus/example/lib/main.dart#L45)

## Related Issues

Closes #2527

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

