### PR TITLE
fix(sensors_plus): WASM-compatible conditional imports

### DIFF
--- a/packages/sensors_plus/sensors_plus/lib/sensors_plus.dart
+++ b/packages/sensors_plus/sensors_plus/lib/sensors_plus.dart
@@ -4,7 +4,8 @@ import 'src/sensors.dart';
 
 export 'package:sensors_plus_platform_interface/sensors_plus_platform_interface.dart';
 
-export 'src/sensors.dart' if (dart.library.js_interop) 'src/sensors_plus_web.dart';
+export 'src/sensors.dart'
+    if (dart.library.js_interop) 'src/sensors_plus_web.dart';
 
 final _sensors = Sensors();
 

--- a/packages/sensors_plus/sensors_plus/lib/sensors_plus.dart
+++ b/packages/sensors_plus/sensors_plus/lib/sensors_plus.dart
@@ -4,7 +4,7 @@ import 'src/sensors.dart';
 
 export 'package:sensors_plus_platform_interface/sensors_plus_platform_interface.dart';
 
-export 'src/sensors.dart' if (dart.library.html) 'src/sensors_plus_web.dart';
+export 'src/sensors.dart' if (dart.library.js_interop) 'src/sensors_plus_web.dart';
 
 final _sensors = Sensors();
 


### PR DESCRIPTION
## Description

Migrates the conditional imports to support WASM (see https://dart.dev/interop/js-interop/package-web#conditional-imports)

## Related Issues

- Fixes https://github.com/fluttercommunity/plus_plugins/issues/2823

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

