### PR TITLE
fix (android_alarm_manager_plus): Fix showIntent not being set correctly in setAlarmClock

### DIFF
--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmService.java
@@ -9,6 +9,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Handler;
 import android.util.Log;
@@ -147,7 +148,18 @@ public class AlarmService extends JobIntentService {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !manager.canScheduleExactAlarms()) {
         Log.e(TAG, "Can`t schedule exact alarm due to revoked SCHEDULE_EXACT_ALARM permission");
       } else {
-        AlarmManagerCompat.setAlarmClock(manager, startMillis, pendingIntent, pendingIntent);
+        PackageManager packageManager = context.getPackageManager();
+        String appId = context.getPackageName();
+        Intent launchIntent = packageManager.getLaunchIntentForPackage(appId);
+        launchIntent.putExtra("id", requestCode);
+        launchIntent.putExtra("params", params == null ? null : params.toString());
+        PendingIntent showPendingIntent = PendingIntent.getActivity(
+            context,
+            requestCode,
+            launchIntent,
+            (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M ? PendingIntent.FLAG_IMMUTABLE : 0)
+                | PendingIntent.FLAG_UPDATE_CURRENT);
+        AlarmManagerCompat.setAlarmClock(manager, startMillis, showPendingIntent, pendingIntent);
       }
       return;
     }


### PR DESCRIPTION
## Description

### The issue
Currently the android_alarm_manager_plus does not set the `showIntent` argument properly when setting an alarm clock using `setAlarmClock`. According to android [docs](https://developer.android.com/reference/androidx/core/app/AlarmManagerCompat#setAlarmClock(android.app.AlarmManager,long,android.app.PendingIntent,android.app.PendingIntent)), this is supposed to set a pending intent that shows the user details of the alarm, or the ability to edit the alarm. This is usually done by launching the relevant app that set the alarm. This intent is used when the user clicks on the [quick setting alarm tile](https://developer.android.com/develop/ui/views/quicksettings-tiles), or most other system UIs showing the next alarm (notification are, lock screen etc.).
![image](https://github.com/fluttercommunity/plus_plugins/assets/41967492/0d4c4926-598f-456c-bcaa-d8060016190b)
Currently, `showIntent`  is set as the intent that triggers the alarm isolate. This means that whenever the user taps the above mentioned system UIs, the code inside the alarm isolate runs, which is not what was expected.

### The fix
This PR sets the `showIntent` such that it launches the app, as well as passing the alarm `id` and `params` as extras to this intent. No new parameters have been added.

These extras can be used by the app to direct the user to the relevant alarm, and the relevant screen. An example of how these extras can be used in the receiving dart code using the [receive_intent](https://pub.dev/packages/receive_intent) package.

```dart
final paramsExtra = receivedIntent.extra?["params"];
if (paramsExtra != null){
  final params = jsonDecode(params);
}
final id = receivedIntent.extra?["id"];
```

## Related Issues

Fix #2766 

## Checklist

- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

