### PR TITLE
fix(connectivity_plus): Ensure Connectivity on Android is correctly reported when lost

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -101,8 +101,6 @@ _`none` is supported on all platforms by default._
 
 Connectivity changes are no longer communicated to Android apps in the background starting with Android O (8.0). You should always check for connectivity status when your app is resumed. The broadcast is only useful when your application is in the foreground.
 
-To ensure connectivity changes on Android are tracked correctly, an event containing `[ConnectivityResult.none]` may be emitted in during connectivity changes. e.g. Going from WiFi to mobile network may emit: `[wifi] -> [none] -> [mobile]`.
-
 ### iOS & MacOS
 
 On iOS simulators, the connectivity types stream might not update when Wi-Fi status changes. This is a known issue.

--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -58,7 +58,9 @@ if (connectivityResult.contains(ConnectivityResult.mobile)) {
 ```
 
 You can also listen for active connectivity types changes by subscribing to the stream
-exposed by the plugin:
+exposed by the plugin.
+
+This method should ensure emitting only distinct values.
 
 ```dart
 import 'package:connectivity_plus/connectivity_plus.dart';
@@ -98,6 +100,8 @@ _`none` is supported on all platforms by default._
 ### Android
 
 Connectivity changes are no longer communicated to Android apps in the background starting with Android O (8.0). You should always check for connectivity status when your app is resumed. The broadcast is only useful when your application is in the foreground.
+
+To ensure connectivity changes on Android are tracked correctly, an event containing `[ConnectivityResult.none]` may be emitted in during connectivity changes. e.g. Going from WiFi to mobile network may emit: `[wifi] -> [none] -> [mobile]`.
 
 ### iOS & MacOS
 

--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/Connectivity.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/Connectivity.java
@@ -8,118 +8,114 @@ import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.os.Build;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
-
 import java.util.ArrayList;
 import java.util.List;
 
-/**
- * Reports connectivity related information such as connectivity type and wifi information.
- */
+/** Reports connectivity related information such as connectivity type and wifi information. */
 public class Connectivity {
-    static final String CONNECTIVITY_NONE = "none";
-    static final String CONNECTIVITY_WIFI = "wifi";
-    static final String CONNECTIVITY_MOBILE = "mobile";
-    static final String CONNECTIVITY_ETHERNET = "ethernet";
-    static final String CONNECTIVITY_BLUETOOTH = "bluetooth";
-    static final String CONNECTIVITY_VPN = "vpn";
-    static final String CONNECTIVITY_OTHER = "other";
-    private final ConnectivityManager connectivityManager;
+  static final String CONNECTIVITY_NONE = "none";
+  static final String CONNECTIVITY_WIFI = "wifi";
+  static final String CONNECTIVITY_MOBILE = "mobile";
+  static final String CONNECTIVITY_ETHERNET = "ethernet";
+  static final String CONNECTIVITY_BLUETOOTH = "bluetooth";
+  static final String CONNECTIVITY_VPN = "vpn";
+  static final String CONNECTIVITY_OTHER = "other";
+  private final ConnectivityManager connectivityManager;
 
-    public Connectivity(ConnectivityManager connectivityManager) {
-        this.connectivityManager = connectivityManager;
-    }
+  public Connectivity(ConnectivityManager connectivityManager) {
+    this.connectivityManager = connectivityManager;
+  }
 
-    List<String> getNetworkTypes() {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            Network network = connectivityManager.getActiveNetwork();
-            return getCapabilitiesFromNetwork(network);
-        } else {
-            // For legacy versions, return a single type as before or adapt similarly if multiple types
-            // need to be supported
-            return getNetworkTypesLegacy();
-        }
+  List<String> getNetworkTypes() {
+    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      Network network = connectivityManager.getActiveNetwork();
+      return getCapabilitiesFromNetwork(network);
+    } else {
+      // For legacy versions, return a single type as before or adapt similarly if multiple types
+      // need to be supported
+      return getNetworkTypesLegacy();
     }
+  }
 
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    List<String> getCapabilitiesFromNetwork(Network network) {
-        NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(network);
-        return getCapabilitiesList(capabilities);
-    }
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  List<String> getCapabilitiesFromNetwork(Network network) {
+    NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(network);
+    return getCapabilitiesList(capabilities);
+  }
 
-    @NonNull
-    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
-    List<String> getCapabilitiesList(NetworkCapabilities capabilities) {
-        List<String> types = new ArrayList<>();
-        if (capabilities == null
-                || !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
-            types.add(CONNECTIVITY_NONE);
-            return types;
-        }
-        if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
-                || capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE)) {
-            types.add(CONNECTIVITY_WIFI);
-        }
-        if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
-            types.add(CONNECTIVITY_ETHERNET);
-        }
-        if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
-            types.add(CONNECTIVITY_VPN);
-        }
-        if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-            types.add(CONNECTIVITY_MOBILE);
-        }
-        if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
-            types.add(CONNECTIVITY_BLUETOOTH);
-        }
-        if (types.isEmpty()
-                && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
-            types.add(CONNECTIVITY_OTHER);
-        }
-        if (types.isEmpty()) {
-            types.add(CONNECTIVITY_NONE);
-        }
-        return types;
+  @NonNull
+  @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+  List<String> getCapabilitiesList(NetworkCapabilities capabilities) {
+    List<String> types = new ArrayList<>();
+    if (capabilities == null
+        || !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+      types.add(CONNECTIVITY_NONE);
+      return types;
     }
+    if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+        || capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE)) {
+      types.add(CONNECTIVITY_WIFI);
+    }
+    if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+      types.add(CONNECTIVITY_ETHERNET);
+    }
+    if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+      types.add(CONNECTIVITY_VPN);
+    }
+    if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+      types.add(CONNECTIVITY_MOBILE);
+    }
+    if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
+      types.add(CONNECTIVITY_BLUETOOTH);
+    }
+    if (types.isEmpty()
+        && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+      types.add(CONNECTIVITY_OTHER);
+    }
+    if (types.isEmpty()) {
+      types.add(CONNECTIVITY_NONE);
+    }
+    return types;
+  }
 
