### PR TITLE
fix(battery_plus): Fix return value of getBattery to be nullable

### DIFF
--- a/packages/battery_plus/battery_plus/example/lib/main.dart
+++ b/packages/battery_plus/battery_plus/example/lib/main.dart
@@ -42,24 +42,9 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void initState() {
     super.initState();
-    try {
-      _battery.batteryState.then(
-        _updateBatteryState,
-        onError: (e) {
-          _showError('onError: batteryState: $e');
-          _updateBatteryState(BatteryState.unknown);
-        },
-      );
-      _batteryStateSubscription = _battery.onBatteryStateChanged.listen(
-        _updateBatteryState,
-        onError: (e) {
-          _showError('onError: onBatteryStateChanged: $e');
-          _updateBatteryState(BatteryState.unknown);
-        },
-      );
-    } on Error catch (e) {
-      _showError('catch: batteryState: $e');
-    }
+    _battery.batteryState.then(_updateBatteryState);
+    _batteryStateSubscription =
+        _battery.onBatteryStateChanged.listen(_updateBatteryState);
   }
 
   void _updateBatteryState(BatteryState state) {
@@ -67,16 +52,6 @@ class _MyHomePageState extends State<MyHomePage> {
     setState(() {
       _batteryState = state;
     });
-  }
-
-  void _showError(String message) {
-    // see https://github.com/fluttercommunity/plus_plugins/pull/2720
-    // The exception may not be caught in the package and an exception may occur in the caller, so use try-catch as needed.
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(message),
-      ),
-    );
   }
 
   @override
@@ -102,69 +77,55 @@ class _MyHomePageState extends State<MyHomePage> {
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () {
-                try {
-                  _battery.batteryLevel.then(
-                    (batteryLevel) {
-                      showDialog<void>(
-                        context: context,
-                        builder: (_) => AlertDialog(
-                          content: Text('Battery: $batteryLevel%'),
-                          actions: <Widget>[
-                            TextButton(
-                              onPressed: () {
-                                Navigator.pop(context);
-                              },
-                              child: const Text('OK'),
-                            )
-                          ],
-                        ),
-                      );
-                    },
-                    onError: (e) {
-                      _showError('onError: batteryLevel: $e');
-                    },
-                  );
-                } on Error catch (e) {
-                  _showError('catch: batteryLevel: $e');
-                }
+                _battery.batteryLevel.then(
+                  (batteryLevel) {
+                    showDialog<void>(
+                      context: context,
+                      builder: (_) => AlertDialog(
+                        content: Text('Battery: $batteryLevel%'),
+                        actions: <Widget>[
+                          TextButton(
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
+                            child: const Text('OK'),
+                          )
+                        ],
+                      ),
+                    );
+                  },
+                );
               },
               child: const Text('Get battery level'),
             ),
             const SizedBox(height: 24),
             ElevatedButton(
               onPressed: () {
-                try {
-                  _battery.isInBatterySaveMode.then(
-                    (isInPowerSaveMode) {
-                      showDialog<void>(
-                        context: context,
-                        builder: (_) => AlertDialog(
-                          title: const Text(
-                            'Is in Battery Save mode?',
-                            style: TextStyle(fontSize: 20),
-                          ),
-                          content: Text(
-                            "$isInPowerSaveMode",
-                            style: const TextStyle(fontSize: 18),
-                          ),
-                          actions: <Widget>[
-                            TextButton(
-                              onPressed: () {
-                                Navigator.pop(context);
-                              },
-                              child: const Text('Close'),
-                            )
-                          ],
+                _battery.isInBatterySaveMode.then(
+                  (isInPowerSaveMode) {
+                    showDialog<void>(
+                      context: context,
+                      builder: (_) => AlertDialog(
+                        title: const Text(
+                          'Is in Battery Save mode?',
+                          style: TextStyle(fontSize: 20),
                         ),
-                      );
-                    },
-                    onError: (e) {
-                      _showError('onError: isInBatterySaveMode: $e');
-                    },
-                  );
-                } on Error catch (e) {
-                  _showError('catch: isInBatterySaveMode: $e');
-                }
+                        content: Text(
+                          "$isInPowerSaveMode",
+                          style: const TextStyle(fontSize: 18),
+                        ),
+                        actions: <Widget>[
+                          TextButton(
+                            onPressed: () {
+                              Navigator.pop(context);
+                            },
+                            child: const Text('Close'),
+                          )
+                        ],
+                      ),
+                    );
+                  },
+                );
               },
               child: const Text('Is in Battery Save mode?'),
             )

--- a/packages/battery_plus/battery_plus/lib/src/battery_plus_web.dart
+++ b/packages/battery_plus/battery_plus/lib/src/battery_plus_web.dart
@@ -18,7 +18,7 @@ class BatteryPlusWebPlugin extends BatteryPlatform {
   /// Return [BatteryManager] if the BatteryManager API is supported by the User Agent.
   Future<BatteryManager?> _getBatteryManager() async {
     try {
-      return await web.window.navigator.getBattery().toDart;
+      return await web.window.navigator.getBattery()?.toDart;
     } on NoSuchMethodError catch (_) {
       // BatteryManager API is not supported this User Agent.
       return null;
@@ -108,7 +108,7 @@ class BatteryPlusWebPlugin extends BatteryPlatform {
 
 extension on web.Navigator {
   /// https://developer.mozilla.org/en-US/docs/Web/API/Navigator/getBattery
-  external JSPromise<BatteryManager> getBattery();
+  external JSPromise<BatteryManager>? getBattery();
 }
 
 /// BatteryManager API


### PR DESCRIPTION
## Description

Fixed an exception that occurred when calling `getBattery()` in firefox and safari.
In cases where `getBattery()` is undefined, you need to declare `JSPromise<BatteryManager>? ` instead of `JSPromise<BatteryManager>`.

The example code has been reverted to the previous one, as the try-catch is now correct.

## Related Issues

- Related #2720

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

