### PR TITLE
refactor(all): Update integration tests configuration

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [21, 26, 31]
+        android-api-level: [22, 26, 31, 34]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 22, 26, 31 ]
+        android-api-level: [ 22, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 22, 26, 31 ]
+        android-api-level: [ 22, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"
@@ -115,7 +115,7 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v3
         with:
-          model: "iPhone 14"
+          model: "iPhone 15"
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios battery_plus_example
 

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 21, 26, 31 ]
+        android-api-level: [ 21, 26, 31, 34]
 
     steps:
       - name: "Checkout repository"
@@ -115,7 +115,7 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v3
         with:
-          model: 'iPhone 14'
+          model: 'iPhone 15'
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios connectivity_plus_example
 

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 22, 26, 31 ]
+        android-api-level: [ 22, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"
@@ -114,7 +114,7 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v3
         with:
-          model: 'iPhone 14'
+          model: 'iPhone 15'
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios device_info_plus_example
 

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 22, 26, 31 ]
+        android-api-level: [ 22, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"
@@ -114,7 +114,7 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v3
         with:
-          model: 'iPhone 14'
+          model: 'iPhone 15'
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios network_info_plus_example
 

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 22, 26, 31 ]
+        android-api-level: [ 22, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"
@@ -114,7 +114,7 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v3
         with:
-          model: 'iPhone 14'
+          model: 'iPhone 15'
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios package_info_plus_example
 

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 22, 26, 31 ]
+        android-api-level: [ 22, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"
@@ -109,7 +109,7 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v3
         with:
-          model: 'iPhone 14'
+          model: 'iPhone 15'
       - name: "Bootstrap Workspace"
         run: melos bootstrap --scope="$PLUGIN_SCOPE"
       - name: "Run Integration Test"

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -63,7 +63,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        android-api-level: [ 22, 26, 31 ]
+        android-api-level: [ 22, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"
@@ -113,7 +113,7 @@ jobs:
       - name: "Start Simulator"
         uses: futureware-tech/simulator-action@v3
         with:
-          model: 'iPhone 14'
+          model: 'iPhone 15'
       - name: "Run Integration Test"
         run: ./.github/workflows/scripts/integration-test.sh ios share_plus_example
 


### PR DESCRIPTION
## Description

Expanding the Android versions matrix to include the latest Android 14 (API 34) into a test suit as well. 
I expect that integration tests will fail for `android_alarm_manager_plus` because of permission requirements.
Also changed from iPhone 14 to 15, but it shouldn't make any difference for iOS tests.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

