### PR TITLE
feat(package_info_plus): Add customVersionJson URI to getAll method

### DIFF
--- a/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_web_test.dart
+++ b/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_web_test.dart
@@ -29,6 +29,8 @@ void main() {
     'build_signature': '',
   };
 
+  final customUri = Uri.tryParse('https://example.com/version.json');
+
   late PackageInfoPlusWebPlugin plugin;
   late MockClient client;
 
@@ -75,6 +77,25 @@ void main() {
           expect(versionMap.packageName, isEmpty);
           expect(versionMap.version, isEmpty);
           expect(versionMap.buildSignature, isEmpty);
+        },
+      );
+
+      testWidgets(
+        'Get package info using custom version json uri',
+        (tester) async {
+          when(client.get(customUri)).thenAnswer(
+            (_) => Future.value(
+              http.Response(jsonEncode(VERSION_JSON), 200),
+            ),
+          );
+
+          final versionMap = await plugin.getAll(customVersionJson: customUri);
+
+          expect(versionMap.appName, VERSION_JSON['app_name']);
+          expect(versionMap.version, VERSION_JSON['version']);
+          expect(versionMap.buildNumber, VERSION_JSON['build_number']);
+          expect(versionMap.packageName, VERSION_JSON['package_name']);
+          expect(versionMap.buildSignature, VERSION_JSON['build_signature']);
         },
       );
 

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -34,10 +34,9 @@ class PackageInfo {
   /// Retrieves package information from the platform.
   /// The result is cached.
   ///
-  /// Web: The plugin uses the generated version.json to read the package
-  /// information.
+  /// Web: Uses the generated version.json to read the package information.
   /// By default, the package uses the browser navigator base URL.
-  /// Optionally, a custom version JSON URI can be provided.
+  /// Optionally, a custom URI can be provided.
   static Future<PackageInfo> fromPlatform({Uri? customVersionJson}) async {
     if (_fromPlatform != null) {
       return _fromPlatform!;

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -33,12 +33,19 @@ class PackageInfo {
 
   /// Retrieves package information from the platform.
   /// The result is cached.
-  static Future<PackageInfo> fromPlatform() async {
+  ///
+  /// Web: The plugin uses the generated version.json to read the package
+  /// information.
+  /// By default, the package uses the browser navigator base URL.
+  /// Optionally, a custom version JSON URI can be provided.
+  static Future<PackageInfo> fromPlatform({Uri? customVersionJson}) async {
     if (_fromPlatform != null) {
       return _fromPlatform!;
     }
 
-    final platformData = await PackageInfoPlatform.instance.getAll();
+    final platformData = await PackageInfoPlatform.instance.getAll(
+      customVersionJson: customVersionJson,
+    );
     _fromPlatform = PackageInfo(
       appName: platformData.appName,
       packageName: platformData.packageName,

--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_linux.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_linux.dart
@@ -15,7 +15,7 @@ class PackageInfoPlusLinuxPlugin extends PackageInfoPlatform {
   /// Returns a map with the following keys:
   /// appName, packageName, version, buildNumber
   @override
-  Future<PackageInfoData> getAll() async {
+  Future<PackageInfoData> getAll({Uri? customVersionJson}) async {
     final versionJson = await _getVersionJson();
     return PackageInfoData(
       appName: versionJson['app_name'] ?? '',

--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_windows.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_windows.dart
@@ -18,7 +18,7 @@ class PackageInfoPlusWindowsPlugin extends PackageInfoPlatform {
   /// Returns a map with the following keys:
   /// appName, packageName, version, buildNumber
   @override
-  Future<PackageInfoData> getAll() {
+  Future<PackageInfoData> getAll({Uri? customVersionJson}) {
     String resolvedExecutable = Platform.resolvedExecutable;
 
     /// Workaround for https://github.com/dart-lang/sdk/issues/52309

--- a/packages/package_info_plus/package_info_plus_platform_interface/lib/method_channel_package_info.dart
+++ b/packages/package_info_plus/package_info_plus_platform_interface/lib/method_channel_package_info.dart
@@ -9,7 +9,7 @@ const MethodChannel _channel =
 /// An implementation of [PackageInfoPlatform] that uses method channels.
 class MethodChannelPackageInfo extends PackageInfoPlatform {
   @override
-  Future<PackageInfoData> getAll() async {
+  Future<PackageInfoData> getAll({Uri? customVersionJson}) async {
     final map = await _channel.invokeMapMethod<String, dynamic>('getAll');
     return PackageInfoData(
       appName: map!['appName'] ?? '',

--- a/packages/package_info_plus/package_info_plus_platform_interface/lib/package_info_platform_interface.dart
+++ b/packages/package_info_plus/package_info_plus_platform_interface/lib/package_info_platform_interface.dart
@@ -30,7 +30,7 @@ abstract class PackageInfoPlatform extends PlatformInterface {
   }
 
   ///Returns a map with the following keys : appName,packageName,version,buildNumber
-  Future<PackageInfoData> getAll() {
+  Future<PackageInfoData> getAll({Uri? customVersionJson}) {
     throw UnimplementedError('getAll() has not been implemented.');
   }
 }


### PR DESCRIPTION
## Description

WIP, the idea is to add a customVersionJson URI to the `getAll()` method, so web users can provide alternative locations for the `version.json` file.

## Related Issues

Could be combined with https://github.com/fluttercommunity/plus_plugins/pull/2733 in the future, so we can use the asset base url as a fail-back option.

- Potential fix: https://github.com/fluttercommunity/plus_plugins/issues/2732
- Potential fix: https://github.com/fluttercommunity/plus_plugins/issues/2699
- Potential fix: https://github.com/fluttercommunity/plus_plugins/issues/1409

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

Note: This is potentially breaking since the `getAll` method signature changes, and that will require a new release of the platform interface. Still need to think about it.
