### PR TITLE
refactor(share_plus)!: Share API cleanup

### DIFF
--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -101,6 +101,15 @@ This special method is only properly supported on iOS.
 Share.shareUri(uri: uri);
 ```
 
+### Share Results
+
+All three methods return a `ShareResult` object which contains the following information:
+
+- `status`: a `ShareResultStatus`
+- `raw`: a `String` describing the share result, e.g. the opening app ID.
+
+Note: `status` will be `ShareResultStatus.unavailable` if the platform does not support identifying the user action.
+
 ## Known Issues
 
 ### Sharing data created with XFile.fromData

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -11,14 +11,16 @@
 A Flutter plugin to share content from your Flutter app via the platform's
 share dialog.
 
-Wraps the `ACTION_SEND` Intent on Android and `UIActivityViewController`
-on iOS.
+Wraps the `ACTION_SEND` Intent on Android, `UIActivityViewController`
+on iOS, or equivalent platform content sharing methods.
 
 ## Platform Support
 
-| Android | iOS | MacOS | Web | Linux | Windows |
-| :-----: | :-: | :---: | :-: | :---: | :----: |
-|   ✅    | ✅  |  ✅   | ✅  |  ✅   |   ✅   |
+| Method        | Android | iOS | MacOS | Web | Linux | Windows |
+| :-----------: | :-----: | :-: | :---: | :-: | :---: | :----: |
+| `share`       |   ✅    | ✅  |  ✅   | ✅  |  ✅   |   ✅   |
+| `shareUri`    |   ✅    | ✅  |       |     |       |        |
+| `shareXFiles` |   ✅    | ✅  |  ✅   | ✅  |       |   ✅   |
 
 Also compatible with Windows and Linux by using "mailto" to share text via Email.
 
@@ -28,15 +30,15 @@ Sharing files is not supported on Linux.
 
 To use this plugin, add `share_plus` as a [dependency in your pubspec.yaml file](https://plus.fluttercommunity.dev/docs/overview).
 
-## Example
-
 Import the library.
 
 ```dart
 import 'package:share_plus/share_plus.dart';
 ```
 
-Then invoke the static `share` method anywhere in your Dart code.
+### Share Text
+
+Invoke the static `share` method anywhere in your Dart code.
 
 ```dart
 Share.share('check out my website https://example.com');
@@ -49,15 +51,17 @@ sharing to email.
 Share.share('check out my website https://example.com', subject: 'Look what I made!');
 ```
 
-If you are interested in the action your user performed with the share sheet, you can instead use the `shareWithResult` method.
+If you are interested in the action your user performed with the share sheet, the `share` method returns a status object.
 
 ```dart
-final result = await Share.shareWithResult('check out my website https://example.com');
+final result = await Share.share('check out my website https://example.com');
 
 if (result.status == ShareResultStatus.success) {
     print('Thank you for sharing my website!');
 }
 ```
+
+### Share Files
 
 To share one or multiple files, invoke the static `shareXFiles` method anywhere in your Dart code. The method returns a `ShareResult`. Optionally, you can pass `subject`, `text` and `sharePositionOrigin`.
 
@@ -77,7 +81,6 @@ if (result.status == ShareResultStatus.dismissed) {
 }
 ```
 
