### PR TITLE
feat(device_info_plus): Add isLowRamDevice property to AndroidDeviceInfo

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
@@ -1,5 +1,6 @@
 package dev.fluttercommunity.plus.device_info
 
+import android.app.ActivityManager
 import android.content.Context
 import android.content.pm.PackageManager
 import android.view.WindowManager
@@ -23,7 +24,8 @@ class DeviceInfoPlusPlugin : FlutterPlugin {
     private fun setupMethodChannel(messenger: BinaryMessenger, context: Context) {
         methodChannel = MethodChannel(messenger, "dev.fluttercommunity.plus/device_info")
         val packageManager: PackageManager = context.packageManager
-        val handler = MethodCallHandlerImpl(packageManager, context)
+        val activityManager: ActivityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val handler = MethodCallHandlerImpl(packageManager, activityManager)
         methodChannel.setMethodCallHandler(handler)
     }
 }

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
@@ -23,7 +23,7 @@ class DeviceInfoPlusPlugin : FlutterPlugin {
     private fun setupMethodChannel(messenger: BinaryMessenger, context: Context) {
         methodChannel = MethodChannel(messenger, "dev.fluttercommunity.plus/device_info")
         val packageManager: PackageManager = context.packageManager
-        val handler = MethodCallHandlerImpl(packageManager)
+        val handler = MethodCallHandlerImpl(packageManager, context)
         methodChannel.setMethodCallHandler(handler)
     }
 }

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
@@ -1,5 +1,7 @@
 package dev.fluttercommunity.plus.device_info
 
+import android.app.ActivityManager
+import android.content.Context
 import android.content.pm.FeatureInfo
 import android.content.pm.PackageManager
 import android.os.Build
