### PR TITLE
fix(share_plus): Recover ShareSuccessManager state after error

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
@@ -53,9 +53,9 @@ internal class MethodCallHandler(
 
                 else -> result.notImplemented()
             }
-        } catch (e: IOException) {
+        } catch (e: Throwable) {
             manager.clear()
-            result.error("Share failed", e.message, null)
+            result.error("Share failed", e.message, e)
         }
     }
 

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
@@ -7,39 +7,50 @@ import java.io.IOException
 
 /** Handles the method calls for the plugin.  */
 internal class MethodCallHandler(
-    private val share: Share,
-    private val manager: ShareSuccessManager
+    private val share: Share, private val manager: ShareSuccessManager
 ) : MethodChannel.MethodCallHandler {
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
-        expectMapArguments(call)
-
         // The user used a *WithResult method
         val isResultRequested = call.method.endsWith("WithResult")
         // We don't attempt to return a result if the current API version doesn't support it
-        val isWithResult = isResultRequested && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
+        val isWithResult =
+            isResultRequested && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
 
-        if (isWithResult)
-            manager.setCallback(result)
+        expectMapArguments(call)
+        if (isWithResult && !manager.setCallback(result)) return
 
         when (call.method) {
             "shareUri" -> {
-                share.share(
-                    call.argument<Any>("uri") as String,
-                    subject = null,
-                    withResult= false
-                )
+                try {
+                    share.share(
+                        call.argument<Any>("uri") as String, subject = null, withResult = false
+                    )
+                } catch (e: IOException) {
+                    manager.clear()
+                    result.error("Share failed", e.message, null)
+                }
                 if (!isWithResult) {
-                    result.success(null)
+                    if (isResultRequested) {
+                        result.success("dev.fluttercommunity.plus/share/unavailable")
+                    } else {
+                        result.success(null)
+                    }
                 }
             }
+
             "share", "shareWithResult" -> {
                 // Android does not support showing the share sheet at a particular point on screen.
-                share.share(
-                    call.argument<Any>("text") as String,
-                    call.argument<Any>("subject") as String?,
-                    isWithResult,
-                )
+                try {
+                    share.share(
+                        call.argument<Any>("text") as String,
+                        call.argument<Any>("subject") as String?,
+                        isWithResult,
+                    )
+                } catch (e: IOException) {
+                    manager.clear()
+                    result.error("Share failed", e.message, null)
+                }
 
                 if (!isWithResult) {
                     if (isResultRequested) {
@@ -49,6 +60,7 @@ internal class MethodCallHandler(
                     }
                 }
             }
+
             "shareFiles", "shareFilesWithResult" -> {
                 // Android does not support showing the share sheet at a particular point on screen.
                 try {
@@ -59,18 +71,20 @@ internal class MethodCallHandler(
                         call.argument<String?>("subject"),
                         isWithResult,
                     )
-
-                    if (!isWithResult) {
-                        if (isResultRequested) {
-                            result.success("dev.fluttercommunity.plus/share/unavailable")
-                        } else {
-                            result.success(null)
-                        }
-                    }
                 } catch (e: IOException) {
+                    manager.clear()
                     result.error("Share failed", e.message, null)
                 }
+
+                if (!isWithResult) {
+                    if (isResultRequested) {
+                        result.success("dev.fluttercommunity.plus/share/unavailable")
+                    } else {
+                        result.success(null)
+                    }
+                }
             }
+
             else -> result.notImplemented()
         }
     }

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
@@ -12,14 +12,18 @@ internal class MethodCallHandler(
 ) : MethodChannel.MethodCallHandler {
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
+        expectMapArguments(call)
+
         // The user used a *WithResult method
         val isResultRequested = call.method.endsWith("WithResult")
         // We don't attempt to return a result if the current API version doesn't support it
         val isWithResult = isResultRequested && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
 
+        if (isWithResult)
+            manager.setCallback(result)
+
         when (call.method) {
             "shareUri" -> {
-                expectMapArguments(call)
                 share.share(
                     call.argument<Any>("uri") as String,
                     subject = null,
@@ -30,9 +34,6 @@ internal class MethodCallHandler(
                 }
             }
             "share", "shareWithResult" -> {
-                expectMapArguments(call)
-                if (isWithResult && !manager.setCallback(result)) return
-
                 // Android does not support showing the share sheet at a particular point on screen.
                 share.share(
                     call.argument<Any>("text") as String,
@@ -49,9 +50,6 @@ internal class MethodCallHandler(
                 }
             }
             "shareFiles", "shareFilesWithResult" -> {
-                expectMapArguments(call)
-                if (isWithResult && !manager.setCallback(result)) return
-
                 // Android does not support showing the share sheet at a particular point on screen.
                 try {
                     share.shareFiles(

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
@@ -17,11 +17,21 @@ internal class ShareSuccessManager(private val context: Context) : ActivityResul
      * Set result callback that will wait for the share-sheet to close and get either
      * the componentname of the chosen option or an empty string on dismissal.
      */
-    fun setCallback(callback: MethodChannel.Result) {
-        // Prepare all state for new share
-        SharePlusPendingIntent.result = ""
-        isCalledBack.set(false)
-        this.callback = callback
+    fun setCallback(callback: MethodChannel.Result): Boolean {
+        return if (isCalledBack.compareAndSet(true, false)) {
+            // Prepare all state for new share
+            SharePlusPendingIntent.result = ""
+            isCalledBack.set(false)
+            this.callback = callback
+            true
+        } else {
+            callback.error(
+                "Share callback error",
+                "prior share-sheet did not call back, did you await it? Maybe use non-result variant",
+                null,
+            )
+            false
+        }
     }
 
     /**
@@ -29,6 +39,14 @@ internal class ShareSuccessManager(private val context: Context) : ActivityResul
      */
     fun unavailable() {
         returnResult(RESULT_UNAVAILABLE)
+    }
+
+    /**
+     * Must be called on error to avoid deadlocking.
+     */
+    fun clear() {
+        isCalledBack.set(true)
+        callback = null
     }
 
     /**

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
@@ -17,21 +17,11 @@ internal class ShareSuccessManager(private val context: Context) : ActivityResul
      * Set result callback that will wait for the share-sheet to close and get either
      * the componentname of the chosen option or an empty string on dismissal.
      */
-    fun setCallback(callback: MethodChannel.Result): Boolean {
-        return if (isCalledBack.compareAndSet(true, false)) {
-            // Prepare all state for new share
-            SharePlusPendingIntent.result = ""
-            isCalledBack.set(false)
-            this.callback = callback
-            true
-        } else {
-            callback.error(
-                "Share callback error",
-                "prior share-sheet did not call back, did you await it? Maybe use non-result variant",
-                null,
-            )
-            false
-        }
+    fun setCallback(callback: MethodChannel.Result) {
+        // Prepare all state for new share
+        SharePlusPendingIntent.result = ""
+        isCalledBack.set(false)
+        this.callback = callback
     }
 
     /**


### PR DESCRIPTION
## Description

- Looking at issues reported in #1936 and #1351, I figured out that the `ShareSuccessManager` was in a bad state which blocked users from continuing using the plugin.
- The `ShareSuccessManager` checks the state of the current callback state, and fails if a callback was never executed. This is problematic because causes this state to be never recover after an error happened.
- The problem is that, on error, `onActivityResult` is never called, so the state is never restored.
- To solve this problem, I introduced a `clear()` method that will reset the state, only call to this method in cases we catch an error.
- did a refactor, and moved things a bit, simplifying the code of the `MethodCallHandler`.
- to test this, I call `shareXFiles` with bad `XFile` (wrong paths), which causes an exception. Then I call the `share` methods normally and still works, both with result and without.
- In the future, if we find other edge cases where `ShareSuccessManager` is in a bad state, we can use the clear method in those edge cases to clean up the state.
- This PR supersedes #2446 as it provides a more precise way to handle errors, while still maintaining the old functionality intact.

## Related Issues

- Fix #1351 
- Fix #1612
- Fix #1936
- Fix #2461
- Fix #2530

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

