### PR TITLE
build(alarm_manager_plus)!: Target Java 17 on Android

### DIFF
--- a/packages/android_alarm_manager_plus/android/build.gradle
+++ b/packages/android_alarm_manager_plus/android/build.gradle
@@ -30,12 +30,12 @@ android {
     namespace 'dev.fluttercommunity.plus.androidalarmmanager'
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = 17
     }
 
     defaultConfig {


### PR DESCRIPTION
## Description

Targeting Java 17 to be up to date with ecosystem.
Considering that we are using Gradle 8.4 now no compatibility problems expected: https://docs.gradle.org/current/userguide/compatibility.html

Also, with this change users should not see such deprecation warnings anymore:
<img width="696" alt="Screenshot 2024-03-16 at 15 05 19" src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/0372d8c6-6f20-4fd0-8f72-d481ada09c8b">

Marking as a breaking change to highlight it in release notes.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