-    @SuppressWarnings("deprecation")
-    private List<String> getNetworkTypesLegacy() {
-        // handle type for Android versions less than Android 6
-        android.net.NetworkInfo info = connectivityManager.getActiveNetworkInfo();
-        List<String> types = new ArrayList<>();
-        if (info == null || !info.isConnected()) {
-            types.add(CONNECTIVITY_NONE);
-            return types;
-        }
-        int type = info.getType();
-        switch (type) {
-            case ConnectivityManager.TYPE_BLUETOOTH:
-                types.add(CONNECTIVITY_BLUETOOTH);
-                break;
-            case ConnectivityManager.TYPE_ETHERNET:
-                types.add(CONNECTIVITY_ETHERNET);
-                break;
-            case ConnectivityManager.TYPE_WIFI:
-            case ConnectivityManager.TYPE_WIMAX:
-                types.add(CONNECTIVITY_WIFI);
-                break;
-            case ConnectivityManager.TYPE_VPN:
-                types.add(CONNECTIVITY_VPN);
-                break;
-            case ConnectivityManager.TYPE_MOBILE:
-            case ConnectivityManager.TYPE_MOBILE_DUN:
-            case ConnectivityManager.TYPE_MOBILE_HIPRI:
-                types.add(CONNECTIVITY_MOBILE);
-                break;
-            default:
-                types.add(CONNECTIVITY_OTHER);
-        }
-        return types;
+  @SuppressWarnings("deprecation")
+  private List<String> getNetworkTypesLegacy() {
+    // handle type for Android versions less than Android 6
+    android.net.NetworkInfo info = connectivityManager.getActiveNetworkInfo();
+    List<String> types = new ArrayList<>();
+    if (info == null || !info.isConnected()) {
+      types.add(CONNECTIVITY_NONE);
+      return types;
     }
+    int type = info.getType();
+    switch (type) {
+      case ConnectivityManager.TYPE_BLUETOOTH:
+        types.add(CONNECTIVITY_BLUETOOTH);
+        break;
+      case ConnectivityManager.TYPE_ETHERNET:
+        types.add(CONNECTIVITY_ETHERNET);
+        break;
+      case ConnectivityManager.TYPE_WIFI:
+      case ConnectivityManager.TYPE_WIMAX:
+        types.add(CONNECTIVITY_WIFI);
+        break;
+      case ConnectivityManager.TYPE_VPN:
+        types.add(CONNECTIVITY_VPN);
+        break;
+      case ConnectivityManager.TYPE_MOBILE:
+      case ConnectivityManager.TYPE_MOBILE_DUN:
+      case ConnectivityManager.TYPE_MOBILE_HIPRI:
+        types.add(CONNECTIVITY_MOBILE);
+        break;
+      default:
+        types.add(CONNECTIVITY_OTHER);
+    }
+    return types;
+  }
 
-    public ConnectivityManager getConnectivityManager() {
-        return connectivityManager;
-    }
+  public ConnectivityManager getConnectivityManager() {
+    return connectivityManager;
+  }
 }

