### PR TITLE
docs(connectivity_plus): Specify behavior when there is no connectivi…

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
@@ -43,6 +43,10 @@ class Connectivity {
   /// On Android, the Stream may emit new values even when
   /// the [ConnectivityResult] list remains the same.
   ///
+  /// The emitted list is never empty. In case of no connectivity, the list contains
+  /// a single element of [ConnectivityResult.none]. Note also that this is the only
+  /// case where [ConnectivityResult.none] is present.
+  ///
   /// This method doesn't filter events, nor it ensures distinct values.
   Stream<List<ConnectivityResult>> get onConnectivityChanged {
     return _platform.onConnectivityChanged;
@@ -51,9 +55,12 @@ class Connectivity {
   /// Checks the connection status of the device.
   ///
   /// Do not use the result of this function to decide whether you can reliably
-  /// make a network request. It only gives you the radio status.
+  /// make a network request, it only gives you the radio status. Instead, listen
+  /// for connectivity changes via [onConnectivityChanged] stream.
   ///
-  /// Instead listen for connectivity changes via [onConnectivityChanged] stream.
+  /// The returned list is never empty. In case of no connectivity, the list contains
+  /// a single element of [ConnectivityResult.none]. Note also that this is the only
+  /// case where [ConnectivityResult.none] is present.
   Future<List<ConnectivityResult>> checkConnectivity() {
     return _platform.checkConnectivity();
   }


### PR DESCRIPTION
Document on behavior of `ConnectivityResult.none` (#2752)

With the latest changes in API, connectivity is exposed as a list of available connections instead of single state as before. When there is no connections, the list contains a single item `ConnectivityResult.none`, which can be surprising for some users. This PR add documentation to `Connectivity` class to specify this behavior.
