### PR TITLE
fix(connectivity_plus): WASM-compatible conditional imports

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
@@ -11,7 +11,7 @@ export 'package:connectivity_plus_platform_interface/connectivity_plus_platform_
     show ConnectivityResult;
 
 export 'src/connectivity_plus_linux.dart'
-    if (dart.library.html) 'src/connectivity_plus_web.dart';
+    if (dart.library.js_interop) 'src/connectivity_plus_web.dart';
 
 /// Discover network connectivity configurations: Distinguish between WI-FI and cellular, check WI-FI status and more.
 class Connectivity {


### PR DESCRIPTION
## Description

Migrates the conditional imports to support WASM (see https://dart.dev/interop/js-interop/package-web#conditional-imports)

## Related Issues

- Fixes https://github.com/fluttercommunity/plus_plugins/issues/2822

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