--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/Connectivity.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/Connectivity.java
@@ -8,102 +8,118 @@ import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
+
 import java.util.ArrayList;
 import java.util.List;
 
-/** Reports connectivity related information such as connectivity type and wifi information. */
+/**
+ * Reports connectivity related information such as connectivity type and wifi information.
+ */
 public class Connectivity {
-  static final String CONNECTIVITY_NONE = "none";
-  static final String CONNECTIVITY_WIFI = "wifi";
-  static final String CONNECTIVITY_MOBILE = "mobile";
-  static final String CONNECTIVITY_ETHERNET = "ethernet";
-  static final String CONNECTIVITY_BLUETOOTH = "bluetooth";
-  static final String CONNECTIVITY_VPN = "vpn";
-  static final String CONNECTIVITY_OTHER = "other";
-  private final ConnectivityManager connectivityManager;
+    static final String CONNECTIVITY_NONE = "none";
+    static final String CONNECTIVITY_WIFI = "wifi";
+    static final String CONNECTIVITY_MOBILE = "mobile";
+    static final String CONNECTIVITY_ETHERNET = "ethernet";
+    static final String CONNECTIVITY_BLUETOOTH = "bluetooth";
+    static final String CONNECTIVITY_VPN = "vpn";
+    static final String CONNECTIVITY_OTHER = "other";
+    private final ConnectivityManager connectivityManager;
 
-  public Connectivity(ConnectivityManager connectivityManager) {
-    this.connectivityManager = connectivityManager;
-  }
+    public Connectivity(ConnectivityManager connectivityManager) {
+        this.connectivityManager = connectivityManager;
+    }
 
-  List<String> getNetworkTypes() {
-    List<String> types = new ArrayList<>();
-    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-      Network network = connectivityManager.getActiveNetwork();
-      NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(network);
-      if (capabilities == null
-          || !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
-        types.add(CONNECTIVITY_NONE);
+    List<String> getNetworkTypes() {
+        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            Network network = connectivityManager.getActiveNetwork();
+            return getCapabilitiesFromNetwork(network);
+        } else {
+            // For legacy versions, return a single type as before or adapt similarly if multiple types
+            // need to be supported
+            return getNetworkTypesLegacy();
+        }
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    List<String> getCapabilitiesFromNetwork(Network network) {
+        NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(network);
+        return getCapabilitiesList(capabilities);
+    }
+
+    @NonNull
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    List<String> getCapabilitiesList(NetworkCapabilities capabilities) {
+        List<String> types = new ArrayList<>();
+        if (capabilities == null
+                || !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+            types.add(CONNECTIVITY_NONE);
+            return types;
+        }
+        if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
+                || capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE)) {
+            types.add(CONNECTIVITY_WIFI);
+        }
+        if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+            types.add(CONNECTIVITY_ETHERNET);
+        }
+        if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
+            types.add(CONNECTIVITY_VPN);
+        }
+        if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+            types.add(CONNECTIVITY_MOBILE);
+        }
+        if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
+            types.add(CONNECTIVITY_BLUETOOTH);
+        }
+        if (types.isEmpty()
+                && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+            types.add(CONNECTIVITY_OTHER);
+        }
+        if (types.isEmpty()) {
+            types.add(CONNECTIVITY_NONE);
+        }
         return types;