-
 On web, you can use `SharePlus.shareXFiles()`. This uses the [Web Share API](https://web.dev/web-share/)
 if it's available. Otherwise it falls back to downloading the shared files.
 See [Can I Use - Web Share API](https://caniuse.com/web-share) to understand
@@ -87,6 +90,15 @@ package.
 
 ```dart
 Share.shareXFiles([XFile('assets/hello.txt')], text: 'Great picture');
+```
+
+### Share URI
+
+iOS supports fetching metadata from a URI when shared using `UIActivityViewController`.
+This special method is only properly supported on iOS.
+
+```dart
+Share.shareUri(uri: uri);
 ```
 
 ## Known Issues
@@ -103,9 +115,13 @@ Alternatively, don't use `XFile.fromData` and instead write the data down to a `
 
 ### Mobile platforms (Android and iOS)
 
-#### Facebook limitations (WhatsApp, Instagram, Facebook Messenger)
+#### Meta (WhatsApp, Instagram, Facebook Messenger) and similar apps
 
-Due to restrictions set up by Facebook this plugin isn't capable of sharing data reliably to Facebook related apps on Android and iOS. This includes eg. sharing text to the Facebook Messenger. If you require this functionality please check the native Facebook Sharing SDK ([https://developers.facebook.com/docs/sharing](https://developers.facebook.com/docs/sharing)) or search for other Flutter plugins implementing this SDK. More information can be found in [this issue](https://github.com/fluttercommunity/plus_plugins/issues/413).
+Due to restrictions set up by Meta/Facebook this plugin isn't capable of sharing data reliably to Facebook related apps on Android and iOS. This includes eg. sharing text to the Facebook Messenger. If you require this functionality please check the native Facebook Sharing SDK ([https://developers.facebook.com/docs/sharing](https://developers.facebook.com/docs/sharing)) or search for other Flutter plugins implementing this SDK. More information can be found in [this issue](https://github.com/fluttercommunity/plus_plugins/issues/413).
+
+Other apps may also give problems when attempting to share content to them.
+We cannot warranty that a 3rd party app will properly implement the share functionality.
+Therefore, all bugs reported regarding compatibility with a specific app will be closed.
 
 #### Localization in Apple platforms
 

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -38,7 +38,7 @@ import 'package:share_plus/share_plus.dart';
 
 ### Share Text
 
-Invoke the static `share` method anywhere in your Dart code.
+Invoke the static `share()` method anywhere in your Dart code.
 
 ```dart
 Share.share('check out my website https://example.com');

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -51,7 +51,7 @@ sharing to email.
 Share.share('check out my website https://example.com', subject: 'Look what I made!');
 ```
 
-If you are interested in the action your user performed with the share sheet, the `share` method returns a status object.
+`share()` returns `status` object that allows to check the result of user action in the share sheet.
 
 ```dart
 final result = await Share.share('check out my website https://example.com');

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
@@ -1,6 +1,7 @@
 package dev.fluttercommunity.plus.share
 
 import android.os.Build
+import io.flutter.BuildConfig
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import java.io.IOException
@@ -18,7 +19,8 @@ internal class MethodCallHandler(
         val isWithResult =
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1
 
-        if (isWithResult && !manager.setCallback(result)) return
+        if (isWithResult)
+            manager.setCallback(result)
 
         try {
             when (call.method) {

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/ShareSuccessManager.kt
@@ -17,20 +17,22 @@ internal class ShareSuccessManager(private val context: Context) : ActivityResul
      * Set result callback that will wait for the share-sheet to close and get either
      * the componentname of the chosen option or an empty string on dismissal.
      */
-    fun setCallback(callback: MethodChannel.Result): Boolean {
+    fun setCallback(callback: MethodChannel.Result) {
         return if (isCalledBack.compareAndSet(true, false)) {
             // Prepare all state for new share
             SharePlusPendingIntent.result = ""
             isCalledBack.set(false)
             this.callback = callback
-            true
         } else {
-            callback.error(
-                "Share callback error",
-                "prior share-sheet did not call back, did you await it? Maybe use non-result variant",
-                null,
-            )
-            false
+            // Ensure no deadlocks.
+            // Return result of any waiting call.
+            // e.g. user called to `share` but did not await for result.
+            this.callback?.success(RESULT_UNAVAILABLE)
+
+            // Prepare all state for new share
+            SharePlusPendingIntent.result = ""
+            isCalledBack.set(false)
+            this.callback = callback
         }
     }
 

--- a/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
+++ b/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
@@ -12,12 +12,14 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('Can launch share', (WidgetTester tester) async {
-    expect(Share.share('message', subject: 'title'), completes);
-  }, skip: Platform.isMacOS);
-
-  testWidgets('Can launch share in MacOS', (WidgetTester tester) async {
+    // Check isNotNull because we cannot wait for ShareResult
     expect(Share.share('message', subject: 'title'), isNotNull);
-  }, skip: !Platform.isMacOS);
+  });
+
+  testWidgets('Can launch shareUri', (WidgetTester tester) async {
+    // Check isNotNull because we cannot wait for ShareResult
+    expect(Share.shareUri(Uri.parse('https://example.com')), isNotNull);
+  }, skip: !Platform.isAndroid && !Platform.isIOS);
 
   testWidgets('Can shareXFile created using File.fromData()',
       (WidgetTester tester) async {

--- a/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
+++ b/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
@@ -19,10 +19,6 @@ void main() {
     expect(Share.share('message', subject: 'title'), isNotNull);
   }, skip: !Platform.isMacOS);
 
-  testWidgets('Can launch shareWithResult', (WidgetTester tester) async {
-    expect(Share.shareWithResult('message', subject: 'title'), isNotNull);
-  });
-
   testWidgets('Can shareXFile created using File.fromData()',
       (WidgetTester tester) async {
     final bytes = Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8]);

--- a/packages/share_plus/share_plus/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/share_plus/share_plus/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/packages/share_plus/share_plus/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/share_plus/share_plus/example/ios/Runner.xcodeproj/project.pbxproj
@@ -97,7 +97,6 @@
 				535124FC9BB266447EC60189 /* Pods-RunnerTests.release.xcconfig */,
 				A8F8F8E1F770CE9853568BC6 /* Pods-RunnerTests.profile.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -215,7 +214,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/packages/share_plus/share_plus/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/share_plus/share_plus/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/share_plus/share_plus/example/ios/Runner/Info.plist
+++ b/packages/share_plus/share_plus/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -24,6 +26,8 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -41,11 +45,9 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Load photos for sharing functionality</string>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<key>CADisableMinimumFrameDurationOnPhone</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
 </dict>
 </plist>

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -135,25 +135,10 @@ class DemoAppState extends State<DemoApp> {
                       foregroundColor: Theme.of(context).colorScheme.onPrimary,
                       backgroundColor: Theme.of(context).colorScheme.primary,
                     ),
-                    onPressed: text.isEmpty && imagePaths.isEmpty && uri.isEmpty
-                        ? null
-                        : () => _onShare(context),
-                    child: const Text('Share'),
-                  );
-                },
-              ),
-              const SizedBox(height: 16),
-              Builder(
-                builder: (BuildContext context) {
-                  return ElevatedButton(
-                    style: ElevatedButton.styleFrom(
-                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                      backgroundColor: Theme.of(context).colorScheme.primary,
-                    ),
                     onPressed: text.isEmpty && imagePaths.isEmpty
                         ? null
                         : () => _onShareWithResult(context),
-                    child: const Text('Share With Result'),
+                    child: const Text('Share'),
                   );
                 },
               ),
@@ -186,7 +171,7 @@ class DemoAppState extends State<DemoApp> {
     });
   }
 
-  void _onShare(BuildContext context) async {
+  void _onShareWithResult(BuildContext context) async {
     // A builder is used to retrieve the context immediately
     // surrounding the ElevatedButton.
     //
@@ -196,29 +181,6 @@ class DemoAppState extends State<DemoApp> {
     // has its position and size after it's built.
     final box = context.findRenderObject() as RenderBox?;
 
-    if (uri.isNotEmpty) {
-      await Share.shareUri(
-        Uri.parse(uri),
-        sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
-      );
-    } else if (imagePaths.isNotEmpty) {
-      final files = <XFile>[];
-      for (var i = 0; i < imagePaths.length; i++) {
-        files.add(XFile(imagePaths[i], name: imageNames[i]));
-      }
-      await Share.shareXFiles(files,
-          text: text,
-          subject: subject,
-          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
-    } else {
-      await Share.share(text,
-          subject: subject,
-          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
-    }
-  }
-
-  void _onShareWithResult(BuildContext context) async {
-    final box = context.findRenderObject() as RenderBox?;
     final scaffoldMessenger = ScaffoldMessenger.of(context);
     ShareResult shareResult;
     if (imagePaths.isNotEmpty) {
@@ -231,7 +193,7 @@ class DemoAppState extends State<DemoApp> {
           subject: subject,
           sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
     } else {
-      shareResult = await Share.shareWithResult(text,
+      shareResult = await Share.share(text,
           subject: subject,
           sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
     }

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -188,14 +188,23 @@ class DemoAppState extends State<DemoApp> {
       for (var i = 0; i < imagePaths.length; i++) {
         files.add(XFile(imagePaths[i], name: imageNames[i]));
       }
-      shareResult = await Share.shareXFiles(files,
-          text: text,
-          subject: subject,
-          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
+      shareResult = await Share.shareXFiles(
+        files,
+        text: text,
+        subject: subject,
+        sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+      );
+    } else if (uri.isNotEmpty) {
+      shareResult = await Share.shareUri(
+        Uri.parse(uri),
+        sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+      );
     } else {
-      shareResult = await Share.share(text,
-          subject: subject,
-          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size);
+      shareResult = await Share.share(
+        text,
+        subject: subject,
+        sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+      );
     }
     scaffoldMessenger.showSnackBar(getResultSnackBar(shareResult));
   }

--- a/packages/share_plus/share_plus/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/share_plus/share_plus/example/macos/Runner.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {

--- a/packages/share_plus/share_plus/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/share_plus/share_plus/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
@@ -8,35 +8,35 @@
 static NSString *const PLATFORM_CHANNEL = @"dev.fluttercommunity.plus/share";
 
 static UIViewController *RootViewController() {
-    if (@available(iOS 13, *)) { // UIApplication.keyWindow is deprecated
-        NSSet *scenes = [[UIApplication sharedApplication] connectedScenes];
-        for (UIScene *scene in scenes) {
-            if ([scene isKindOfClass:[UIWindowScene class]]) {
-                NSArray *windows = ((UIWindowScene *)scene).windows;
-                for (UIWindow *window in windows) {
-                    if (window.isKeyWindow) {
-                        return window.rootViewController;
-                    }
-                }
-            }
+  if (@available(iOS 13, *)) { // UIApplication.keyWindow is deprecated
+    NSSet *scenes = [[UIApplication sharedApplication] connectedScenes];
+    for (UIScene *scene in scenes) {
+      if ([scene isKindOfClass:[UIWindowScene class]]) {
+        NSArray *windows = ((UIWindowScene *)scene).windows;
+        for (UIWindow *window in windows) {
+          if (window.isKeyWindow) {
+            return window.rootViewController;
+          }
         }
-        return nil;
-    } else {
-        return [UIApplication sharedApplication].keyWindow.rootViewController;
+      }
     }
+    return nil;
+  } else {
+    return [UIApplication sharedApplication].keyWindow.rootViewController;
+  }
 }
 
 static UIViewController *
 TopViewControllerForViewController(UIViewController *viewController) {
-    if (viewController.presentedViewController) {
-        return TopViewControllerForViewController(
-                                                  viewController.presentedViewController);
-    }
-    if ([viewController isKindOfClass:[UINavigationController class]]) {
-        return TopViewControllerForViewController(
-                                                  ((UINavigationController *)viewController).visibleViewController);
-    }
-    return viewController;
+  if (viewController.presentedViewController) {
+    return TopViewControllerForViewController(
+        viewController.presentedViewController);
+  }
+  if ([viewController isKindOfClass:[UINavigationController class]]) {
+    return TopViewControllerForViewController(
+        ((UINavigationController *)viewController).visibleViewController);
+  }
+  return viewController;
 }
 
 // We need the companion to avoid ARC deadlock
@@ -53,21 +53,21 @@ TopViewControllerForViewController(UIViewController *viewController) {
 @implementation UIActivityViewSuccessCompanion
 
 - (id)initWithResult:(FlutterResult)result {
-    if (self = [super init]) {
-        self.result = result;
-        self.completed = false;
-    }
-    return self;
+  if (self = [super init]) {
+    self.result = result;
+    self.completed = false;
+  }
+  return self;
 }
 
 // We use dealloc as the share-sheet might disappear (e.g. iCloud photo album
 // creation) and could then reappear if the user cancels
 - (void)dealloc {
-    if (self.completed) {
-        self.result(self.activityType);
-    } else {
-        self.result(@"");
-    }
+  if (self.completed) {
+    self.result(self.activityType);
+  } else {
+    self.result(@"");
+  }
 }
 
 @end
@@ -99,141 +99,141 @@ TopViewControllerForViewController(UIViewController *viewController) {
                      subject:(NSString *)subject NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init
-__attribute__((unavailable("Use initWithSubject:text: instead")));
+    __attribute__((unavailable("Use initWithSubject:text: instead")));
 
 @end
 
 @implementation SharePlusData
 
 - (instancetype)init {
-    [super doesNotRecognizeSelector:_cmd];
-    return nil;
+  [super doesNotRecognizeSelector:_cmd];
+  return nil;
 }
 
 - (instancetype)initWithSubject:(NSString *)subject text:(NSString *)text {
-    self = [super init];
-    if (self) {
-        _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
-        _text = text;
-    }
-    return self;
+  self = [super init];
+  if (self) {
+    _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
+    _text = text;
+  }
+  return self;
 }
 
 - (instancetype)initWithFile:(NSString *)path mimeType:(NSString *)mimeType {
-    self = [super init];
-    if (self) {
-        _path = path;
-        _mimeType = mimeType;
-    }
-    return self;
+  self = [super init];
+  if (self) {
+    _path = path;
+    _mimeType = mimeType;
+  }
+  return self;
 }
 
 - (instancetype)initWithFile:(NSString *)path
                     mimeType:(NSString *)mimeType
                      subject:(NSString *)subject {
-    self = [super init];
-    if (self) {
-        _path = path;
-        _mimeType = mimeType;
-        _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
-    }
-    return self;
+  self = [super init];
+  if (self) {
+    _path = path;
+    _mimeType = mimeType;
+    _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
+  }
+  return self;
 }
 
 - (id)activityViewControllerPlaceholderItem:
-(UIActivityViewController *)activityViewController {
-    return [self
-            activityViewController:activityViewController
-            itemForActivityType:@"dev.fluttercommunity.share_plus.placeholder"];
+    (UIActivityViewController *)activityViewController {
+  return [self
+      activityViewController:activityViewController
+         itemForActivityType:@"dev.fluttercommunity.share_plus.placeholder"];
 }
 
 - (id)activityViewController:(UIActivityViewController *)activityViewController
          itemForActivityType:(UIActivityType)activityType {
-    if (!_path || !_mimeType) {
-        return _text;
-    }
-    
-    // If the shared file is an image return an UIImage for the placeholder
-    // to show a preview.
-    if ([activityType
-         isEqualToString:@"dev.fluttercommunity.share_plus.placeholder"] &&
-        [_mimeType hasPrefix:@"image/"]) {
-        UIImage *image = [UIImage imageWithContentsOfFile:_path];
-        return image;
-    }
-    
-    // Return an NSURL for the real share to conserve the file name
-    NSURL *url = [NSURL fileURLWithPath:_path];
-    return url;
+  if (!_path || !_mimeType) {
+    return _text;
+  }
+
+  // If the shared file is an image return an UIImage for the placeholder
+  // to show a preview.
+  if ([activityType
+          isEqualToString:@"dev.fluttercommunity.share_plus.placeholder"] &&
+      [_mimeType hasPrefix:@"image/"]) {
+    UIImage *image = [UIImage imageWithContentsOfFile:_path];
+    return image;
+  }
+
+  // Return an NSURL for the real share to conserve the file name
+  NSURL *url = [NSURL fileURLWithPath:_path];
+  return url;
 }
 
 - (NSString *)activityViewController:
-(UIActivityViewController *)activityViewController
+                  (UIActivityViewController *)activityViewController
               subjectForActivityType:(UIActivityType)activityType {
-    return _subject;
+  return _subject;
 }
 
 - (UIImage *)activityViewController:
-(UIActivityViewController *)activityViewController
+                 (UIActivityViewController *)activityViewController
       thumbnailImageForActivityType:(UIActivityType)activityType
                       suggestedSize:(CGSize)suggestedSize {
-    if (!_path || !_mimeType || ![_mimeType hasPrefix:@"image/"]) {
-        return nil;
-    }
-    
-    UIImage *image = [UIImage imageWithContentsOfFile:_path];
-    return [self imageWithImage:image scaledToSize:suggestedSize];
+  if (!_path || !_mimeType || ![_mimeType hasPrefix:@"image/"]) {
+    return nil;
+  }
+
+  UIImage *image = [UIImage imageWithContentsOfFile:_path];
+  return [self imageWithImage:image scaledToSize:suggestedSize];
 }
 
 - (UIImage *)imageWithImage:(UIImage *)image scaledToSize:(CGSize)newSize {
-    UIGraphicsBeginImageContext(newSize);
-    [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
-    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
-    UIGraphicsEndImageContext();
-    return newImage;
+  UIGraphicsBeginImageContext(newSize);
+  [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
+  UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+  UIGraphicsEndImageContext();
+  return newImage;
 }
 
 - (LPLinkMetadata *)activityViewControllerLinkMetadata:
-(UIActivityViewController *)activityViewController
-API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0)) {
-    LPLinkMetadata *metadata = [[LPLinkMetadata alloc] init];
-    
-    if ([_subject length] > 0) {
-        metadata.title = _subject;
-    } else if ([_text length] > 0) {
-        metadata.title = _text;
+    (UIActivityViewController *)activityViewController
+    API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0)) {
+  LPLinkMetadata *metadata = [[LPLinkMetadata alloc] init];
+
+  if ([_subject length] > 0) {
+    metadata.title = _subject;
+  } else if ([_text length] > 0) {
+    metadata.title = _text;
+  }
+
+  if (_path) {
+    NSString *extesnion = [_path pathExtension];
+
+    unsigned long long rawSize = (
+        [[[NSFileManager defaultManager] attributesOfItemAtPath:_path
+                                                          error:nil] fileSize]);
+    NSString *readableSize = [NSByteCountFormatter
+        stringFromByteCount:rawSize
+                 countStyle:NSByteCountFormatterCountStyleFile];
+
+    NSString *description = @"";
+
+    if (![extesnion isEqualToString:@""]) {
+      description =
+          [description stringByAppendingString:[extesnion uppercaseString]];
+      description = [description stringByAppendingString:@" • "];
+      description = [description stringByAppendingString:readableSize];
+    } else {
+      description = [description stringByAppendingString:readableSize];
     }
-    
-    if (_path) {
-        NSString *extesnion = [_path pathExtension];
-        
-        unsigned long long rawSize = (
-                                      [[[NSFileManager defaultManager] attributesOfItemAtPath:_path
-                                                                                        error:nil] fileSize]);
-        NSString *readableSize = [NSByteCountFormatter
-                                  stringFromByteCount:rawSize
-                                  countStyle:NSByteCountFormatterCountStyleFile];
-        
-        NSString *description = @"";
-        
-        if (![extesnion isEqualToString:@""]) {
-            description =
-            [description stringByAppendingString:[extesnion uppercaseString]];
-            description = [description stringByAppendingString:@" • "];
-            description = [description stringByAppendingString:readableSize];
-        } else {
-            description = [description stringByAppendingString:readableSize];
-        }
-        
-        // https://stackoverflow.com/questions/60563773/ios-13-share-sheet-changing-subtitle-item-description
-        metadata.originalURL = [NSURL fileURLWithPath:description];
-        if (_mimeType && [_mimeType hasPrefix:@"image/"]) {
-            metadata.imageProvider = [[NSItemProvider alloc]
-                                      initWithObject:[UIImage imageWithContentsOfFile:_path]];
-        }
+
+    // https://stackoverflow.com/questions/60563773/ios-13-share-sheet-changing-subtitle-item-description
+    metadata.originalURL = [NSURL fileURLWithPath:description];
+    if (_mimeType && [_mimeType hasPrefix:@"image/"]) {
+      metadata.imageProvider = [[NSItemProvider alloc]
+          initWithObject:[UIImage imageWithContentsOfFile:_path]];
     }
-    
-    return metadata;
+  }
+
+  return metadata;
 }
 
 @end
@@ -241,83 +241,83 @@ API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0)) {
 @implementation FPPSharePlusPlugin
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
-    FlutterMethodChannel *shareChannel =
-    [FlutterMethodChannel methodChannelWithName:PLATFORM_CHANNEL
-                                binaryMessenger:registrar.messenger];
-    
-    [shareChannel
-     setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
+  FlutterMethodChannel *shareChannel =
+      [FlutterMethodChannel methodChannelWithName:PLATFORM_CHANNEL
+                                  binaryMessenger:registrar.messenger];
+
+  [shareChannel
+      setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
         NSDictionary *arguments = [call arguments];
         NSNumber *originX = arguments[@"originX"];
         NSNumber *originY = arguments[@"originY"];
         NSNumber *originWidth = arguments[@"originWidth"];
         NSNumber *originHeight = arguments[@"originHeight"];
-        
+
         CGRect originRect = CGRectZero;
         if (originX && originY && originWidth && originHeight) {
-            originRect =
-            CGRectMake([originX doubleValue], [originY doubleValue],
-                       [originWidth doubleValue], [originHeight doubleValue]);
+          originRect =
+              CGRectMake([originX doubleValue], [originY doubleValue],
+                         [originWidth doubleValue], [originHeight doubleValue]);
         }
-        
+
         if ([@"share" isEqualToString:call.method]) {
-            NSString *shareText = arguments[@"text"];
-            NSString *shareSubject = arguments[@"subject"];
-            
-            if (shareText.length == 0) {
-                result([FlutterError errorWithCode:@"error"
-                                           message:@"Non-empty text expected"
-                                           details:nil]);
-                return;
-            }
-            
-            UIViewController *rootViewController = RootViewController();
-            if (!rootViewController) {
-                result([FlutterError errorWithCode:@"error"
-                                           message:@"No root view controller found"
-                                           details:nil]);
-                return;
-            }
-            UIViewController *topViewController =
-            TopViewControllerForViewController(rootViewController);
-            
-            [self shareText:shareText
-                    subject:shareSubject
-             withController:topViewController
-                   atSource:originRect
-                   toResult:result];
+          NSString *shareText = arguments[@"text"];
+          NSString *shareSubject = arguments[@"subject"];
+
+          if (shareText.length == 0) {
+            result([FlutterError errorWithCode:@"error"
+                                       message:@"Non-empty text expected"
+                                       details:nil]);
+            return;
+          }
+
+          UIViewController *rootViewController = RootViewController();
+          if (!rootViewController) {
+            result([FlutterError errorWithCode:@"error"
+                                       message:@"No root view controller found"
+                                       details:nil]);
+            return;
+          }
+          UIViewController *topViewController =
+              TopViewControllerForViewController(rootViewController);
+
+          [self shareText:shareText
+                     subject:shareSubject
+              withController:topViewController
+                    atSource:originRect
+                    toResult:result];
         } else if ([@"shareFiles" isEqualToString:call.method]) {
-            NSArray *paths = arguments[@"paths"];
-            NSArray *mimeTypes = arguments[@"mimeTypes"];
-            NSString *subject = arguments[@"subject"];
-            NSString *text = arguments[@"text"];
-            
-            if (paths.count == 0) {
-                result([FlutterError errorWithCode:@"error"
-                                           message:@"Non-empty paths expected"
-                                           details:nil]);
-                return;
+          NSArray *paths = arguments[@"paths"];
+          NSArray *mimeTypes = arguments[@"mimeTypes"];
+          NSString *subject = arguments[@"subject"];
+          NSString *text = arguments[@"text"];
+
+          if (paths.count == 0) {
+            result([FlutterError errorWithCode:@"error"
+                                       message:@"Non-empty paths expected"
+                                       details:nil]);
+            return;
+          }
+
+          for (NSString *path in paths) {
+            if (path.length == 0) {
+              result([FlutterError errorWithCode:@"error"
+                                         message:@"Each path must not be empty"
+                                         details:nil]);
+              return;
             }
-            
-            for (NSString *path in paths) {
-                if (path.length == 0) {
-                    result([FlutterError errorWithCode:@"error"
-                                               message:@"Each path must not be empty"
-                                               details:nil]);
-                    return;
-                }
-            }
-            
-            UIViewController *rootViewController = RootViewController();
-            if (!rootViewController) {
-                result([FlutterError errorWithCode:@"error"
-                                           message:@"No root view controller found"
-                                           details:nil]);
-                return;
-            }
-            UIViewController *topViewController =
-            TopViewControllerForViewController(rootViewController);
-            [self shareFiles:paths
+          }
+
+          UIViewController *rootViewController = RootViewController();
+          if (!rootViewController) {
+            result([FlutterError errorWithCode:@"error"
+                                       message:@"No root view controller found"
+                                       details:nil]);
+            return;
+          }
+          UIViewController *topViewController =
+              TopViewControllerForViewController(rootViewController);
+          [self shareFiles:paths
                 withMimeType:mimeTypes
                  withSubject:subject
                     withText:text
@@ -325,115 +325,115 @@ API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0)) {
                     atSource:originRect
                     toResult:result];
         } else if ([@"shareUri" isEqualToString:call.method]) {
-            NSString *uri = arguments[@"uri"];
-            
-            if (uri.length == 0) {
-                result([FlutterError errorWithCode:@"error"
-                                           message:@"Non-empty uri expected"
-                                           details:nil]);
-                return;
-            }
-            
-            UIViewController *rootViewController = RootViewController();
-            if (!rootViewController) {
-                result([FlutterError errorWithCode:@"error"
-                                           message:@"No root view controller found"
-                                           details:nil]);
-                return;
-            }
-            UIViewController *topViewController =
-            TopViewControllerForViewController(rootViewController);
-            
-            [self shareUri:uri
-            withController:topViewController
-                  atSource:originRect
-                  toResult:result];
+          NSString *uri = arguments[@"uri"];
+
+          if (uri.length == 0) {
+            result([FlutterError errorWithCode:@"error"
+                                       message:@"Non-empty uri expected"
+                                       details:nil]);
+            return;
+          }
+
+          UIViewController *rootViewController = RootViewController();
+          if (!rootViewController) {
+            result([FlutterError errorWithCode:@"error"
+                                       message:@"No root view controller found"
+                                       details:nil]);
+            return;
+          }
+          UIViewController *topViewController =
+              TopViewControllerForViewController(rootViewController);
+
+          [self shareUri:uri
+              withController:topViewController
+                    atSource:originRect
+                    toResult:result];
         } else {
-            result(FlutterMethodNotImplemented);
+          result(FlutterMethodNotImplemented);
         }
-    }];
+      }];
 }
 
 + (void)share:(NSArray *)shareItems
-  withSubject:(NSString *)subject
-withController:(UIViewController *)controller
-     atSource:(CGRect)origin
-     toResult:(FlutterResult)result {
-    UIActivityViewSuccessController *activityViewController =
-    [[UIActivityViewSuccessController alloc] initWithActivityItems:shareItems
-                                             applicationActivities:nil];
-    
-    // Force subject when sharing a raw url or files
-    if (![subject isKindOfClass:[NSNull class]]) {
-        [activityViewController setValue:subject forKey:@"subject"];
-    }
-    
-    activityViewController.popoverPresentationController.sourceView =
-    controller.view;
-    BOOL isCoordinateSpaceOfSourceView =
-    CGRectContainsRect(controller.view.frame, origin);
-    
-    // If device is e.g. an iPad then hasPopoverPresentationController is true
-    BOOL hasPopoverPresentationController =
-    [activityViewController popoverPresentationController] != NULL;
-    if (hasPopoverPresentationController &&
-        (!isCoordinateSpaceOfSourceView || CGRectIsEmpty(origin))) {
-        NSString *sharePositionIssue = [NSString
-                                        stringWithFormat:
-                                            @"sharePositionOrigin: argument must be set, %@ must be non-zero "
-                                        @"and within coordinate space of source view: %@",
-                                        NSStringFromCGRect(origin),
-                                        NSStringFromCGRect(controller.view.bounds)];
-        
-        result([FlutterError errorWithCode:@"error"
-                                   message:sharePositionIssue
-                                   details:nil]);
-        return;
-    }
-    
-    if (!CGRectIsEmpty(origin)) {
-        activityViewController.popoverPresentationController.sourceRect = origin;
-    }
-    
-    UIActivityViewSuccessCompanion *companion =
-    [[UIActivityViewSuccessCompanion alloc] initWithResult:result];
-    activityViewController.companion = companion;
-    activityViewController.completionWithItemsHandler =
-    ^(UIActivityType activityType, BOOL completed, NSArray *returnedItems,
-      NSError *activityError) {
+       withSubject:(NSString *)subject
+    withController:(UIViewController *)controller
+          atSource:(CGRect)origin
+          toResult:(FlutterResult)result {
+  UIActivityViewSuccessController *activityViewController =
+      [[UIActivityViewSuccessController alloc] initWithActivityItems:shareItems
+                                               applicationActivities:nil];
+
+  // Force subject when sharing a raw url or files
+  if (![subject isKindOfClass:[NSNull class]]) {
+    [activityViewController setValue:subject forKey:@"subject"];
+  }
+
+  activityViewController.popoverPresentationController.sourceView =
+      controller.view;
+  BOOL isCoordinateSpaceOfSourceView =
+      CGRectContainsRect(controller.view.frame, origin);
+
+  // If device is e.g. an iPad then hasPopoverPresentationController is true
+  BOOL hasPopoverPresentationController =
+      [activityViewController popoverPresentationController] != NULL;
+  if (hasPopoverPresentationController &&
+      (!isCoordinateSpaceOfSourceView || CGRectIsEmpty(origin))) {
+    NSString *sharePositionIssue = [NSString
+        stringWithFormat:
+            @"sharePositionOrigin: argument must be set, %@ must be non-zero "
+            @"and within coordinate space of source view: %@",
+            NSStringFromCGRect(origin),
+            NSStringFromCGRect(controller.view.bounds)];
+
+    result([FlutterError errorWithCode:@"error"
+                               message:sharePositionIssue
+                               details:nil]);
+    return;
+  }
+
+  if (!CGRectIsEmpty(origin)) {
+    activityViewController.popoverPresentationController.sourceRect = origin;
+  }
+
+  UIActivityViewSuccessCompanion *companion =
+      [[UIActivityViewSuccessCompanion alloc] initWithResult:result];
+  activityViewController.companion = companion;
+  activityViewController.completionWithItemsHandler =
+      ^(UIActivityType activityType, BOOL completed, NSArray *returnedItems,
+        NSError *activityError) {
         companion.activityType = activityType;
         companion.completed = completed;
-    };
-    
-    [controller presentViewController:activityViewController
-                             animated:YES
-                           completion:nil];
+      };
+
+  [controller presentViewController:activityViewController
+                           animated:YES
+                         completion:nil];
 }
 
 + (void)shareUri:(NSString *)uri
-  withController:(UIViewController *)controller
-        atSource:(CGRect)origin
-        toResult:(FlutterResult)result {
-    NSURL *data = [NSURL URLWithString:uri];
-    [self share:@[ data ]
-    withSubject:nil
- withController:controller
-       atSource:origin
-       toResult:result];
+    withController:(UIViewController *)controller
+          atSource:(CGRect)origin
+          toResult:(FlutterResult)result {
+  NSURL *data = [NSURL URLWithString:uri];
+  [self share:@[ data ]
+         withSubject:nil
+      withController:controller
+            atSource:origin
+            toResult:result];
 }
 
 + (void)shareText:(NSString *)shareText
-          subject:(NSString *)subject
-   withController:(UIViewController *)controller
-         atSource:(CGRect)origin
-         toResult:(FlutterResult)result {
-    NSObject *data = [[SharePlusData alloc] initWithSubject:subject
-                                                       text:shareText];
-    [self share:@[ data ]
-    withSubject:subject
- withController:controller
-       atSource:origin
-       toResult:result];
+           subject:(NSString *)subject
+    withController:(UIViewController *)controller
+          atSource:(CGRect)origin
+          toResult:(FlutterResult)result {
+  NSObject *data = [[SharePlusData alloc] initWithSubject:subject
+                                                     text:shareText];
+  [self share:@[ data ]
+         withSubject:subject
+      withController:controller
+            atSource:origin
+            toResult:result];
 }
 
 + (void)shareFiles:(NSArray *)paths
@@ -443,25 +443,25 @@ withController:(UIViewController *)controller
     withController:(UIViewController *)controller
           atSource:(CGRect)origin
           toResult:(FlutterResult)result {
-    NSMutableArray *items = [[NSMutableArray alloc] init];
-    
-    for (int i = 0; i < [paths count]; i++) {
-        NSString *path = paths[i];
-        NSString *mimeType = mimeTypes[i];
-        [items addObject:[[SharePlusData alloc] initWithFile:path
-                                                    mimeType:mimeType
-                                                     subject:subject]];
-    }
-    if (text != nil) {
-        NSObject *data = [[SharePlusData alloc] initWithSubject:subject text:text];
-        [items addObject:data];
-    }
-    
-    [self share:items
-    withSubject:subject
- withController:controller
-       atSource:origin
-       toResult:result];
+  NSMutableArray *items = [[NSMutableArray alloc] init];
+
+  for (int i = 0; i < [paths count]; i++) {
+    NSString *path = paths[i];
+    NSString *mimeType = mimeTypes[i];
+    [items addObject:[[SharePlusData alloc] initWithFile:path
+                                                mimeType:mimeType
+                                                 subject:subject]];
+  }
+  if (text != nil) {
+    NSObject *data = [[SharePlusData alloc] initWithSubject:subject text:text];
+    [items addObject:data];
+  }
+
+  [self share:items
+         withSubject:subject
+      withController:controller
+            atSource:origin
+            toResult:result];
 }
 
 @end

--- a/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
@@ -8,35 +8,35 @@
 static NSString *const PLATFORM_CHANNEL = @"dev.fluttercommunity.plus/share";
 
 static UIViewController *RootViewController() {
-  if (@available(iOS 13, *)) { // UIApplication.keyWindow is deprecated
-    NSSet *scenes = [[UIApplication sharedApplication] connectedScenes];
-    for (UIScene *scene in scenes) {
-      if ([scene isKindOfClass:[UIWindowScene class]]) {
-        NSArray *windows = ((UIWindowScene *)scene).windows;
-        for (UIWindow *window in windows) {
-          if (window.isKeyWindow) {
-            return window.rootViewController;
-          }
+    if (@available(iOS 13, *)) { // UIApplication.keyWindow is deprecated
+        NSSet *scenes = [[UIApplication sharedApplication] connectedScenes];
+        for (UIScene *scene in scenes) {
+            if ([scene isKindOfClass:[UIWindowScene class]]) {
+                NSArray *windows = ((UIWindowScene *)scene).windows;
+                for (UIWindow *window in windows) {
+                    if (window.isKeyWindow) {
+                        return window.rootViewController;
+                    }
+                }
+            }
         }
-      }
+        return nil;
+    } else {
+        return [UIApplication sharedApplication].keyWindow.rootViewController;
     }
-    return nil;
-  } else {
-    return [UIApplication sharedApplication].keyWindow.rootViewController;
-  }
 }
 
 static UIViewController *
 TopViewControllerForViewController(UIViewController *viewController) {
-  if (viewController.presentedViewController) {
-    return TopViewControllerForViewController(
-        viewController.presentedViewController);
-  }
-  if ([viewController isKindOfClass:[UINavigationController class]]) {
-    return TopViewControllerForViewController(
-        ((UINavigationController *)viewController).visibleViewController);
-  }
-  return viewController;
+    if (viewController.presentedViewController) {
+        return TopViewControllerForViewController(
+                                                  viewController.presentedViewController);
+    }
+    if ([viewController isKindOfClass:[UINavigationController class]]) {
+        return TopViewControllerForViewController(
+                                                  ((UINavigationController *)viewController).visibleViewController);
+    }
+    return viewController;
 }
 
 // We need the companion to avoid ARC deadlock
@@ -53,21 +53,21 @@ TopViewControllerForViewController(UIViewController *viewController) {
 @implementation UIActivityViewSuccessCompanion
 
 - (id)initWithResult:(FlutterResult)result {
-  if (self = [super init]) {
-    self.result = result;
-    self.completed = false;
-  }
-  return self;
+    if (self = [super init]) {
+        self.result = result;
+        self.completed = false;
+    }
+    return self;
 }
 
 // We use dealloc as the share-sheet might disappear (e.g. iCloud photo album
 // creation) and could then reappear if the user cancels
 - (void)dealloc {
-  if (self.completed) {
-    self.result(self.activityType);
-  } else {
-    self.result(@"");
-  }
+    if (self.completed) {
+        self.result(self.activityType);
+    } else {
+        self.result(@"");
+    }
 }
 
 @end
@@ -99,141 +99,141 @@ TopViewControllerForViewController(UIViewController *viewController) {
                      subject:(NSString *)subject NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init
-    __attribute__((unavailable("Use initWithSubject:text: instead")));
+__attribute__((unavailable("Use initWithSubject:text: instead")));
 
 @end
 
 @implementation SharePlusData
 
 - (instancetype)init {
-  [super doesNotRecognizeSelector:_cmd];
-  return nil;
+    [super doesNotRecognizeSelector:_cmd];
+    return nil;
 }
 
 - (instancetype)initWithSubject:(NSString *)subject text:(NSString *)text {
-  self = [super init];
-  if (self) {
-    _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
-    _text = text;
-  }
-  return self;
+    self = [super init];
+    if (self) {
+        _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
+        _text = text;
+    }
+    return self;
 }
 
 - (instancetype)initWithFile:(NSString *)path mimeType:(NSString *)mimeType {
-  self = [super init];
-  if (self) {
-    _path = path;
-    _mimeType = mimeType;
-  }
-  return self;
+    self = [super init];
+    if (self) {
+        _path = path;
+        _mimeType = mimeType;
+    }
+    return self;
 }
 
 - (instancetype)initWithFile:(NSString *)path
                     mimeType:(NSString *)mimeType
                      subject:(NSString *)subject {
-  self = [super init];
-  if (self) {
-    _path = path;
-    _mimeType = mimeType;
-    _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
-  }
-  return self;
+    self = [super init];
+    if (self) {
+        _path = path;
+        _mimeType = mimeType;
+        _subject = [subject isKindOfClass:NSNull.class] ? @"" : subject;
+    }
+    return self;
 }
 
 - (id)activityViewControllerPlaceholderItem:
-    (UIActivityViewController *)activityViewController {
-  return [self
-      activityViewController:activityViewController
-         itemForActivityType:@"dev.fluttercommunity.share_plus.placeholder"];
+(UIActivityViewController *)activityViewController {
+    return [self
+            activityViewController:activityViewController
+            itemForActivityType:@"dev.fluttercommunity.share_plus.placeholder"];
 }
 
 - (id)activityViewController:(UIActivityViewController *)activityViewController
          itemForActivityType:(UIActivityType)activityType {
-  if (!_path || !_mimeType) {
-    return _text;
-  }
-
-  // If the shared file is an image return an UIImage for the placeholder
-  // to show a preview.
-  if ([activityType
-          isEqualToString:@"dev.fluttercommunity.share_plus.placeholder"] &&
-      [_mimeType hasPrefix:@"image/"]) {
-    UIImage *image = [UIImage imageWithContentsOfFile:_path];
-    return image;
-  }
-
-  // Return an NSURL for the real share to conserve the file name
-  NSURL *url = [NSURL fileURLWithPath:_path];
-  return url;
+    if (!_path || !_mimeType) {
+        return _text;
+    }
+    
+    // If the shared file is an image return an UIImage for the placeholder
+    // to show a preview.
+    if ([activityType
+         isEqualToString:@"dev.fluttercommunity.share_plus.placeholder"] &&
+        [_mimeType hasPrefix:@"image/"]) {
+        UIImage *image = [UIImage imageWithContentsOfFile:_path];
+        return image;
+    }
+    
+    // Return an NSURL for the real share to conserve the file name
+    NSURL *url = [NSURL fileURLWithPath:_path];
+    return url;
 }
 
 - (NSString *)activityViewController:
-                  (UIActivityViewController *)activityViewController
+(UIActivityViewController *)activityViewController
               subjectForActivityType:(UIActivityType)activityType {
-  return _subject;
+    return _subject;
 }
 
 - (UIImage *)activityViewController:
-                 (UIActivityViewController *)activityViewController
+(UIActivityViewController *)activityViewController
       thumbnailImageForActivityType:(UIActivityType)activityType
                       suggestedSize:(CGSize)suggestedSize {
-  if (!_path || !_mimeType || ![_mimeType hasPrefix:@"image/"]) {
-    return nil;
-  }
-
-  UIImage *image = [UIImage imageWithContentsOfFile:_path];
-  return [self imageWithImage:image scaledToSize:suggestedSize];
+    if (!_path || !_mimeType || ![_mimeType hasPrefix:@"image/"]) {
+        return nil;
+    }
+    
+    UIImage *image = [UIImage imageWithContentsOfFile:_path];
+    return [self imageWithImage:image scaledToSize:suggestedSize];
 }
 
 - (UIImage *)imageWithImage:(UIImage *)image scaledToSize:(CGSize)newSize {
-  UIGraphicsBeginImageContext(newSize);
-  [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
-  UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
-  UIGraphicsEndImageContext();
-  return newImage;
+    UIGraphicsBeginImageContext(newSize);
+    [image drawInRect:CGRectMake(0, 0, newSize.width, newSize.height)];
+    UIImage *newImage = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    return newImage;
 }
 
 - (LPLinkMetadata *)activityViewControllerLinkMetadata:
-    (UIActivityViewController *)activityViewController
-    API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0)) {
-  LPLinkMetadata *metadata = [[LPLinkMetadata alloc] init];
-
-  if ([_subject length] > 0) {
-    metadata.title = _subject;
-  } else if ([_text length] > 0) {
-    metadata.title = _text;
-  }
-
-  if (_path) {
-    NSString *extesnion = [_path pathExtension];
-
-    unsigned long long rawSize = (
-        [[[NSFileManager defaultManager] attributesOfItemAtPath:_path
-                                                          error:nil] fileSize]);
-    NSString *readableSize = [NSByteCountFormatter
-        stringFromByteCount:rawSize
-                 countStyle:NSByteCountFormatterCountStyleFile];
-
-    NSString *description = @"";
-
-    if (![extesnion isEqualToString:@""]) {
-      description =
-          [description stringByAppendingString:[extesnion uppercaseString]];
-      description = [description stringByAppendingString:@" • "];
-      description = [description stringByAppendingString:readableSize];
-    } else {
-      description = [description stringByAppendingString:readableSize];
+(UIActivityViewController *)activityViewController
+API_AVAILABLE(macos(10.15), ios(13.0), watchos(6.0)) {
+    LPLinkMetadata *metadata = [[LPLinkMetadata alloc] init];
+    
+    if ([_subject length] > 0) {
+        metadata.title = _subject;
+    } else if ([_text length] > 0) {
+        metadata.title = _text;
     }
-
-    // https://stackoverflow.com/questions/60563773/ios-13-share-sheet-changing-subtitle-item-description
-    metadata.originalURL = [NSURL fileURLWithPath:description];
-    if (_mimeType && [_mimeType hasPrefix:@"image/"]) {
-      metadata.imageProvider = [[NSItemProvider alloc]
-          initWithObject:[UIImage imageWithContentsOfFile:_path]];
+    
+    if (_path) {
+        NSString *extesnion = [_path pathExtension];
+        
+        unsigned long long rawSize = (
+                                      [[[NSFileManager defaultManager] attributesOfItemAtPath:_path
+                                                                                        error:nil] fileSize]);
+        NSString *readableSize = [NSByteCountFormatter
+                                  stringFromByteCount:rawSize
+                                  countStyle:NSByteCountFormatterCountStyleFile];
+        
+        NSString *description = @"";
+        
+        if (![extesnion isEqualToString:@""]) {
+            description =
+            [description stringByAppendingString:[extesnion uppercaseString]];
+            description = [description stringByAppendingString:@" • "];
+            description = [description stringByAppendingString:readableSize];
+        } else {
+            description = [description stringByAppendingString:readableSize];
+        }
+        
+        // https://stackoverflow.com/questions/60563773/ios-13-share-sheet-changing-subtitle-item-description
+        metadata.originalURL = [NSURL fileURLWithPath:description];
+        if (_mimeType && [_mimeType hasPrefix:@"image/"]) {
+            metadata.imageProvider = [[NSItemProvider alloc]
+                                      initWithObject:[UIImage imageWithContentsOfFile:_path]];
+        }
     }
-  }
-
-  return metadata;
+    
+    return metadata;
 }
 
 @end
@@ -241,217 +241,199 @@ TopViewControllerForViewController(UIViewController *viewController) {
 @implementation FPPSharePlusPlugin
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
-  FlutterMethodChannel *shareChannel =
-      [FlutterMethodChannel methodChannelWithName:PLATFORM_CHANNEL
-                                  binaryMessenger:registrar.messenger];
-
-  [shareChannel
-      setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
-        BOOL withResult = [call.method hasSuffix:@"WithResult"];
+    FlutterMethodChannel *shareChannel =
+    [FlutterMethodChannel methodChannelWithName:PLATFORM_CHANNEL
+                                binaryMessenger:registrar.messenger];
+    
+    [shareChannel
+     setMethodCallHandler:^(FlutterMethodCall *call, FlutterResult result) {
         NSDictionary *arguments = [call arguments];
         NSNumber *originX = arguments[@"originX"];
         NSNumber *originY = arguments[@"originY"];
         NSNumber *originWidth = arguments[@"originWidth"];
         NSNumber *originHeight = arguments[@"originHeight"];
-
+        
         CGRect originRect = CGRectZero;
         if (originX && originY && originWidth && originHeight) {
-          originRect =
-              CGRectMake([originX doubleValue], [originY doubleValue],
-                         [originWidth doubleValue], [originHeight doubleValue]);
+            originRect =
+            CGRectMake([originX doubleValue], [originY doubleValue],
+                       [originWidth doubleValue], [originHeight doubleValue]);
         }
-
-        if ([@"share" isEqualToString:call.method] ||
-            [@"shareWithResult" isEqualToString:call.method]) {
-          NSString *shareText = arguments[@"text"];
-          NSString *shareSubject = arguments[@"subject"];
-
-          if (shareText.length == 0) {
-            result([FlutterError errorWithCode:@"error"
-                                       message:@"Non-empty text expected"
-                                       details:nil]);
-            return;
-          }
-
-          UIViewController *rootViewController = RootViewController();
-          if (!rootViewController) {
-            result([FlutterError errorWithCode:@"error"
-                                       message:@"No root view controller found"
-                                       details:nil]);
-            return;
-          }
-          UIViewController *topViewController =
-              TopViewControllerForViewController(rootViewController);
-
-          [self shareText:shareText
-                     subject:shareSubject
-              withController:topViewController
-                    atSource:originRect
-                    toResult:result
-                  withResult:withResult];
-          if (!withResult)
-            result(nil);
-        } else if ([@"shareFiles" isEqualToString:call.method] ||
-                   [@"shareFilesWithResult" isEqualToString:call.method]) {
-          NSArray *paths = arguments[@"paths"];
-          NSArray *mimeTypes = arguments[@"mimeTypes"];
-          NSString *subject = arguments[@"subject"];
-          NSString *text = arguments[@"text"];
-
-          if (paths.count == 0) {
-            result([FlutterError errorWithCode:@"error"
-                                       message:@"Non-empty paths expected"
-                                       details:nil]);
-            return;
-          }
-
-          for (NSString *path in paths) {
-            if (path.length == 0) {
-              result([FlutterError errorWithCode:@"error"
-                                         message:@"Each path must not be empty"
-                                         details:nil]);
-              return;
+        
+        if ([@"share" isEqualToString:call.method]) {
+            NSString *shareText = arguments[@"text"];
+            NSString *shareSubject = arguments[@"subject"];
+            
+            if (shareText.length == 0) {
+                result([FlutterError errorWithCode:@"error"
+                                           message:@"Non-empty text expected"
+                                           details:nil]);
+                return;
             }
-          }
-
-          UIViewController *rootViewController = RootViewController();
-          if (!rootViewController) {
-            result([FlutterError errorWithCode:@"error"
-                                       message:@"No root view controller found"
-                                       details:nil]);
-            return;
-          }
-          UIViewController *topViewController =
-              TopViewControllerForViewController(rootViewController);
-          [self shareFiles:paths
+            
+            UIViewController *rootViewController = RootViewController();
+            if (!rootViewController) {
+                result([FlutterError errorWithCode:@"error"
+                                           message:@"No root view controller found"
+                                           details:nil]);
+                return;
+            }
+            UIViewController *topViewController =
+            TopViewControllerForViewController(rootViewController);
+            
+            [self shareText:shareText
+                    subject:shareSubject
+             withController:topViewController
+                   atSource:originRect
+                   toResult:result];
+        } else if ([@"shareFiles" isEqualToString:call.method]) {
+            NSArray *paths = arguments[@"paths"];
+            NSArray *mimeTypes = arguments[@"mimeTypes"];
+            NSString *subject = arguments[@"subject"];
+            NSString *text = arguments[@"text"];
+            
+            if (paths.count == 0) {
+                result([FlutterError errorWithCode:@"error"
+                                           message:@"Non-empty paths expected"
+                                           details:nil]);
+                return;
+            }
+            
+            for (NSString *path in paths) {
+                if (path.length == 0) {
+                    result([FlutterError errorWithCode:@"error"
+                                               message:@"Each path must not be empty"
+                                               details:nil]);
+                    return;
+                }
+            }
+            
+            UIViewController *rootViewController = RootViewController();
+            if (!rootViewController) {
+                result([FlutterError errorWithCode:@"error"
+                                           message:@"No root view controller found"
+                                           details:nil]);
+                return;
+            }
+            UIViewController *topViewController =
+            TopViewControllerForViewController(rootViewController);
+            [self shareFiles:paths
                 withMimeType:mimeTypes
                  withSubject:subject
                     withText:text
               withController:topViewController
                     atSource:originRect
-                    toResult:result
-                  withResult:withResult];
-          if (!withResult)
-            result(nil);
+                    toResult:result];
         } else if ([@"shareUri" isEqualToString:call.method]) {
-          NSString *uri = arguments[@"uri"];
-
-          if (uri.length == 0) {
-            result([FlutterError errorWithCode:@"error"
-                                       message:@"Non-empty uri expected"
-                                       details:nil]);
-            return;
-          }
-
-          UIViewController *rootViewController = RootViewController();
-          if (!rootViewController) {
-            result([FlutterError errorWithCode:@"error"
-                                       message:@"No root view controller found"
-                                       details:nil]);
-            return;
-          }
-          UIViewController *topViewController =
-              TopViewControllerForViewController(rootViewController);
-
-          [self shareUri:uri
-              withController:topViewController
-                    atSource:originRect
-                    toResult:result
-                  withResult:withResult];
-          if (!withResult)
-            result(nil);
+            NSString *uri = arguments[@"uri"];
+            
+            if (uri.length == 0) {
+                result([FlutterError errorWithCode:@"error"
+                                           message:@"Non-empty uri expected"
+                                           details:nil]);
+                return;
+            }
+            
+            UIViewController *rootViewController = RootViewController();
+            if (!rootViewController) {
+                result([FlutterError errorWithCode:@"error"
+                                           message:@"No root view controller found"
+                                           details:nil]);
+                return;
+            }
+            UIViewController *topViewController =
+            TopViewControllerForViewController(rootViewController);
+            
+            [self shareUri:uri
+            withController:topViewController
+                  atSource:originRect
+                  toResult:result];
         } else {
-          result(FlutterMethodNotImplemented);
+            result(FlutterMethodNotImplemented);
         }
-      }];
+    }];
 }
 
 + (void)share:(NSArray *)shareItems
-       withSubject:(NSString *)subject
-    withController:(UIViewController *)controller
-          atSource:(CGRect)origin
-          toResult:(FlutterResult)result
-        withResult:(BOOL)withResult {
-  UIActivityViewSuccessController *activityViewController =
-      [[UIActivityViewSuccessController alloc] initWithActivityItems:shareItems
-                                               applicationActivities:nil];
-
-  // Force subject when sharing a raw url or files
-  if (![subject isKindOfClass:[NSNull class]]) {
-    [activityViewController setValue:subject forKey:@"subject"];
-  }
-
-  activityViewController.popoverPresentationController.sourceView =
-      controller.view;
-  BOOL isCoordinateSpaceOfSourceView =
-      CGRectContainsRect(controller.view.frame, origin);
-
-  // If device is e.g. an iPad then hasPopoverPresentationController is true
-  BOOL hasPopoverPresentationController =
-      [activityViewController popoverPresentationController] != NULL;
-  if (hasPopoverPresentationController &&
-      (!isCoordinateSpaceOfSourceView || CGRectIsEmpty(origin))) {
-    NSString *sharePositionIssue = [NSString
-        stringWithFormat:
-            @"sharePositionOrigin: argument must be set, %@ must be non-zero "
-            @"and within coordinate space of source view: %@",
-            NSStringFromCGRect(origin),
-            NSStringFromCGRect(controller.view.bounds)];
-
-    result([FlutterError errorWithCode:@"error"
-                               message:sharePositionIssue
-                               details:nil]);
-    return;
-  }
-
-  if (!CGRectIsEmpty(origin)) {
-    activityViewController.popoverPresentationController.sourceRect = origin;
-  }
-
-  if (withResult) {
+  withSubject:(NSString *)subject
+withController:(UIViewController *)controller
+     atSource:(CGRect)origin
+     toResult:(FlutterResult)result {
+    UIActivityViewSuccessController *activityViewController =
+    [[UIActivityViewSuccessController alloc] initWithActivityItems:shareItems
+                                             applicationActivities:nil];
+    
+    // Force subject when sharing a raw url or files
+    if (![subject isKindOfClass:[NSNull class]]) {
+        [activityViewController setValue:subject forKey:@"subject"];
+    }
+    
+    activityViewController.popoverPresentationController.sourceView =
+    controller.view;
+    BOOL isCoordinateSpaceOfSourceView =
+    CGRectContainsRect(controller.view.frame, origin);
+    
+    // If device is e.g. an iPad then hasPopoverPresentationController is true
+    BOOL hasPopoverPresentationController =
+    [activityViewController popoverPresentationController] != NULL;
+    if (hasPopoverPresentationController &&
+        (!isCoordinateSpaceOfSourceView || CGRectIsEmpty(origin))) {
+        NSString *sharePositionIssue = [NSString
+                                        stringWithFormat:
+                                            @"sharePositionOrigin: argument must be set, %@ must be non-zero "
+                                        @"and within coordinate space of source view: %@",
+                                        NSStringFromCGRect(origin),
+                                        NSStringFromCGRect(controller.view.bounds)];
+        
+        result([FlutterError errorWithCode:@"error"
+                                   message:sharePositionIssue
+                                   details:nil]);
+        return;
+    }
+    
+    if (!CGRectIsEmpty(origin)) {
+        activityViewController.popoverPresentationController.sourceRect = origin;
+    }
+    
     UIActivityViewSuccessCompanion *companion =
-        [[UIActivityViewSuccessCompanion alloc] initWithResult:result];
+    [[UIActivityViewSuccessCompanion alloc] initWithResult:result];
     activityViewController.companion = companion;
     activityViewController.completionWithItemsHandler =
-        ^(UIActivityType activityType, BOOL completed, NSArray *returnedItems,
-          NSError *activityError) {
-          companion.activityType = activityType;
-          companion.completed = completed;
-        };
-  }
-  [controller presentViewController:activityViewController
-                           animated:YES
-                         completion:nil];
+    ^(UIActivityType activityType, BOOL completed, NSArray *returnedItems,
+      NSError *activityError) {
+        companion.activityType = activityType;
+        companion.completed = completed;
+    };
+    
+    [controller presentViewController:activityViewController
+                             animated:YES
+                           completion:nil];
 }
 
 + (void)shareUri:(NSString *)uri
-    withController:(UIViewController *)controller
-          atSource:(CGRect)origin
-          toResult:(FlutterResult)result
-        withResult:(BOOL)withResult {
-  NSURL *data = [NSURL URLWithString:uri];
-  [self share:@[ data ]
-         withSubject:nil
-      withController:controller
-            atSource:origin
-            toResult:result
-          withResult:withResult];
+  withController:(UIViewController *)controller
+        atSource:(CGRect)origin
+        toResult:(FlutterResult)result {
+    NSURL *data = [NSURL URLWithString:uri];
+    [self share:@[ data ]
+    withSubject:nil
+ withController:controller
+       atSource:origin
+       toResult:result];
 }
 
 + (void)shareText:(NSString *)shareText
-           subject:(NSString *)subject
-    withController:(UIViewController *)controller
-          atSource:(CGRect)origin
-          toResult:(FlutterResult)result
-        withResult:(BOOL)withResult {
-  NSObject *data = [[SharePlusData alloc] initWithSubject:subject
-                                                     text:shareText];
-  [self share:@[ data ]
-         withSubject:subject
-      withController:controller
-            atSource:origin
-            toResult:result
-          withResult:withResult];
+          subject:(NSString *)subject
+   withController:(UIViewController *)controller
+         atSource:(CGRect)origin
+         toResult:(FlutterResult)result {
+    NSObject *data = [[SharePlusData alloc] initWithSubject:subject
+                                                       text:shareText];
+    [self share:@[ data ]
+    withSubject:subject
+ withController:controller
+       atSource:origin
+       toResult:result];
 }
 
 + (void)shareFiles:(NSArray *)paths
@@ -460,28 +442,26 @@ TopViewControllerForViewController(UIViewController *viewController) {
           withText:(NSString *)text
     withController:(UIViewController *)controller
           atSource:(CGRect)origin
-          toResult:(FlutterResult)result
-        withResult:(BOOL)withResult {
-  NSMutableArray *items = [[NSMutableArray alloc] init];
-
-  for (int i = 0; i < [paths count]; i++) {
-    NSString *path = paths[i];
-    NSString *mimeType = mimeTypes[i];
-    [items addObject:[[SharePlusData alloc] initWithFile:path
-                                                mimeType:mimeType
-                                                 subject:subject]];
-  }
-  if (text != nil) {
-    NSObject *data = [[SharePlusData alloc] initWithSubject:subject text:text];
-    [items addObject:data];
-  }
-
-  [self share:items
-         withSubject:subject
-      withController:controller
-            atSource:origin
-            toResult:result
-          withResult:withResult];
+          toResult:(FlutterResult)result {
+    NSMutableArray *items = [[NSMutableArray alloc] init];
+    
+    for (int i = 0; i < [paths count]; i++) {
+        NSString *path = paths[i];
+        NSString *mimeType = mimeTypes[i];
+        [items addObject:[[SharePlusData alloc] initWithFile:path
+                                                    mimeType:mimeType
+                                                     subject:subject]];
+    }
+    if (text != nil) {
+        NSObject *data = [[SharePlusData alloc] initWithSubject:subject text:text];
+        [items addObject:data];
+    }
+    
+    [self share:items
+    withSubject:subject
+ withController:controller
+       atSource:origin
+       toResult:result];
 }
 
 @end

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -26,12 +26,14 @@ class Share {
   /// (if available), and the website icon will be extracted and displayed on
   /// the iOS share sheet.
   ///
-  /// The optional `sharePositionOrigin` parameter can be used to specify a global
+  /// The optional [sharePositionOrigin] parameter can be used to specify a global
   /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
   /// on other devices.
   ///
   /// May throw [PlatformException]
   /// from [MethodChannel].
+  ///
+  /// See documentation about [ShareResult] on [share] method.
   static Future<ShareResult> shareUri(
     Uri uri, {
     Rect? sharePositionOrigin,
@@ -103,12 +105,14 @@ class Share {
   /// On iOS image/jpg, image/jpeg and image/png are handled as images, while
   /// every other MIME type is considered a normal file.
   ///
-  /// The optional `sharePositionOrigin` parameter can be used to specify a global
+  /// The optional [sharePositionOrigin] parameter can be used to specify a global
   /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
   /// on other devices.
   ///
   /// May throw [PlatformException] or [FormatException]
   /// from [MethodChannel].
+  ///
+  /// See documentation about [ShareResult] on [share] method.
   static Future<ShareResult> shareXFiles(
     List<XFile> files, {
     String? subject,

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -32,7 +32,7 @@ class Share {
   ///
   /// May throw [PlatformException]
   /// from [MethodChannel].
-  static Future<void> shareUri(
+  static Future<ShareResult> shareUri(
     Uri uri, {
     Rect? sharePositionOrigin,
   }) async {
@@ -57,123 +57,33 @@ class Share {
   ///
   /// May throw [PlatformException] or [FormatException]
   /// from [MethodChannel].
-  static Future<void> share(
+  ///
+  /// [ShareResult] provides feedback on how the user
+  /// interacted with the share-sheet. Until the returned future is completed,
+  /// any other call to any share method that returns a result _might_ result in
+  /// a [PlatformException] (on Android).
+  ///
+  /// Because IOS, Android and macOS provide different feedback on share-sheet
+  /// interaction, a result on IOS will be more specific than on Android or macOS.
+  /// While on IOS the selected action can inform its caller that it was completed
+  /// or dismissed midway (_actions are free to return whatever they want_),
+  /// Android and macOS only record if the user selected an action or outright
+  /// dismissed the share-sheet. It is not guaranteed that the user actually shared
+  /// something.
+  ///
+  /// Providing result is only supported on Android, iOS and macOS.
+  ///
+  /// Will gracefully fall back to the non result variant if not implemented
+  /// for the current environment and return [ShareResult.unavailable].
+  static Future<ShareResult> share(
     String text, {
     String? subject,
     Rect? sharePositionOrigin,
-  }) {
+  }) async {
     assert(text.isNotEmpty);
     return _platform.share(
       text,
       subject: subject,
-      sharePositionOrigin: sharePositionOrigin,
-    );
-  }
-
-  /// Summons the platform's share sheet to share multiple files.
-  ///
-  /// Wraps the platform's native share dialog. Can share a file.
-  /// It uses the `ACTION_SEND` Intent on Android and `UIActivityViewController`
-  /// on iOS.
-  ///
-  /// The optional `mimeTypes` parameter can be used to specify MIME types for
-  /// the provided files.
-  /// Android supports all natively available MIME types (wildcards like image/*
-  /// are also supported) and it's considered best practice to avoid mixing
-  /// unrelated file types (eg. image/jpg & application/pdf). If MIME types are
-  /// mixed the plugin attempts to find the lowest common denominator. Even
-  /// if MIME types are supplied the receiving app decides if those are used
-  /// or handled.
-  /// On iOS image/jpg, image/jpeg and image/png are handled as images, while
-  /// every other MIME type is considered a normal file.
-  ///
-  /// The optional `sharePositionOrigin` parameter can be used to specify a global
-  /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
-  /// on other devices.
-  ///
-  /// May throw [PlatformException] or [FormatException]
-  /// from [MethodChannel].
-  @Deprecated("Use shareXFiles instead.")
-  static Future<void> shareFiles(
-    List<String> paths, {
-    List<String>? mimeTypes,
-    String? subject,
-    String? text,
-    Rect? sharePositionOrigin,
-  }) {
-    assert(paths.isNotEmpty);
-    assert(paths.every((element) => element.isNotEmpty));
-    return _platform.shareFiles(
-      paths,
-      mimeTypes: mimeTypes,
-      subject: subject,
-      text: text,
-      sharePositionOrigin: sharePositionOrigin,
-    );
-  }
-
-  /// Behaves exactly like [share] while providing feedback on how the user
-  /// interacted with the share-sheet. Until the returned future is completed,
-  /// any other call to any share method that returns a result _might_ result in
-  /// a [PlatformException] (on Android).
-  ///
-  /// Because IOS, Android and macOS provide different feedback on share-sheet
-  /// interaction, a result on IOS will be more specific than on Android or macOS.
-  /// While on IOS the selected action can inform its caller that it was completed
-  /// or dismissed midway (_actions are free to return whatever they want_),
-  /// Android and macOS only record if the user selected an action or outright
-  /// dismissed the share-sheet. It is not guaranteed that the user actually shared
-  /// something.
-  ///
-  /// **Currently only implemented on IOS, Android and macOS.**
-  ///
-  /// Will gracefully fall back to the non result variant if not implemented
-  /// for the current environment and return [ShareResult.unavailable].
-  static Future<ShareResult> shareWithResult(
-    String text, {
-    String? subject,
-    Rect? sharePositionOrigin,
-  }) async {
-    assert(text.isNotEmpty);
-    return _platform.shareWithResult(
-      text,
-      subject: subject,
-      sharePositionOrigin: sharePositionOrigin,
-    );
-  }
-
-  /// Behaves exactly like [shareFiles] while providing feedback on how the user
-  /// interacted with the share-sheet. Until the returned future is completed,
-  /// any other call to any share method that returns a result _might_ result in
-  /// a [PlatformException] (on Android).
-  ///
-  /// Because IOS, Android and macOS provide different feedback on share-sheet
-  /// interaction, a result on IOS will be more specific than on Android or macOS.
-  /// While on IOS the selected action can inform its caller that it was completed
-  /// or dismissed midway (_actions are free to return whatever they want_),
-  /// Android and macOS only record if the user selected an action or outright
-  /// dismissed the share-sheet. It is not guaranteed that the user actually shared
-  /// something.
-  ///
-  /// **Currently only implemented on IOS, Android and macOS.**
-  ///
-  /// Will gracefully fall back to the non result variant if not implemented
-  /// for the current environment and return [ShareResult.unavailable].
-  @Deprecated("Use shareXFiles instead.")
-  static Future<ShareResult> shareFilesWithResult(
-    List<String> paths, {
-    List<String>? mimeTypes,
-    String? subject,
-    String? text,
-    Rect? sharePositionOrigin,
-  }) async {
-    assert(paths.isNotEmpty);
-    assert(paths.every((element) => element.isNotEmpty));
-    return _platform.shareFilesWithResult(
-      paths,
-      mimeTypes: mimeTypes,
-      subject: subject,
-      text: text,
       sharePositionOrigin: sharePositionOrigin,
     );
   }

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -61,9 +61,11 @@ class Share {
   /// from [MethodChannel].
   ///
   /// [ShareResult] provides feedback on how the user
-  /// interacted with the share-sheet. Until the returned future is completed,
-  /// any other call to any share method that returns a result _might_ result in
-  /// a [PlatformException] (on Android).
+  /// interacted with the share-sheet.
+  ///
+  /// To avoid deadlocks on Android,
+  /// any new call to [share()] when there is a call pending,
+  /// will cause the previous call to return a [ShareResult.unavailable].
   ///
   /// Because IOS, Android and macOS provide different feedback on share-sheet
   /// interaction, a result on IOS will be more specific than on Android or macOS.

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -64,7 +64,7 @@ class Share {
   /// interacted with the share-sheet.
   ///
   /// To avoid deadlocks on Android,
-  /// any new call to [share()] when there is a call pending,
+  /// any new call to [share] when there is a call pending,
   /// will cause the previous call to return a [ShareResult.unavailable].
   ///
   /// Because IOS, Android and macOS provide different feedback on share-sheet

--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -7,8 +7,6 @@ import 'package:share_plus_platform_interface/share_plus_platform_interface.dart
 import 'package:url_launcher_linux/url_launcher_linux.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
-import 'dart:developer' as developer;
-
 /// The Linux implementation of SharePlatform.
 class SharePlusLinuxPlugin extends SharePlatform {
   SharePlusLinuxPlugin(this.urlLauncher);

--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -57,10 +57,7 @@ class SharePlusLinuxPlugin extends SharePlatform {
       const LaunchOptions(),
     );
     if (!launchResult) {
-      developer.log(
-        'Failed to launch url: $uri',
-      );
-      return ShareResult.failed;
+      throw Exception('Failed to launch $uri');
     }
 
     return ShareResult.unavailable;

--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -7,6 +7,8 @@ import 'package:share_plus_platform_interface/share_plus_platform_interface.dart
 import 'package:url_launcher_linux/url_launcher_linux.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 
+import 'dart:developer' as developer;
+
 /// The Linux implementation of SharePlatform.
 class SharePlusLinuxPlugin extends SharePlatform {
   SharePlusLinuxPlugin(this.urlLauncher);
@@ -18,9 +20,20 @@ class SharePlusLinuxPlugin extends SharePlatform {
     SharePlatform.instance = SharePlusLinuxPlugin(UrlLauncherLinux());
   }
 
+  @override
+  Future<ShareResult> shareUri(
+    Uri uri, {
+    String? subject,
+    String? text,
+    Rect? sharePositionOrigin,
+  }) async {
+    throw UnimplementedError(
+        'shareUri() has not been implemented on Linux. Use share().');
+  }
+
   /// Share text.
   @override
-  Future<void> share(
+  Future<ShareResult> share(
     String text, {
     String? subject,
     Rect? sharePositionOrigin,
@@ -44,20 +57,13 @@ class SharePlusLinuxPlugin extends SharePlatform {
       const LaunchOptions(),
     );
     if (!launchResult) {
-      throw Exception('Failed to launch $uri');
+      developer.log(
+        'Failed to launch url: $uri',
+      );
+      return ShareResult.failed;
     }
-  }
 
-  /// Share files.
-  @override
-  Future<void> shareFiles(
-    List<String> paths, {
-    List<String>? mimeTypes,
-    String? subject,
-    String? text,
-    Rect? sharePositionOrigin,
-  }) {
-    throw UnimplementedError('shareFiles() has not been implemented on Linux.');
+    return ShareResult.unavailable;
   }
 
   /// Share [XFile] objects with Result.

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -57,7 +57,6 @@ class SharePlusWebPlugin extends SharePlatform {
     try {
       await _navigator.share(data).toDart;
     } on web.DOMException catch (e) {
-      // Ignore DOMException
       developer.log(
         'Failed to share uri',
         error: '${e.name}: ${e.message}',

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -47,11 +47,11 @@ class SharePlusWebPlugin extends SharePlatform {
         error: e,
       );
 
-      return ShareResult.failed;
+      throw Exception('Navigator.canShare() is unavailable');
     }
 
     if (!canShare) {
-      return ShareResult.failed;
+      throw Exception('Navigator.canShare() is false');
     }
 
     try {
@@ -63,7 +63,7 @@ class SharePlusWebPlugin extends SharePlatform {
         error: '${e.name}: ${e.message}',
       );
 
-      return ShareResult.failed;
+      throw Exception('Navigator.share() failed: ${e.message}');
     }
 
     return ShareResult.unavailable;
@@ -116,17 +116,14 @@ class SharePlusWebPlugin extends SharePlatform {
         const LaunchOptions(),
       );
       if (!launchResult) {
-        developer.log(
-          'Failed to launch uri: $uri',
-        );
-        return ShareResult.failed;
+        throw Exception('Failed to launch $uri');
       }
 
       return ShareResult.unavailable;
     }
 
     if (!canShare) {
-      return ShareResult.failed;
+      throw Exception('Navigator.canShare() is false');
     }
 
     try {
@@ -143,9 +140,9 @@ class SharePlusWebPlugin extends SharePlatform {
         'Failed to share text',
         error: '${e.name}: ${e.message}',
       );
-    }
 
-    return ShareResult.failed;
+      throw Exception('Navigator.share() failed: ${e.message}');
+    }
   }
 
   /// Share [XFile] objects.
@@ -200,11 +197,11 @@ class SharePlusWebPlugin extends SharePlatform {
         error: e,
       );
 
-      return ShareResult.failed;
+      throw Exception('Navigator.canShare() is unavailable');
     }
 
     if (!canShare) {
-      return ShareResult.failed;
+      throw Exception('Navigator.canShare() is false');
     }
 
     try {
@@ -221,9 +218,9 @@ class SharePlusWebPlugin extends SharePlatform {
         'Failed to share files',
         error: '${e.name}: ${e.message}',
       );
-    }
 
-    return ShareResult.failed;
+      throw Exception('Navigator.share() failed: ${e.message}');
+    }
   }
 
   static Future<web.File> _fromXFile(XFile file) async {

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -8,8 +8,6 @@ import 'package:share_plus_platform_interface/share_plus_platform_interface.dart
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 import 'package:url_launcher_windows/url_launcher_windows.dart';
 
-import 'dart:developer' as developer;
-
 /// The fallback Windows implementation of [SharePlatform], for older Windows versions.
 ///
 class SharePlusWindowsPlugin extends SharePlatform {

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -62,10 +62,7 @@ class SharePlusWindowsPlugin extends SharePlatform {
       const LaunchOptions(),
     );
     if (!launchResult) {
-      developer.log(
-        'Failed to launch url: $uri',
-      );
-      return ShareResult.failed;
+      throw Exception('Failed to launch $uri');
     }
 
     return ShareResult.unavailable;

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -8,6 +8,8 @@ import 'package:share_plus_platform_interface/share_plus_platform_interface.dart
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 import 'package:url_launcher_windows/url_launcher_windows.dart';
 
+import 'dart:developer' as developer;
+
 /// The fallback Windows implementation of [SharePlatform], for older Windows versions.
 ///
 class SharePlusWindowsPlugin extends SharePlatform {
@@ -23,9 +25,20 @@ class SharePlusWindowsPlugin extends SharePlatform {
     }
   }
 
+  @override
+  Future<ShareResult> shareUri(
+    Uri uri, {
+    String? subject,
+    String? text,
+    Rect? sharePositionOrigin,
+  }) async {
+    throw UnimplementedError(
+        'shareUri() has not been implemented on Linux. Use share().');
+  }
+
   /// Share text.
   @override
-  Future<void> share(
+  Future<ShareResult> share(
     String text, {
     String? subject,
     Rect? sharePositionOrigin,
@@ -49,22 +62,13 @@ class SharePlusWindowsPlugin extends SharePlatform {
       const LaunchOptions(),
     );
     if (!launchResult) {
-      throw Exception('Failed to launch $uri');
+      developer.log(
+        'Failed to launch url: $uri',
+      );
+      return ShareResult.failed;
     }
-  }
 
-  /// Share files.
-  @override
-  Future<void> shareFiles(
-    List<String> paths, {
-    List<String>? mimeTypes,
-    String? subject,
-    String? text,
-    Rect? sharePositionOrigin,
-  }) {
-    throw UnimplementedError(
-      'shareFiles() is only available for Windows versions higher than 10.0.${VersionHelper.kWindows10RS5BuildNumber}.',
-    );
+    return ShareResult.unavailable;
   }
 
   /// Share [XFile] objects with Result.

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -31,7 +31,7 @@ class SharePlusWindowsPlugin extends SharePlatform {
     Rect? sharePositionOrigin,
   }) async {
     throw UnimplementedError(
-        'shareUri() has not been implemented on Linux. Use share().');
+        'shareUri() has not been implemented on Windows. Use share().');
   }
 
   /// Share text.

--- a/packages/share_plus/share_plus/macos/Classes/SharePlusMacosPlugin.swift
+++ b/packages/share_plus/share_plus/macos/Classes/SharePlusMacosPlugin.swift
@@ -23,18 +23,8 @@ public class SharePlusMacosPlugin: NSObject, FlutterPlugin, NSSharingServicePick
     case "share":
       let text = args["text"] as! String
       let subject = args["subject"] as? String
-      shareItems([text], subject: subject, origin: origin, view: registrar.view!)
-      result(true)
-    case "shareFiles":
-      let paths = args["paths"] as! [String]
-      let urls = paths.map { NSURL.fileURL(withPath: $0) }
-      shareItems(urls, origin: origin, view: registrar.view!)
-      result(true)
-    case "shareWithResult":
-      let text = args["text"] as! String
-      let subject = args["subject"] as? String
       shareItems([text], subject: subject, origin: origin, view: registrar.view!, callback: result)
-    case "shareFilesWithResult":
+    case "shareFiles":
       let paths = args["paths"] as! [String]
       let urls = paths.map { NSURL.fileURL(withPath: $0) }
       shareItems(urls, origin: origin, view: registrar.view!, callback: result)
@@ -48,15 +38,10 @@ public class SharePlusMacosPlugin: NSObject, FlutterPlugin, NSSharingServicePick
     return sharingService.delegate
   }
 
-  private func shareItems(_ items: [Any], subject: String? = nil, origin: NSRect, view: NSView, callback: FlutterResult? = nil) {
+  private func shareItems(_ items: [Any], subject: String? = nil, origin: NSRect, view: NSView, callback: @escaping FlutterResult) {
     DispatchQueue.main.async {
       let picker = NSSharingServicePicker(items: items)
-      if callback != nil {
-        picker.delegate = SharePlusMacosSuccessDelegate(subject: subject, callback: callback!).keep()
-      } else {
-        picker.delegate = self
-        self.subject = subject
-      }
+      picker.delegate = SharePlusMacosSuccessDelegate(subject: subject, callback: callback).keep()
       picker.show(relativeTo: origin, of: view, preferredEdge: NSRectEdge.maxY)
     }
   }

--- a/packages/share_plus/share_plus/windows/share_plus_plugin.cpp
+++ b/packages/share_plus/share_plus/windows/share_plus_plugin.cpp
@@ -93,10 +93,7 @@ HRESULT SharePlusWindowsPlugin::GetStorageFileFromPath(
 void SharePlusWindowsPlugin::HandleMethodCall(
     const flutter::MethodCall<flutter::EncodableValue> &method_call,
     std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-  if (method_call.method_name().compare(kShare) == 0 ||
-      method_call.method_name().compare(kShareWithResult) == 0) {
-    auto is_result_requested =
-        method_call.method_name().compare(kShareWithResult) == 0;
+  if (method_call.method_name().compare(kShare) == 0) {
     auto data_transfer_manager = GetDataTransferManager();
     auto args = std::get<flutter::EncodableMap>(*method_call.arguments());
     if (auto text_value =
@@ -142,15 +139,8 @@ void SharePlusWindowsPlugin::HandleMethodCall(
     if (data_transfer_manager_interop_ != nullptr) {
       data_transfer_manager_interop_->ShowShareUIForWindow(GetWindow());
     }
-    if (is_result_requested) {
-      result->Success(flutter::EncodableValue(kShareResultUnavailable));
-    } else {
-      result->Success(flutter::EncodableValue());
-    }
-  } else if (method_call.method_name().compare(kShareFiles) == 0 ||
-             method_call.method_name().compare(kShareFilesWithResult) == 0) {
-    auto is_result_requested =
-        method_call.method_name().compare(kShareFilesWithResult) == 0;
+    result->Success(flutter::EncodableValue(kShareResultUnavailable));
+  } else if (method_call.method_name().compare(kShareFiles) == 0) {
     auto data_transfer_manager = GetDataTransferManager();
     auto args = std::get<flutter::EncodableMap>(*method_call.arguments());
     if (auto text_value =
@@ -238,11 +228,7 @@ void SharePlusWindowsPlugin::HandleMethodCall(
     if (data_transfer_manager_interop_ != nullptr) {
       data_transfer_manager_interop_->ShowShareUIForWindow(GetWindow());
     }
-    if (is_result_requested) {
-      result->Success(flutter::EncodableValue(kShareResultUnavailable));
-    } else {
-      result->Success(flutter::EncodableValue());
-    }
+    result->Success(flutter::EncodableValue(kShareResultUnavailable));
   } else {
     result->NotImplemented();
   }

--- a/packages/share_plus/share_plus/windows/share_plus_windows_plugin.h
+++ b/packages/share_plus/share_plus/windows/share_plus_windows_plugin.h
@@ -46,8 +46,6 @@ private:
 
   static constexpr auto kShare = "share";
   static constexpr auto kShareFiles = "shareFiles";
-  static constexpr auto kShareWithResult = "shareWithResult";
-  static constexpr auto kShareFilesWithResult = "shareFilesWithResult";
 
   HWND GetWindow();
 

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -24,10 +24,10 @@ class MethodChannelShare extends SharePlatform {
       MethodChannel('dev.fluttercommunity.plus/share');
 
   @override
-  Future<void> shareUri(
+  Future<ShareResult> shareUri(
     Uri uri, {
     Rect? sharePositionOrigin,
-  }) {
+  }) async {
     final params = <String, dynamic>{'uri': uri.toString()};
 
     if (sharePositionOrigin != null) {
@@ -37,104 +37,62 @@ class MethodChannelShare extends SharePlatform {
       params['originHeight'] = sharePositionOrigin.height;
     }
 
-    return channel.invokeMethod<void>('shareUri', params);
-  }
-
-  /// Summons the platform's share sheet to share text.
-  @override
-  Future<void> share(
-    String text, {
-    String? subject,
-    Rect? sharePositionOrigin,
-  }) {
-    assert(text.isNotEmpty);
-    final params = <String, dynamic>{
-      'text': text,
-      'subject': subject,
-    };
-
-    if (sharePositionOrigin != null) {
-      params['originX'] = sharePositionOrigin.left;
-      params['originY'] = sharePositionOrigin.top;
-      params['originWidth'] = sharePositionOrigin.width;
-      params['originHeight'] = sharePositionOrigin.height;
-    }
-
-    return channel.invokeMethod<void>('share', params);
-  }
-
-  /// Summons the platform's share sheet to share multiple files.
-  @override
-  Future<void> shareFiles(
-    List<String> paths, {
-    List<String>? mimeTypes,
-    String? subject,
-    String? text,
-    Rect? sharePositionOrigin,
-  }) {
-    assert(paths.isNotEmpty);
-    assert(paths.every((element) => element.isNotEmpty));
-    final params = <String, dynamic>{
-      'paths': paths,
-      'mimeTypes': mimeTypes ??
-          paths.map((String path) => _mimeTypeForPath(path)).toList(),
-    };
-
-    if (subject != null) params['subject'] = subject;
-    if (text != null) params['text'] = text;
-
-    if (sharePositionOrigin != null) {
-      params['originX'] = sharePositionOrigin.left;
-      params['originY'] = sharePositionOrigin.top;
-      params['originWidth'] = sharePositionOrigin.width;
-      params['originHeight'] = sharePositionOrigin.height;
-    }
-
-    return channel.invokeMethod('shareFiles', params);
-  }
-
-  /// Summons the platform's share sheet to share text and returns the result.
-  @override
-  Future<ShareResult> shareWithResult(
-    String text, {
-    String? subject,
-    Rect? sharePositionOrigin,
-  }) async {
-    assert(text.isNotEmpty);
-    final params = <String, dynamic>{
-      'text': text,
-      'subject': subject,
-    };
-
-    if (sharePositionOrigin != null) {
-      params['originX'] = sharePositionOrigin.left;
-      params['originY'] = sharePositionOrigin.top;
-      params['originWidth'] = sharePositionOrigin.width;
-      params['originHeight'] = sharePositionOrigin.height;
-    }
-
-    final result =
-        await channel.invokeMethod<String>('shareWithResult', params) ??
-            'dev.fluttercommunity.plus/share/unavailable';
+    final result = await channel.invokeMethod<String>('shareUri', params) ??
+        'dev.fluttercommunity.plus/share/unavailable';
 
     return ShareResult(result, _statusFromResult(result));
   }
 
-  /// Summons the platform's share sheet to share multiple files and returns the result.
+  /// Summons the platform's share sheet to share text.
   @override
-  Future<ShareResult> shareFilesWithResult(
-    List<String> paths, {
-    List<String>? mimeTypes,
+  Future<ShareResult> share(
+    String text, {
+    String? subject,
+    Rect? sharePositionOrigin,
+  }) async {
+    assert(text.isNotEmpty);
+    final params = <String, dynamic>{
+      'text': text,
+      'subject': subject,
+    };
+
+    if (sharePositionOrigin != null) {
+      params['originX'] = sharePositionOrigin.left;
+      params['originY'] = sharePositionOrigin.top;
+      params['originWidth'] = sharePositionOrigin.width;
+      params['originHeight'] = sharePositionOrigin.height;
+    }
+
+    final result = await channel.invokeMethod<String>('share', params) ??
+        'dev.fluttercommunity.plus/share/unavailable';
+
+    return ShareResult(result, _statusFromResult(result));
+  }
+
+  /// Summons the platform's share sheet to share multiple files.
+  @override
+  Future<ShareResult> shareXFiles(
+    List<XFile> files, {
     String? subject,
     String? text,
     Rect? sharePositionOrigin,
   }) async {
-    assert(paths.isNotEmpty);
-    assert(paths.every((element) => element.isNotEmpty));
+    assert(files.isNotEmpty);
+    assert(files.every((element) => element.path.isNotEmpty));
+
+    final filesWithPath = await _getFiles(files);
+
+    final mimeTypes = filesWithPath
+        .map((e) => e.mimeType ?? _mimeTypeForPath(e.path))
+        .toList();
+
+    final paths = filesWithPath.map((e) => e.path).toList();
+    assert(paths.length == mimeTypes.length);
+    assert(mimeTypes.every((element) => element.isNotEmpty));
+
     final params = <String, dynamic>{
       'paths': paths,
-      'mimeTypes': mimeTypes ??
-          paths.map((String path) => _mimeTypeForPath(path)).toList(),
+      'mimeTypes': mimeTypes,
     };
 
     if (subject != null) params['subject'] = subject;
@@ -152,29 +110,6 @@ class MethodChannelShare extends SharePlatform {
             'dev.fluttercommunity.plus/share/unavailable';
 
     return ShareResult(result, _statusFromResult(result));
-  }
-
-  /// Summons the platform's share sheet to share multiple files.
-  @override
-  Future<ShareResult> shareXFiles(
-    List<XFile> files, {
-    String? subject,
-    String? text,
-    Rect? sharePositionOrigin,
-  }) async {
-    final filesWithPath = await _getFiles(files);
-
-    final mimeTypes = filesWithPath
-        .map((e) => e.mimeType ?? _mimeTypeForPath(e.path))
-        .toList();
-
-    return shareFilesWithResult(
-      filesWithPath.map((e) => e.path).toList(),
-      mimeTypes: mimeTypes,
-      subject: subject,
-      text: text,
-      sharePositionOrigin: sharePositionOrigin,
-    );
   }
 
   /// Ensure that a file is readable from the file system. Will create file on-demand under TemporaryDiectory and return the temporary file otherwise.

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -78,9 +78,9 @@ class MethodChannelShare extends SharePlatform {
     Rect? sharePositionOrigin,
   }) async {
     assert(files.isNotEmpty);
-    assert(files.every((element) => element.path.isNotEmpty));
 
     final filesWithPath = await _getFiles(files);
+    assert(filesWithPath.every((element) => element.path.isNotEmpty));
 
     final mimeTypes = filesWithPath
         .map((e) => e.mimeType ?? _mimeTypeForPath(e.path))

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -105,9 +105,8 @@ class MethodChannelShare extends SharePlatform {
       params['originHeight'] = sharePositionOrigin.height;
     }
 
-    final result =
-        await channel.invokeMethod<String>('shareFilesWithResult', params) ??
-            'dev.fluttercommunity.plus/share/unavailable';
+    final result = await channel.invokeMethod<String>('shareFiles', params) ??
+        'dev.fluttercommunity.plus/share/unavailable';
 
     return ShareResult(result, _statusFromResult(result));
   }

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -32,7 +32,7 @@ class SharePlatform extends PlatformInterface {
   }
 
   /// Share uri.
-  Future<void> shareUri(
+  Future<ShareResult> shareUri(
     Uri uri, {
     Rect? sharePositionOrigin,
   }) {
@@ -42,70 +42,17 @@ class SharePlatform extends PlatformInterface {
     );
   }
 
-  /// Share text.
-  Future<void> share(
-    String text, {
-    String? subject,
-    Rect? sharePositionOrigin,
-  }) {
-    return _instance.share(
-      text,
-      subject: subject,
-      sharePositionOrigin: sharePositionOrigin,
-    );
-  }
-
-  /// Share files.
-  @Deprecated("Use shareXFiles instead.")
-  Future<void> shareFiles(
-    List<String> paths, {
-    List<String>? mimeTypes,
-    String? subject,
-    String? text,
-    Rect? sharePositionOrigin,
-  }) {
-    return _instance.shareFiles(
-      paths,
-      mimeTypes: mimeTypes,
-      subject: subject,
-      text: text,
-      sharePositionOrigin: sharePositionOrigin,
-    );
-  }
-
   /// Share text with Result.
-  Future<ShareResult> shareWithResult(
+  Future<ShareResult> share(
     String text, {
     String? subject,
     Rect? sharePositionOrigin,
   }) async {
-    await _instance.share(
+    return await _instance.share(
       text,
       subject: subject,
       sharePositionOrigin: sharePositionOrigin,
     );
-
-    return _resultUnavailable;
-  }
-
-  /// Share files with Result.
-  @Deprecated("Use shareXFiles instead.")
-  Future<ShareResult> shareFilesWithResult(
-    List<String> paths, {
-    List<String>? mimeTypes,
-    String? subject,
-    String? text,
-    Rect? sharePositionOrigin,
-  }) async {
-    await _instance.shareFiles(
-      paths,
-      mimeTypes: mimeTypes,
-      subject: subject,
-      text: text,
-      sharePositionOrigin: sharePositionOrigin,
-    );
-
-    return _resultUnavailable;
   }
 
   /// Share [XFile] objects with Result.
@@ -143,6 +90,31 @@ class ShareResult {
   final ShareResultStatus status;
 
   const ShareResult(this.raw, this.status);
+
+  static const unavailable = ShareResult(
+    'dev.fluttercommunity.plus/share/unavailable',
+    ShareResultStatus.unavailable,
+  );
+
+  static const failed = ShareResult(
+    'dev.fluttercommunity.plus/share/failed',
+    ShareResultStatus.failed,
+  );
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is ShareResult && other.raw == raw && other.status == status;
+  }
+
+  @override
+  int get hashCode => raw.hashCode ^ status.hashCode;
+
+  @override
+  String toString() {
+    return 'ShareResult(raw: $raw, status: $status)';
+  }
 }
 
 /// How the user handled the share-sheet
@@ -153,12 +125,10 @@ enum ShareResultStatus {
   /// The user dismissed the share-sheet
   dismissed,
 
-  /// The status can not be determined
+  /// The platform failed to share content to user
+  failed,
+
+  /// The platform succeed to share content to user
+  /// but the user action can not be determined
   unavailable,
 }
-
-/// Returned if the platform is not supported
-const _resultUnavailable = ShareResult(
-  'dev.fluttercommunity.plus/share/unavailable',
-  ShareResultStatus.unavailable,
-);

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -96,11 +96,6 @@ class ShareResult {
     ShareResultStatus.unavailable,
   );
 
-  static const failed = ShareResult(
-    'dev.fluttercommunity.plus/share/failed',
-    ShareResultStatus.failed,
-  );
-
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
@@ -124,9 +119,6 @@ enum ShareResultStatus {
 
   /// The user dismissed the share-sheet
   dismissed,
-
-  /// The platform failed to share content to user
-  failed,
 
   /// The platform succeed to share content to user
   /// but the user action can not be determined

--- a/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
+++ b/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
@@ -95,8 +95,8 @@ void main() {
         text: 'some text to share',
         sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
       );
-      verify(mockChannel.invokeMethod<void>(
-        'shareFilesWithResult',
+      verify(mockChannel.invokeMethod<String>(
+        'shareFiles',
         <String, dynamic>{
           'paths': [fd.path],
           'mimeTypes': ['image/png'],
@@ -111,23 +111,10 @@ void main() {
     });
   });
 
-  test('sharing empty file fails', () {
-    expect(
-      () => sharePlatform.shareXFiles([XFile('')]),
-      throwsA(const TypeMatcher<AssertionError>()),
-    );
-    expect(
-      () => SharePlatform.instance.shareXFiles([XFile('')]),
-      throwsA(const TypeMatcher<AssertionError>()),
-    );
-
-    verifyZeroInteractions(mockChannel);
-  });
-
   test('sharing file sets correct mimeType', () async {
     await withFile('tempfile-83649b.png', (File fd) async {
       await sharePlatform.shareXFiles([XFile(fd.path)]);
-      verify(mockChannel.invokeMethod('shareFilesWithResult', <String, dynamic>{
+      verify(mockChannel.invokeMethod<String>('shareFiles', <String, dynamic>{
         'paths': [fd.path],
         'mimeTypes': ['image/png'],
       }));
@@ -137,7 +124,7 @@ void main() {
   test('sharing file sets passed mimeType', () async {
     await withFile('tempfile-83649c.png', (File fd) async {
       await sharePlatform.shareXFiles([XFile(fd.path, mimeType: '*/*')]);
-      verify(mockChannel.invokeMethod('shareFilesWithResult', <String, dynamic>{
+      verify(mockChannel.invokeMethod<String>('shareFiles', <String, dynamic>{
         'paths': [fd.path],
         'mimeTypes': ['*/*'],
       }));
@@ -169,7 +156,7 @@ void main() {
       subject: 'some subject to share',
       sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
     );
-    verify(mockChannel.invokeMethod<void>('share', <String, dynamic>{
+    verify(mockChannel.invokeMethod<String>('share', <String, dynamic>{
       'text': 'some text to share',
       'subject': 'some subject to share',
       'originX': 1.0,
@@ -180,7 +167,7 @@ void main() {
 
     await withFile('tempfile-83649e.png', (File fd) async {
       await sharePlatform.shareXFiles([XFile(fd.path)]);
-      verify(mockChannel.invokeMethod('shareFilesWithResult', <String, dynamic>{
+      verify(mockChannel.invokeMethod<String>('shareFiles', <String, dynamic>{
         'paths': [fd.path],
         'mimeTypes': ['image/png'],
       }));

--- a/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
+++ b/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
@@ -55,7 +55,7 @@ void main() {
       throwsA(const TypeMatcher<AssertionError>()),
     );
     expect(
-      () => SharePlatform.instance.shareWithResult(''),
+      () => SharePlatform.instance.share(''),
       throwsA(const TypeMatcher<AssertionError>()),
     );
     verifyZeroInteractions(mockChannel);
@@ -66,7 +66,7 @@ void main() {
       Uri.parse('https://pub.dev/packages/share_plus'),
       sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
     );
-    verify(mockChannel.invokeMethod<void>('shareUri', <String, dynamic>{
+    verify(mockChannel.invokeMethod<String>('shareUri', <String, dynamic>{
       'uri': 'https://pub.dev/packages/share_plus',
       'originX': 1.0,
       'originY': 2.0,
@@ -79,21 +79,7 @@ void main() {
       subject: 'some subject to share',
       sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
     );
-    verify(mockChannel.invokeMethod<void>('share', <String, dynamic>{
-      'text': 'some text to share',
-      'subject': 'some subject to share',
-      'originX': 1.0,
-      'originY': 2.0,
-      'originWidth': 3.0,
-      'originHeight': 4.0,
-    }));
-
-    await SharePlatform.instance.shareWithResult(
-      'some text to share',
-      subject: 'some subject to share',
-      sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
-    );
-    verify(mockChannel.invokeMethod<void>('shareWithResult', <String, dynamic>{
+    verify(mockChannel.invokeMethod<String>('share', <String, dynamic>{
       'text': 'some text to share',
       'subject': 'some subject to share',
       'originX': 1.0,
@@ -103,48 +89,6 @@ void main() {
     }));
 
     await withFile('tempfile-83649a.png', (File fd) async {
-      // ignore: deprecated_member_use_from_same_package
-      await sharePlatform.shareFiles(
-        [fd.path],
-        subject: 'some subject to share',
-        text: 'some text to share',
-        sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
-      );
-      verify(mockChannel.invokeMethod<void>(
-        'shareFiles',
-        <String, dynamic>{
-          'paths': [fd.path],
-          'mimeTypes': ['image/png'],
-          'subject': 'some subject to share',
-          'text': 'some text to share',
-          'originX': 1.0,
-          'originY': 2.0,
-          'originWidth': 3.0,
-          'originHeight': 4.0,
-        },
-      ));
-
-      // ignore: deprecated_member_use_from_same_package
-      await SharePlatform.instance.shareFilesWithResult(
-        [fd.path],
-        subject: 'some subject to share',
-        text: 'some text to share',
-        sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
-      );
-      verify(mockChannel.invokeMethod<void>(
-        'shareFilesWithResult',
-        <String, dynamic>{
-          'paths': [fd.path],
-          'mimeTypes': ['image/png'],
-          'subject': 'some subject to share',
-          'text': 'some text to share',
-          'originX': 1.0,
-          'originY': 2.0,
-          'originWidth': 3.0,
-          'originHeight': 4.0,
-        },
-      ));
-
       await sharePlatform.shareXFiles(
         [XFile(fd.path)],
         subject: 'some subject to share',
@@ -169,13 +113,11 @@ void main() {
 
   test('sharing empty file fails', () {
     expect(
-      // ignore: deprecated_member_use_from_same_package
-      () => sharePlatform.shareFiles(['']),
+      () => sharePlatform.shareXFiles([XFile('')]),
       throwsA(const TypeMatcher<AssertionError>()),
     );
     expect(
-      // ignore: deprecated_member_use_from_same_package
-      () => SharePlatform.instance.shareFilesWithResult(['']),
+      () => SharePlatform.instance.shareXFiles([XFile('')]),
       throwsA(const TypeMatcher<AssertionError>()),
     );
 
@@ -184,20 +126,6 @@ void main() {
 
   test('sharing file sets correct mimeType', () async {
     await withFile('tempfile-83649b.png', (File fd) async {
-      // ignore: deprecated_member_use_from_same_package
-      await sharePlatform.shareFiles([fd.path]);
-      verify(mockChannel.invokeMethod('shareFiles', <String, dynamic>{
-        'paths': [fd.path],
-        'mimeTypes': ['image/png'],
-      }));
-
-      // ignore: deprecated_member_use_from_same_package
-      await SharePlatform.instance.shareFilesWithResult([fd.path]);
-      verify(mockChannel.invokeMethod('shareFilesWithResult', <String, dynamic>{
-        'paths': [fd.path],
-        'mimeTypes': ['image/png'],
-      }));
-
       await sharePlatform.shareXFiles([XFile(fd.path)]);
       verify(mockChannel.invokeMethod('shareFilesWithResult', <String, dynamic>{
         'paths': [fd.path],
@@ -208,21 +136,6 @@ void main() {
 
   test('sharing file sets passed mimeType', () async {
     await withFile('tempfile-83649c.png', (File fd) async {
-      // ignore: deprecated_member_use_from_same_package
-      await sharePlatform.shareFiles([fd.path], mimeTypes: ['*/*']);
-      verify(mockChannel.invokeMethod('shareFiles', <String, dynamic>{
-        'paths': [fd.path],
-        'mimeTypes': ['*/*'],
-      }));
-
-      await SharePlatform.instance
-          // ignore: deprecated_member_use_from_same_package
-          .shareFilesWithResult([fd.path], mimeTypes: ['*/*']);
-      verify(mockChannel.invokeMethod('shareFilesWithResult', <String, dynamic>{
-        'paths': [fd.path],
-        'mimeTypes': ['*/*'],
-      }));
-
       await sharePlatform.shareXFiles([XFile(fd.path, mimeType: '*/*')]);
       verify(mockChannel.invokeMethod('shareFilesWithResult', <String, dynamic>{
         'paths': [fd.path],
@@ -238,21 +151,20 @@ void main() {
     );
 
     expect(
-      sharePlatform.shareWithResult('some text to share'),
+      sharePlatform.share('some text to share'),
       completion(equals(resultUnavailable)),
     );
 
     await withFile('tempfile-83649d.png', (File fd) async {
       expect(
-        // ignore: deprecated_member_use_from_same_package
-        sharePlatform.shareFilesWithResult([fd.path]),
+        sharePlatform.shareXFiles([XFile(fd.path)]),
         completion(equals(resultUnavailable)),
       );
     });
   });
 
   test('withResult methods invoke normal share on non IOS & Android', () async {
-    await sharePlatform.shareWithResult(
+    await sharePlatform.share(
       'some text to share',
       subject: 'some subject to share',
       sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
@@ -265,15 +177,6 @@ void main() {
       'originWidth': 3.0,
       'originHeight': 4.0,
     }));
-
-    await withFile('tempfile-83649e.png', (File fd) async {
-      // ignore: deprecated_member_use_from_same_package
-      await sharePlatform.shareFilesWithResult([fd.path]);
-      verify(mockChannel.invokeMethod('shareFiles', <String, dynamic>{
-        'paths': [fd.path],
-        'mimeTypes': ['image/png'],
-      }));
-    });
 
     await withFile('tempfile-83649e.png', (File fd) async {
       await sharePlatform.shareXFiles([XFile(fd.path)]);


### PR DESCRIPTION
## Description

This PR contains a major cleanup of the `share_plus` plugin.

In detail:

- Reduces API to three methods: `shareUri`, `share` and `shareXFiles`(removed deprecated methods).
- All methods return a `ShareResult`.
- Cleanup of Android implementation. 
  - Modified the `ShareSuccessManager` so it would not deadlock users anymore, instead, calling to `share` while there is another call waiting, causes that the previous call will be called back with `ShareResult.unavailable`, instead of causing an error.
  - Tested on Pixel 5 for all three methods sharing on Telegram, they all work with `ShareResult` correctly returned.
- Clean of iOS implementation.
  - Tested on iPhone 12 mini, sharing uri, text, and text+image on Telegram, all work and return `ShareResult` correctly.
- Cleanup macOs implementation
  - **Note:** originally the shareUri implementation was missing, maybe to do someday?
  - Tested sharing text and images to Telegram desktop
- Linux cleanup and testing (just launches mailto as before)
- Windows 
  - Legacy versions cleanup and testing (just launches mailto as before)
  - Cleanup of the c++ implementation for Windows 10+
- web cleanup and testing
  - Ensure all web methods return either a `ShareResult.undefined` or throw an exception on error. Do not hide errors.
- Update README.md
- Updated tests.
- Fixed integration tests

## Related Issues

- Closes #2819 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

