### PR TITLE
build(battery_plus)!: Target Java 17 on Android

### DIFF
--- a/packages/battery_plus/battery_plus/android/build.gradle
+++ b/packages/battery_plus/battery_plus/android/build.gradle
@@ -29,12 +29,12 @@ android {
     namespace 'dev.fluttercommunity.plus.battery'
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = 17
     }
 
     defaultConfig {

--- a/packages/battery_plus/battery_plus/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/battery_plus/battery_plus/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/battery_plus/battery_plus/example/android/app/build.gradle
+++ b/packages/battery_plus/battery_plus/example/android/app/build.gradle
@@ -31,12 +31,12 @@ android {
     namespace 'io.flutter.plugins.batteryexample.example'
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = 17
     }
 
     sourceSets {

--- a/packages/battery_plus/battery_plus/example/lib/main.dart
+++ b/packages/battery_plus/battery_plus/example/lib/main.dart
@@ -65,8 +65,13 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
+            const Text(
+              'Current battery state:',
+              style: TextStyle(fontSize: 24),
+            ),
+            const SizedBox(height: 8),
             Text(
-              '$_batteryState',
+              '${_batteryState?.name}',
               style: const TextStyle(fontSize: 24),
             ),
             const SizedBox(height: 24),


### PR DESCRIPTION
## Description

Same as #2723 

Additionally updated example app a bit as text with state didn't look good from my point of view.
Here is before and after:

<img src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/6350e871-496f-4a23-94f9-57674e10dc4d" width=40%>
<img src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/64e74f32-0647-40dc-8070-686e1a3e57c5" width=40%>

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