-      }
-      if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)
-          || capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE)) {
-        types.add(CONNECTIVITY_WIFI);
-      }
-      if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
-        types.add(CONNECTIVITY_ETHERNET);
-      }
-      if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN)) {
-        types.add(CONNECTIVITY_VPN);
-      }
-      if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-        types.add(CONNECTIVITY_MOBILE);
-      }
-      if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_BLUETOOTH)) {
-        types.add(CONNECTIVITY_BLUETOOTH);
-      }
-      if (types.isEmpty()
-          && capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
-        types.add(CONNECTIVITY_OTHER);
-      }
-      if (types.isEmpty()) {
-        types.add(CONNECTIVITY_NONE);
-      }
-    } else {
-      // For legacy versions, return a single type as before or adapt similarly if multiple types
-      // need to be supported
-      return getNetworkTypesLegacy();
     }
 
-    return types;
-  }
-
-  @SuppressWarnings("deprecation")
-  private List<String> getNetworkTypesLegacy() {
-    // handle type for Android versions less than Android 6
-    android.net.NetworkInfo info = connectivityManager.getActiveNetworkInfo();
-    List<String> types = new ArrayList<>();
-    if (info == null || !info.isConnected()) {
-      types.add(CONNECTIVITY_NONE);
-      return types;
+    @SuppressWarnings("deprecation")
+    private List<String> getNetworkTypesLegacy() {
+        // handle type for Android versions less than Android 6
+        android.net.NetworkInfo info = connectivityManager.getActiveNetworkInfo();
+        List<String> types = new ArrayList<>();
+        if (info == null || !info.isConnected()) {
+            types.add(CONNECTIVITY_NONE);
+            return types;
+        }
+        int type = info.getType();
+        switch (type) {
+            case ConnectivityManager.TYPE_BLUETOOTH:
+                types.add(CONNECTIVITY_BLUETOOTH);
+                break;
+            case ConnectivityManager.TYPE_ETHERNET:
+                types.add(CONNECTIVITY_ETHERNET);
+                break;
+            case ConnectivityManager.TYPE_WIFI:
+            case ConnectivityManager.TYPE_WIMAX:
+                types.add(CONNECTIVITY_WIFI);
+                break;
+            case ConnectivityManager.TYPE_VPN:
+                types.add(CONNECTIVITY_VPN);
+                break;
+            case ConnectivityManager.TYPE_MOBILE:
+            case ConnectivityManager.TYPE_MOBILE_DUN:
+            case ConnectivityManager.TYPE_MOBILE_HIPRI:
+                types.add(CONNECTIVITY_MOBILE);
+                break;
+            default:
+                types.add(CONNECTIVITY_OTHER);
+        }
+        return types;
     }
-    int type = info.getType();
-    switch (type) {
-      case ConnectivityManager.TYPE_BLUETOOTH:
-        types.add(CONNECTIVITY_BLUETOOTH);
-        break;
-      case ConnectivityManager.TYPE_ETHERNET:
-        types.add(CONNECTIVITY_ETHERNET);
-        break;
-      case ConnectivityManager.TYPE_WIFI:
-      case ConnectivityManager.TYPE_WIMAX:
-        types.add(CONNECTIVITY_WIFI);
-        break;
-      case ConnectivityManager.TYPE_VPN:
-        types.add(CONNECTIVITY_VPN);
-        break;
-      case ConnectivityManager.TYPE_MOBILE:
-      case ConnectivityManager.TYPE_MOBILE_DUN:
-      case ConnectivityManager.TYPE_MOBILE_HIPRI:
-        types.add(CONNECTIVITY_MOBILE);
-        break;
-      default:
-        types.add(CONNECTIVITY_OTHER);
-    }
-    return types;
-  }
 
-  public ConnectivityManager getConnectivityManager() {
-    return connectivityManager;
-  }
+    public ConnectivityManager getConnectivityManager() {
+        return connectivityManager;
+    }
 }

