### PR TITLE
docs(connectivity_plus): Document supported ConnectivityResult per platform

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -80,6 +80,20 @@ dispose() {
 }
 ```
 
+## Platform Support
+
+The following table shows which `ConnectivityResult` values are supported per platform.
+
+|           | Android | iOS | Web | MacOS | Windows | Linux |
+|-----------|:-------:|:---:|:---:|:-----:|:-------:|:-----:|
+| wifi      | ✅      | ✅   |     | ✅      |         |       |
+| bluetooth | ✅      |      |     |       |         |       |
+| ethernet  | ✅      | ⚠️    |     | ⚠️      |         |       |
+| mobile    | ✅      | ✅   |     | ✅      |         |       |
+| vpn       | ✅      |      |     |       |         |       |
+| other     | ✅      | ⚠️    |     | ⚠️      |         |       |
+| none      | ✅      | ✅   |     | ✅      |         |       |
+
 ### Android
 
 Connectivity changes are no longer communicated to Android apps in the background starting with Android O (8.0). You should always check for connectivity status when your app is resumed. The broadcast is only useful when your application is in the foreground.

--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -86,23 +86,25 @@ The following table shows which `ConnectivityResult` values are supported per pl
 
 |           | Android | iOS | Web | MacOS | Windows | Linux |
 |-----------|:-------:|:---:|:---:|:-----:|:-------:|:-----:|
-| wifi      | ✅      | ✅   |     | ✅      |         |       |
-| bluetooth | ✅      |      |     |       |         |       |
-| ethernet  | ✅      | ⚠️    |     | ⚠️      |         |       |
-| mobile    | ✅      | ✅   |     | ✅      |         |       |
-| vpn       | ✅      |      |     |       |         |       |
-| other     | ✅      | ⚠️    |     | ⚠️      |         |       |
-| none      | ✅      | ✅   |     | ✅      |         |       |
+| wifi      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| bluetooth | :white_check_mark: |                    |                    |                    |                    | :white_check_mark: |
+| ethernet  | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+| mobile    | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: |                    |                    |
+| vpn       | :white_check_mark: |                    |                    |                    | :white_check_mark: | :white_check_mark: |
+| other     | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
+
+_`none` is supported on all platforms by default._
 
 ### Android
 
 Connectivity changes are no longer communicated to Android apps in the background starting with Android O (8.0). You should always check for connectivity status when your app is resumed. The broadcast is only useful when your application is in the foreground.
 
-### iOS
+### iOS & MacOS
 
 On iOS simulators, the connectivity types stream might not update when Wi-Fi status changes. This is a known issue.
 
-Starting with iOS 12, the implementation uses `NWPathMonitor` to obtain the enabled connectivity types. We noticed that this observer can give multiple or unreliable results. For example, reporting connectivity "none" followed by connectivity "wifi" right after reconnecting.
+Starting with iOS 12 and MacOS 10.14, the implementation uses `NWPathMonitor` to obtain the enabled connectivity types. We noticed that this observer can give multiple or unreliable results. For example, reporting connectivity "none" followed by connectivity "wifi" right after reconnecting.
+
 We recommend to use the `onConnectivityChanged` with this limitation in mind, as the method doesn't filter events, nor it ensures distinct values.
 
 ### Web


### PR DESCRIPTION
## Description

This PR contains documentation updates for `connectivity_plus`.

Since not all possible `ConnectivityResult` values are supported on all platforms (e.g. the iOS implementation doesn't support bluetooth connectivity reporting) I think it would be useful to document that, in order to avoid misunderstandings.

Also included macOS in the section about iOS, since they share implementation.

## Related Issues

- Closes https://github.com/fluttercommunity/plus_plugins/issues/2776

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

