### PR TITLE
docs(device_info_plus): Add iOS name property entitlements info

### DIFF
--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -53,10 +53,15 @@ final deviceInfo = await deviceInfoPlugin.deviceInfo;
 final allInfo = deviceInfo.data;
 ```
 
-> **Note**
->
-> To get serial number on Android your app needs to meet one of official [requirements](https://developer.android.com/reference/android/os/Build#getSerial())
-> In case the app doesn't meet any of requirements plugin will return `unknown`.
+### Android
+
+To get serial number on Android your app needs to meet one of official [requirements](https://developer.android.com/reference/android/os/Build#getSerial()).
+In case the app doesn't meet any of requirements plugin will return `unknown`.
+
+### iOS
+
+The plugin exposes the value in `UIDevice.current name` as the `name` property, which the assigned device name by the owner.
+This property requires special entitlement [com.apple.developer.device-information.user-assigned-device-name](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_device-information_user-assigned-device-name) in iOS 16 and later, otherwise, the property `name` will always be `iPad` or `iPhone`.
 
 ## Learn more
 

--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -60,7 +60,7 @@ In case the app doesn't meet any of requirements plugin will return `unknown`.
 
 ### iOS
 
-The plugin exposes the value in `UIDevice.current name` as the `name` property, which the assigned device name by the owner.
+The plugin exposes the value in `UIDevice.current.name` as the `name` property, which the assigned device name by the owner.
 This property requires special entitlement [com.apple.developer.device-information.user-assigned-device-name](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_device-information_user-assigned-device-name) in iOS 16 and later, otherwise, the property `name` will always be `iPad` or `iPhone`.
 
 ## Learn more

--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -60,7 +60,7 @@ In case the app doesn't meet any of requirements plugin will return `unknown`.
 
 ### iOS
 
-The plugin exposes the value in `UIDevice.current.name` as the `name` property, which the assigned device name by the owner.
+The `name` property exposes the assigned device name by the owner. This value is obtained from the property `UIDevice.current.name`.
 This property requires special entitlement [com.apple.developer.device-information.user-assigned-device-name](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_device-information_user-assigned-device-name) in iOS 16 and later, otherwise, the property `name` will always be `iPad` or `iPhone`.
 
 ## Learn more


### PR DESCRIPTION
## Description

- Adds clarification regarding entitlements needed to access the property `UIDevice.current.name` on iOS 16 and later.
- Also formatted the README.md a bit.

## Related Issues

- Closes #2755

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