--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
@@ -49,20 +49,35 @@ public class ConnectivityBroadcastReceiver extends BroadcastReceiver
           new ConnectivityManager.NetworkCallback() {
             @Override
             public void onAvailable(Network network) {
-              // Use the provided Network object in the callback
+              // onAvailable is called when the phone switches to a new network
+              // e.g. the phone was offline and gets wifi connection
+              // or the phone was on wifi and now switches to mobile.
+              // The plugin sends the current capability connection to the users.
               sendEvent(connectivity.getCapabilitiesFromNetwork(network));
             }
 
             @Override
             public void onCapabilitiesChanged(
                 Network network, NetworkCapabilities networkCapabilities) {
-              // Use the provided NetworkCapabilities in the callback
+              // This callback is called multiple times after a call to onAvailable
+              // this also causes multiple callbacks to the Flutter layer.
               sendEvent(connectivity.getCapabilitiesList(networkCapabilities));
             }
 
             @Override
             public void onLost(Network network) {
-              // Send NONE to ensure no network is reported when connectivity is lost
+              // This callback is called when a capability is lost.
+
+              // e.g. user disconnected from wifi or disabled mobile data.
+              // If a user switches from wifi to mobile,
+              // onLost is called (for wifi),
+
+              // then onAvailable is called afterwards (for mobile).
+              // Meaning the user receives [wifi] -> [none] -> [mobile]
+
+              // If no other connectivity is present, onAvailable will not be called,
+              // and onLost is the only event that will happen.
+              // i.e. the user will only receive [wifi] -> [none]
               sendEvent(List.of(CONNECTIVITY_NONE));
             }
           };

--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
@@ -115,9 +115,7 @@ public class ConnectivityBroadcastReceiver extends BroadcastReceiver
 
   private void sendEvent(List<String> networkTypes) {
     Runnable runnable = () -> events.success(networkTypes);
-    // The dalay is needed because callback methods suffer from race conditions.
-    // More info:
-    // https://developer.android.com/develop/connectivity/network-ops/reading-network-state#listening-events
-    mainHandler.postDelayed(runnable, 100);
+    // Emit events on main thread
+    mainHandler.post(runnable);
   }
 }

--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
@@ -16,10 +16,8 @@ import android.net.NetworkCapabilities;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
-
-import java.util.List;
-
 import io.flutter.plugin.common.EventChannel;
+import java.util.List;
 
 /**
  * The ConnectivityBroadcastReceiver receives the connectivity updates and send them to the UIThread
@@ -30,81 +28,81 @@ import io.flutter.plugin.common.EventChannel;
  * to set up the receiver.
  */
 public class ConnectivityBroadcastReceiver extends BroadcastReceiver
