### PR TITLE
fix(connectivity_plus): Fix iOS example app name

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/example/ios/Runner/Info.plist
+++ b/packages/connectivity_plus/connectivity_plus/example/ios/Runner/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>Example Device Info</string>
+	<string>Connectivity Plus Example</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
## Description

Looks like I didn't notice wrong name when was working on regeneration of example apps some time ago.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

