### PR TITLE
docs(connectivity_plus): Improve documentation onConnectivityChanged method

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
@@ -34,11 +34,16 @@ class Connectivity {
     return ConnectivityPlatform.instance;
   }
 
-  /// Fires whenever the connectivity state changes.
+  /// Exposes connectivity update events from the platform.
   ///
   /// On iOS, the connectivity status might not update when WiFi
   /// status changes, this is a known issue that only affects simulators.
   /// For details see https://github.com/fluttercommunity/plus_plugins/issues/479.
+  ///
+  /// On Android, the Stream may emit new values even when
+  /// the [ConnectivityResult] list remains the same.
+  ///
+  /// This method doesn't filter event, nor it ensures distinct values.
   Stream<List<ConnectivityResult>> get onConnectivityChanged {
     return _platform.onConnectivityChanged;
   }


### PR DESCRIPTION
## Description

Following the discussion here: https://github.com/fluttercommunity/plus_plugins/pull/2599#issuecomment-2013129686

The goal of the plus plugins are to be as truth to the underlying platform as possible, while providing an easy way to access for all Flutter compatible platforms.

This PR adds a bit of context to the `onConnectivutyChanged` method, explaining why the `Stream` may emit multiple values.

Not that people ever reads documentation, but maybe someone will find it useful :)

Any comments are welcome.

## Related Issues

- Related: #2599

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