@@ -17,6 +19,7 @@ import kotlin.collections.HashMap
  */
 internal class MethodCallHandlerImpl(
     private val packageManager: PackageManager,
+    private val context: Context,
 ) : MethodCallHandler {
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
@@ -62,7 +65,7 @@ internal class MethodCallHandlerImpl(
             version["release"] = Build.VERSION.RELEASE
             version["sdkInt"] = Build.VERSION.SDK_INT
             build["version"] = version
-
+            build["isLowRamDevice"] = isLowRamDevice()
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 build["serialNumber"] = try {
                     Build.getSerial()
@@ -104,4 +107,12 @@ internal class MethodCallHandlerImpl(
             || Build.PRODUCT.contains("vbox86p")
             || Build.PRODUCT.contains("emulator")
             || Build.PRODUCT.contains("simulator"))
+
+    /**
+     * To detect whether it is running on a low-memory device
+     */
+    private fun isLowRamDevice(): Boolean {
+        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        return activityManager.isLowRamDevice
+    }
 }

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
@@ -1,7 +1,6 @@
 package dev.fluttercommunity.plus.device_info
 
 import android.app.ActivityManager
-import android.content.Context
 import android.content.pm.FeatureInfo
 import android.content.pm.PackageManager
 import android.os.Build
@@ -19,7 +18,7 @@ import kotlin.collections.HashMap
  */
 internal class MethodCallHandlerImpl(
     private val packageManager: PackageManager,
-    private val context: Context,
+    private val activityManager: ActivityManager,
 ) : MethodCallHandler {
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
@@ -65,7 +64,7 @@ internal class MethodCallHandlerImpl(
             version["release"] = Build.VERSION.RELEASE
             version["sdkInt"] = Build.VERSION.SDK_INT
             build["version"] = version
-            build["isLowRamDevice"] = isLowRamDevice()
+            build["isLowRamDevice"] = activityManager.isLowRamDevice
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 build["serialNumber"] = try {
                     Build.getSerial()
@@ -107,12 +106,4 @@ internal class MethodCallHandlerImpl(
             || Build.PRODUCT.contains("vbox86p")
             || Build.PRODUCT.contains("emulator")
             || Build.PRODUCT.contains("simulator"))
-
-    /**
-     * To detect whether it is running on a low-memory device
-     */
-    private fun isLowRamDevice(): Boolean {
-        val activityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        return activityManager.isLowRamDevice
-    }
 }

--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -102,6 +102,7 @@ class _MyAppState extends State<MyApp> {
       'isPhysicalDevice': build.isPhysicalDevice,
       'systemFeatures': build.systemFeatures,
       'serialNumber': build.serialNumber,
+      'isLowRamDevice': build.isLowRamDevice,
     };
   }
 

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -137,7 +137,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
   /// https://developer.android.com/reference/android/os/Build#getSerial()
   final String serialNumber;
 
-  /// `true` is it running on a low ram device `false` otherwise
+  /// `true` if the application is running on a low-RAM device, `false` otherwise.
   final bool isLowRamDevice;
 
   /// Deserializes from the message received from [_kChannel].

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -31,6 +31,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
     required this.isPhysicalDevice,
     required List<String> systemFeatures,
     required this.serialNumber,
+    required this.isLowRamDevice,
   })  : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
         supported64BitAbis = List<String>.unmodifiable(supported64BitAbis),
         supportedAbis = List<String>.unmodifiable(supportedAbis),
@@ -136,33 +137,36 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
   /// https://developer.android.com/reference/android/os/Build#getSerial()
   final String serialNumber;
 
+  /// `true` is it running on a low ram device `false` otherwise
+  final bool isLowRamDevice;
+
   /// Deserializes from the message received from [_kChannel].
   static AndroidDeviceInfo fromMap(Map<String, dynamic> map) {
     return AndroidDeviceInfo._(
-      data: map,
-      version: AndroidBuildVersion._fromMap(
-          map['version']?.cast<String, dynamic>() ?? {}),
-      board: map['board'],
-      bootloader: map['bootloader'],
-      brand: map['brand'],
-      device: map['device'],
-      display: map['display'],
-      fingerprint: map['fingerprint'],
-      hardware: map['hardware'],
-      host: map['host'],
-      id: map['id'],
-      manufacturer: map['manufacturer'],
-      model: map['model'],
-      product: map['product'],
-      supported32BitAbis: _fromList(map['supported32BitAbis'] ?? <String>[]),
-      supported64BitAbis: _fromList(map['supported64BitAbis'] ?? <String>[]),
-      supportedAbis: _fromList(map['supportedAbis'] ?? []),
-      tags: map['tags'],
-      type: map['type'],
-      isPhysicalDevice: map['isPhysicalDevice'],
-      systemFeatures: _fromList(map['systemFeatures'] ?? []),
-      serialNumber: map['serialNumber'],
-    );
+        data: map,
+        version: AndroidBuildVersion._fromMap(
+            map['version']?.cast<String, dynamic>() ?? {}),
+        board: map['board'],
+        bootloader: map['bootloader'],
+        brand: map['brand'],
+        device: map['device'],
+        display: map['display'],
+        fingerprint: map['fingerprint'],
+        hardware: map['hardware'],
+        host: map['host'],
+        id: map['id'],
+        manufacturer: map['manufacturer'],
+        model: map['model'],
+        product: map['product'],
+        supported32BitAbis: _fromList(map['supported32BitAbis'] ?? <String>[]),
+        supported64BitAbis: _fromList(map['supported64BitAbis'] ?? <String>[]),
+        supportedAbis: _fromList(map['supportedAbis'] ?? []),
+        tags: map['tags'],
+        type: map['type'],
+        isPhysicalDevice: map['isPhysicalDevice'],
+        systemFeatures: _fromList(map['systemFeatures'] ?? []),
+        serialNumber: map['serialNumber'],
+        isLowRamDevice: map['isLowRamDevice']);
   }
 
   /// Deserializes message as List<String>

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -143,30 +143,31 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
   /// Deserializes from the message received from [_kChannel].
   static AndroidDeviceInfo fromMap(Map<String, dynamic> map) {
     return AndroidDeviceInfo._(
-        data: map,
-        version: AndroidBuildVersion._fromMap(
-            map['version']?.cast<String, dynamic>() ?? {}),
-        board: map['board'],
-        bootloader: map['bootloader'],
-        brand: map['brand'],
-        device: map['device'],
-        display: map['display'],
-        fingerprint: map['fingerprint'],
-        hardware: map['hardware'],
-        host: map['host'],
-        id: map['id'],
-        manufacturer: map['manufacturer'],
-        model: map['model'],
-        product: map['product'],
-        supported32BitAbis: _fromList(map['supported32BitAbis'] ?? <String>[]),
-        supported64BitAbis: _fromList(map['supported64BitAbis'] ?? <String>[]),
-        supportedAbis: _fromList(map['supportedAbis'] ?? []),
-        tags: map['tags'],
-        type: map['type'],
-        isPhysicalDevice: map['isPhysicalDevice'],
-        systemFeatures: _fromList(map['systemFeatures'] ?? []),
-        serialNumber: map['serialNumber'],
-        isLowRamDevice: map['isLowRamDevice']);
+      data: map,
+      version: AndroidBuildVersion._fromMap(
+          map['version']?.cast<String, dynamic>() ?? {}),
+      board: map['board'],
+      bootloader: map['bootloader'],
+      brand: map['brand'],
+      device: map['device'],
+      display: map['display'],
+      fingerprint: map['fingerprint'],
+      hardware: map['hardware'],
+      host: map['host'],
+      id: map['id'],
+      manufacturer: map['manufacturer'],
+      model: map['model'],
+      product: map['product'],
+      supported32BitAbis: _fromList(map['supported32BitAbis'] ?? <String>[]),
+      supported64BitAbis: _fromList(map['supported64BitAbis'] ?? <String>[]),
+      supportedAbis: _fromList(map['supportedAbis'] ?? []),
+      tags: map['tags'],
+      type: map['type'],
+      isPhysicalDevice: map['isPhysicalDevice'],
+      systemFeatures: _fromList(map['systemFeatures'] ?? []),
+      serialNumber: map['serialNumber'],
+      isLowRamDevice: map['isLowRamDevice'],
+    );
   }
 
   /// Deserializes message as List<String>

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
@@ -37,4 +37,5 @@ const _fakeAndroidDeviceInfo = <String, dynamic>{
   'supported64BitAbis': _fakeSupported64BitAbis,
   'supported32BitAbis': _fakeSupported32BitAbis,
   'serialNumber': 'SERIAL',
+  'isLowRamDevice': false,
 };

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
@@ -38,6 +38,7 @@ void main() {
       expect(androidDeviceInfo.version.incremental, 'incremental');
       expect(androidDeviceInfo.version.securityPatch, 'securityPatch');
       expect(androidDeviceInfo.serialNumber, 'SERIAL');
+      expect(androidDeviceInfo.isLowRamDevice, false);
     });
 
     test('toMap should return map with correct key and map', () {


### PR DESCRIPTION
## Description

The idea is to detect whether the running device is on low RAM or not. From `ActivityManager` we are getting `isLowRamDevice()` which is added on `AndroidDeviceInfo`

## Related Issues

- Fix #2759

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