-        implements EventChannel.StreamHandler {
-    private final Context context;
-    private final Connectivity connectivity;
-    private EventChannel.EventSink events;
-    private final Handler mainHandler = new Handler(Looper.getMainLooper());
-    private ConnectivityManager.NetworkCallback networkCallback;
-    public static final String CONNECTIVITY_ACTION = "android.net.conn.CONNECTIVITY_CHANGE";
+    implements EventChannel.StreamHandler {
+  private final Context context;
+  private final Connectivity connectivity;
+  private EventChannel.EventSink events;
+  private final Handler mainHandler = new Handler(Looper.getMainLooper());
+  private ConnectivityManager.NetworkCallback networkCallback;
+  public static final String CONNECTIVITY_ACTION = "android.net.conn.CONNECTIVITY_CHANGE";
 
-    public ConnectivityBroadcastReceiver(Context context, Connectivity connectivity) {
-        this.context = context;
-        this.connectivity = connectivity;
-    }
+  public ConnectivityBroadcastReceiver(Context context, Connectivity connectivity) {
+    this.context = context;
+    this.connectivity = connectivity;
+  }
 
-    @Override
-    public void onListen(Object arguments, EventChannel.EventSink events) {
-        this.events = events;
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            networkCallback =
-                    new ConnectivityManager.NetworkCallback() {
-                        @Override
-                        public void onAvailable(Network network) {
-                            // Use the provided Network object in the callback
-                            sendEvent(connectivity.getCapabilitiesFromNetwork(network));
-                        }
-
-                        @Override
-                        public void onCapabilitiesChanged(
-                                Network network, NetworkCapabilities networkCapabilities) {
-                            // Use the provided NetworkCapabilities in the callback
-                            sendEvent(connectivity.getCapabilitiesList(networkCapabilities));
-                        }
-
-                        @Override
-                        public void onLost(Network network) {
-                            // Send NONE to ensure no network is reported when connectivity is lost
-                            sendEvent(List.of(CONNECTIVITY_NONE));
-                        }
-                    };
-            connectivity.getConnectivityManager().registerDefaultNetworkCallback(networkCallback);
-        } else {
-            context.registerReceiver(this, new IntentFilter(CONNECTIVITY_ACTION));
-        }
-        // Need to emit first event with connectivity types without waiting for first change in system
-        // that might happen much later
-        sendEvent(connectivity.getNetworkTypes());
-    }
-
-    @Override
-    public void onCancel(Object arguments) {
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-            if (networkCallback != null) {
-                connectivity.getConnectivityManager().unregisterNetworkCallback(networkCallback);
-                networkCallback = null;
+  @Override
+  public void onListen(Object arguments, EventChannel.EventSink events) {
+    this.events = events;
+    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      networkCallback =
+          new ConnectivityManager.NetworkCallback() {
+            @Override
+            public void onAvailable(Network network) {
+              // Use the provided Network object in the callback
+              sendEvent(connectivity.getCapabilitiesFromNetwork(network));
             }
-        } else {
-            try {
-                context.unregisterReceiver(this);
-            } catch (Exception e) {
-                // listen never called, ignore the error
+
+            @Override
+            public void onCapabilitiesChanged(
+                Network network, NetworkCapabilities networkCapabilities) {
+              // Use the provided NetworkCapabilities in the callback
+              sendEvent(connectivity.getCapabilitiesList(networkCapabilities));
             }
-        }
-    }
 
-    @Override
-    public void onReceive(Context context, Intent intent) {
-        if (events != null) {
-            events.success(connectivity.getNetworkTypes());
-        }
+            @Override
+            public void onLost(Network network) {
+              // Send NONE to ensure no network is reported when connectivity is lost
+              sendEvent(List.of(CONNECTIVITY_NONE));
+            }
+          };
+      connectivity.getConnectivityManager().registerDefaultNetworkCallback(networkCallback);
+    } else {
+      context.registerReceiver(this, new IntentFilter(CONNECTIVITY_ACTION));
     }
+    // Need to emit first event with connectivity types without waiting for first change in system
+    // that might happen much later
+    sendEvent(connectivity.getNetworkTypes());
+  }
 
-    private void sendEvent(List<String> networkTypes) {
-        Runnable runnable = () -> events.success(networkTypes);
-        // The dalay is needed because callback methods suffer from race conditions.
-        // More info:
-        // https://developer.android.com/develop/connectivity/network-ops/reading-network-state#listening-events
-        mainHandler.postDelayed(runnable, 100);
+  @Override
+  public void onCancel(Object arguments) {
+    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      if (networkCallback != null) {
+        connectivity.getConnectivityManager().unregisterNetworkCallback(networkCallback);
+        networkCallback = null;
+      }
+    } else {
+      try {
+        context.unregisterReceiver(this);
+      } catch (Exception e) {
+        // listen never called, ignore the error
+      }
     }
+  }
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    if (events != null) {
+      events.success(connectivity.getNetworkTypes());
+    }
+  }
+
+  private void sendEvent(List<String> networkTypes) {
+    Runnable runnable = () -> events.success(networkTypes);
+    // The dalay is needed because callback methods suffer from race conditions.
+    // More info:
+    // https://developer.android.com/develop/connectivity/network-ops/reading-network-state#listening-events
+    mainHandler.postDelayed(runnable, 100);
+  }
 }

