### PR TITLE
fix(connectivity_plus): Improve iOS PathMonitorConnectivityProvider implementation and documentation

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -82,11 +82,21 @@ dispose() {
 }
 ```
 
-> **Note**
->
-> Connectivity changes are no longer communicated to Android apps in the background starting with Android O (8.0). You should always check for connectivity status when your app is resumed._ The broadcast is only useful when your application is in the foreground.
+### Android
 
-## Limitations on the web platform
+Connectivity changes are no longer communicated to Android apps in the background starting with Android O (8.0). You should always check for connectivity status when your app is resumed._ The broadcast is only useful when your application is in the foreground.
+
+### iOS
+
+On iOS, the connectivity status might not update when WiFi status changes, this is a known issue that affects mainly simulators.
+
+Starting on iOS 12, the implementation uses `NWPathMonitor` to obtain the enabled connectivity types.
+
+We noticed that this observer can give multiple or unreliable results. For example, reporting connectivity "none" followed by connectivity "wifi" right after reconnecting.
+
+We recommend to use the `onConnectivityChanged` with this limitation in mind, as the method doesn't filter events, nor it ensures distinct values.
+
+### Web
 
 In order to retrieve information about the quality/speed of a browser's connection, the web implementation of the `connectivity` plugin uses the browser's [**NetworkInformation** Web API](https://developer.mozilla.org/en-US/docs/Web/API/NetworkInformation), which as of this writing (June 2020) is still "experimental", and not available in all browsers:
 

--- a/packages/connectivity_plus/connectivity_plus/darwin/Classes/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/darwin/Classes/PathMonitorConnectivityProvider.swift
@@ -9,10 +9,9 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
 
   private var pathMonitor: NWPathMonitor?
 
-  public var currentConnectivityTypes: [ConnectivityType] {
-    let path = ensurePathMonitor().currentPath
+  private func connectivityFrom(path: NWPath) -> [ConnectivityType] {
     var types: [ConnectivityType] = []
-    
+        
     // Check for connectivity and append to types array as necessary
     if path.status == .satisfied {
       if path.usesInterfaceType(.wifi) {
@@ -28,8 +27,13 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
         types.append(.other)
       }
     }
-    
+        
     return types.isEmpty ? [.none] : types
+  }
+
+  public var currentConnectivityTypes: [ConnectivityType] {
+    let path = ensurePathMonitor().currentPath
+    return connectivityFrom(path: path)
   }
 
   public var connectivityUpdateHandler: ConnectivityUpdateHandler?
@@ -60,6 +64,6 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
   }
 
   private func pathUpdateHandler(path: NWPath) {
-    connectivityUpdateHandler?(currentConnectivityTypes)
+    connectivityUpdateHandler?(connectivityFrom(path: path))
   }
 }

--- a/packages/connectivity_plus/connectivity_plus/darwin/Classes/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/darwin/Classes/PathMonitorConnectivityProvider.swift
@@ -3,7 +3,9 @@ import Network
 
 public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
 
-  private let queue = DispatchQueue.global(qos: .background)
+  // Use .utility, as it is intended for tasks that the user does not track actively.
+  // See: https://developer.apple.com/documentation/dispatch/dispatchqos
+  private let queue = DispatchQueue.global(qos: .utility)
 
   private var pathMonitor: NWPathMonitor?
 

--- a/packages/connectivity_plus/connectivity_plus/darwin/Classes/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/darwin/Classes/PathMonitorConnectivityProvider.swift
@@ -11,7 +11,7 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
 
   private func connectivityFrom(path: NWPath) -> [ConnectivityType] {
     var types: [ConnectivityType] = []
-        
+    
     // Check for connectivity and append to types array as necessary
     if path.status == .satisfied {
       if path.usesInterfaceType(.wifi) {
@@ -27,7 +27,7 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
         types.append(.other)
       }
     }
-        
+    
     return types.isEmpty ? [.none] : types
   }
 


### PR DESCRIPTION
## Description

This PR introduces a couple of code changes:

1. Increases the `DispatchQueue` "Quality of Service" from `.background` to `.utility`, as per documentation seems like a better choice.
2. The `pathUpdateHandler` has been modified to use the provided `path` instead of using the stored `currentPath` in the path monitor. This may make a difference when it comes to obtaining reliable connectivity change updates. The code has been refactored to reuse the existing method.

As well, I have updated the README.md with some information regarding the iOS implementation and its limitations.

## Related Issues

- Closes https://github.com/fluttercommunity/plus_plugins/issues/858

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

