### PR TITLE
docs(network_info_plus): Add explanation on Wi-Fi name in quotes to README

### DIFF
--- a/packages/network_info_plus/network_info_plus/README.md
+++ b/packages/network_info_plus/network_info_plus/README.md
@@ -57,6 +57,12 @@ To successfully get WiFi Name or Wi-Fi BSSID starting with Android 1O, ensure al
 
 - If you use device with Android 12 (API level 31) and newer be sure that your app has ACCESS_NETWORK_STATE permission.
 
+**Wi-Fi Name in quotes**
+
+The Android OS will return the Wi-Fi name surrounded in quotes. e.g. `"WiFi Name"` instead of `Wifi Name`.
+These double quotes are added by the operating system, but only when the original Wi-Fi name doesn't contain
+quotes already. This is a known limitation, do not create bug reports about this.
+
 > **Note**
 >
 > This package does not provide the ACCESS_FINE_LOCATION nor the ACCESS_COARSE_LOCATION permission by default


### PR DESCRIPTION
## Description

- Adds clarification regarding the double quotes returned by the get Wi-Fi name method on Android.

## Related Issues

- Related: https://github.com/fluttercommunity/plus_plugins/issues/2505
- Related: https://github.com/fluttercommunity/plus_plugins/issues/1326

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