--- a/packages/connectivity_plus/connectivity_plus/example/lib/main.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/lib/main.dart
@@ -8,7 +8,6 @@ import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/packages/connectivity_plus/connectivity_plus/example/lib/main.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/lib/main.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'dart:developer' as developer;
 
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -86,6 +87,8 @@ class _MyHomePageState extends State<MyHomePage> {
     setState(() {
       _connectionStatus = result;
     });
+    // ignore: avoid_print
+    print('Connectivity changed: $_connectionStatus');
   }
 
   @override

--- a/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 
+import 'package:collection/collection.dart';
+
 // Export enums from the platform_interface so plugin users can use them directly.
 export 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart'
     show ConnectivityResult;
@@ -40,16 +42,20 @@ class Connectivity {
   /// status changes, this is a known issue that only affects simulators.
   /// For details see https://github.com/fluttercommunity/plus_plugins/issues/479.
   ///
-  /// On Android, the Stream may emit new values even when
-  /// the [ConnectivityResult] list remains the same.
+  /// On Android, the Stream may emit [ConnectivityResult.none] after
+  /// losing connection, then emit another [ConnectivityResult] for the
+  /// new network.
+  /// e.g. going from wifi to mobile would emit:
+  ///   wifi -> none -> mobile
   ///
   /// The emitted list is never empty. In case of no connectivity, the list contains
   /// a single element of [ConnectivityResult.none]. Note also that this is the only
   /// case where [ConnectivityResult.none] is present.
   ///
-  /// This method doesn't filter events, nor it ensures distinct values.
+  /// This method applies [Stream.distinct] over the received events to ensure
+  /// only emiting when connectivity changes.
   Stream<List<ConnectivityResult>> get onConnectivityChanged {
-    return _platform.onConnectivityChanged;
+    return _platform.onConnectivityChanged.distinct((a, b) => a.equals(b));
   }
 
   /// Checks the connection status of the device.

--- a/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
@@ -41,12 +41,6 @@ class Connectivity {
   /// status changes, this is a known issue that only affects simulators.
   /// For details see https://github.com/fluttercommunity/plus_plugins/issues/479.
   ///
-  /// On Android, the Stream may emit [ConnectivityResult.none] after
-  /// losing connection, then emit another [ConnectivityResult] for the
-  /// new network.
-  /// e.g. going from wifi to mobile would emit:
-  ///   wifi -> none -> mobile
-  ///
   /// The emitted list is never empty. In case of no connectivity, the list contains
   /// a single element of [ConnectivityResult.none]. Note also that this is the only
   /// case where [ConnectivityResult.none] is present.

--- a/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
-
 import 'package:collection/collection.dart';
 
 // Export enums from the platform_interface so plugin users can use them directly.

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -41,6 +41,7 @@ dependencies:
   web: '>=0.3.0 <=0.6.0'
   meta: ^1.8.0
   nm: ^0.5.0
+  collection: ^1.18.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/share_plus/share_plus/windows/vector.h
+++ b/packages/share_plus/share_plus/windows/vector.h
@@ -65,8 +65,8 @@ __declspec(noreturn) __declspec(noinline) inline void ThrowHR(HRESULT hr,
   ThrowHR(hr);
 }
 
-__declspec(noreturn) __declspec(noinline) inline void
-ThrowHR(HRESULT hr, wchar_t const *message) {
+__declspec(noreturn) __declspec(noinline) inline void ThrowHR(
+    HRESULT hr, wchar_t const *message) {
   using ::Microsoft::WRL::Wrappers::HStringReference;
 
   ThrowHR(hr, HStringReference(message).Get());

--- a/packages/share_plus/share_plus/windows/vector.h
+++ b/packages/share_plus/share_plus/windows/vector.h
@@ -65,8 +65,8 @@ __declspec(noreturn) __declspec(noinline) inline void ThrowHR(HRESULT hr,
   ThrowHR(hr);
 }
 
-__declspec(noreturn) __declspec(noinline) inline void ThrowHR(
-    HRESULT hr, wchar_t const *message) {
+__declspec(noreturn) __declspec(noinline) inline void
+ThrowHR(HRESULT hr, wchar_t const *message) {
   using ::Microsoft::WRL::Wrappers::HStringReference;
 
   ThrowHR(hr, HStringReference(message).Get());


### PR DESCRIPTION
## Description

- Doing tests, I noticed that the connectivity did not change when disabling mobile connection, see https://github.com/fluttercommunity/plus_plugins/issues/2831#issuecomment-2048946133
  - The events received in `onConnectivityChange` were not correct.
  - When I disconnected mobile, the `onConnectivityChange` was still reporting connectivity `mobile`.
- I did some changes on the connectivity change listeners in Android and the issue is gone.
  - In the `onLost` callback: Increased the delay to 500 milliseconds to avoid race conditions.
  - In the other two callbacks, use the provided Network and Capabilities objects, this ensures that the actual event payload is used and not reading a value that may be not up-to-date.
  - The "delayed" callback is now only used `onLost`.
  - I added a `distinct` to the stream, because the callback was being called a lot of times after a change. I don't think users will miss that ;)
-  Tested on Pixel 5, disconnecting wifi and/or mobile network, and it gets reported correctly.

What a plugin consumer will see:

1. Phone connected to wifi and mobile: `[wifi]` is emitted.
2. Phone disconnects from wifi and connects to mobile: `[mobile]` is emitted. (Note: Users may still see a `[none]` event if the phone fails to connect to mobile while switching)
4. Phone connects to wifi again: `[wifi]` is emitted.
5. All connection is lost: `[none]` is emitted.
6. etc.

With a VPN + wifi:
1. Phone connected to wifi + vpn: `[wifi, vpn]`
2. Phone disconnects from vpn: `[wifi]`

BTW, from the Android documentation:

> Do NOT call [ConnectivityManager.getNetworkCapabilities(android.net.Network)](https://developer.android.com/reference/android/net/ConnectivityManager#getNetworkCapabilities(android.net.Network)) or [ConnectivityManager.getLinkProperties(android.net.Network)](https://developer.android.com/reference/android/net/ConnectivityManager#getLinkProperties(android.net.Network)) or other synchronous ConnectivityManager methods in this callback as this is prone to race conditions ; calling these methods while in a callback may return an outdated or even a null object.

Which is why users were still seeing mobile connectivity even if it was disconnected. 
The 100 ms delay we had in place was not enough to ensure that wasn't an issue.
This is why it is increased to 500 ms and used only in `onLost` since it is the only place where it is strictly necessary.

## Related Issues

- Fix #2831 
- Potentially other older tickets.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

