### PR TITLE
fix(device_info_plus): WASM-compatible conditional imports

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/device_info_plus.dart
+++ b/packages/device_info_plus/device_info_plus/lib/device_info_plus.dart
@@ -26,9 +26,9 @@ export 'src/model/web_browser_info.dart';
 export 'src/model/windows_device_info.dart';
 
 export 'src/device_info_plus_linux.dart'
-    if (dart.library.html) 'src/device_info_plus_web.dart';
+    if (dart.library.js_interop) 'src/device_info_plus_web.dart';
 export 'src/device_info_plus_windows.dart'
-    if (dart.library.html) 'src/device_info_plus_web.dart';
+    if (dart.library.js_interop) 'src/device_info_plus_web.dart';
 
 /// Provides device and operating system information.
 class DeviceInfoPlugin {


### PR DESCRIPTION
## Description

Migrates the conditional imports to support WASM (see https://dart.dev/interop/js-interop/package-web#conditional-imports)

## Related Issues

- Fixes https://github.com/fluttercommunity/plus_plugins/issues/2821

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

