### PR TITLE
ci(all): Analyze every package individually

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -19,28 +19,6 @@ on:
       - "**.md"
 
 jobs:
-  analyze:
-    name: "Flutter Analyze"
-    timeout-minutes: 15
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Checkout repository"
-        uses: actions/checkout@v4
-      - name: "Install Flutter"
-        run: ./.github/workflows/scripts/install-flutter.sh stable
-      - name: "Install Tools"
-        run: |
-          ./.github/workflows/scripts/install-tools.sh
-      - name: "Bootstrap Workspace"
-        run: melos bootstrap
-      - name: "Run Dart Analyze"
-        uses: invertase/github-action-dart-analyzer@v3
-        with:
-          fatal-infos: false
-          fatal-warnings: true
-          annotate: true
-          working-directory: ./packages
-
   pub_dev_publish_check:
     name: "Check pub.dev requirements"
     timeout-minutes: 15

--- a/.github/workflows/all_plugins_skipper.yaml
+++ b/.github/workflows/all_plugins_skipper.yaml
@@ -12,12 +12,6 @@ on:
       - "**.md"
 
 jobs:
-  analyze:
-    name: "Flutter Analyze"
-    runs-on: ubuntu-latest
-    steps:
-      - run: 'echo "No analyze required as only docs or non-plugin files changed"'
-
   check_formatting:
     name: "Check code formatting"
     runs-on: ubuntu-latest

--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -18,6 +18,28 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*android_alarm_manager_plus_example*"
 
 jobs:
+  analyze:
+    name: "Dart Analyzer"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: |
+          ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
+      - name: "Run Dart Analyze"
+        uses: invertase/github-action-dart-analyzer@v3
+        with:
+          fatal-infos: false
+          fatal-warnings: true
+          annotate: true
+          working-directory: ./packages/android_alarm_manager_plus
+
   android_example_build:
     runs-on: macos-14
     timeout-minutes: 30

--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -18,6 +18,28 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*android_intent_example*"
 
 jobs:
+  analyze:
+    name: "Dart Analyzer"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: |
+          ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
+      - name: "Run Dart Analyze"
+        uses: invertase/github-action-dart-analyzer@v3
+        with:
+          fatal-infos: false
+          fatal-warnings: true
+          annotate: true
+          working-directory: ./packages/android_intent_plus
+
   android_example_build:
     runs-on: macos-14
     timeout-minutes: 30

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -22,6 +22,28 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*battery_plus_example*"
 
 jobs:
+  analyze:
+    name: "Dart Analyzer"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: |
+          ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
+      - name: "Run Dart Analyze"
+        uses: invertase/github-action-dart-analyzer@v3
+        with:
+          fatal-infos: false
+          fatal-warnings: true
+          annotate: true
+          working-directory: ./packages/battery_plus
+
   android_example_build:
     runs-on: macos-14
     timeout-minutes: 30

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -22,6 +22,28 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*connectivity_plus_example*"
 
 jobs:
+  analyze:
+    name: "Dart Analyzer"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: |
+          ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
+      - name: "Run Dart Analyze"
+        uses: invertase/github-action-dart-analyzer@v3
+        with:
+          fatal-infos: false
+          fatal-warnings: true
+          annotate: true
+          working-directory: ./packages/connectivity_plus
+
   android_example_build:
     runs-on: macos-14
     timeout-minutes: 30

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -22,6 +22,28 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*device_info_plus_example*"
 
 jobs:
+  analyze:
+    name: "Dart Analyzer"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: |
+          ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
+      - name: "Run Dart Analyze"
+        uses: invertase/github-action-dart-analyzer@v3
+        with:
+          fatal-infos: false
+          fatal-warnings: true
+          annotate: true
+          working-directory: ./packages/device_info_plus
+
   android_example_build:
     runs-on: macos-14
     timeout-minutes: 30

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -22,6 +22,28 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*network_info_plus_example*"
 
 jobs:
+  analyze:
+    name: "Dart Analyzer"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: |
+          ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
+      - name: "Run Dart Analyze"
+        uses: invertase/github-action-dart-analyzer@v3
+        with:
+          fatal-infos: false
+          fatal-warnings: true
+          annotate: true
+          working-directory: ./packages/network_info_plus
+
   android_example_build:
     runs-on: macos-14
     timeout-minutes: 30

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -22,6 +22,28 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*package_info_plus_example*"
 
 jobs:
+  analyze:
+    name: "Dart Analyzer"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: |
+          ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
+      - name: "Run Dart Analyze"
+        uses: invertase/github-action-dart-analyzer@v3
+        with:
+          fatal-infos: false
+          fatal-warnings: true
+          annotate: true
+          working-directory: ./packages/package_info_plus
+
   android_example_build:
     runs-on: macos-14
     timeout-minutes: 30

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -18,6 +18,28 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*sensors_plus_example*"
 
 jobs:
+  analyze:
+    name: "Dart Analyzer"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: |
+          ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
+      - name: "Run Dart Analyze"
+        uses: invertase/github-action-dart-analyzer@v3
+        with:
+          fatal-infos: false
+          fatal-warnings: true
+          annotate: true
+          working-directory: ./packages/sensors_plus
+
   android_build:
     runs-on: macos-14
     timeout-minutes: 30

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -22,6 +22,28 @@ env:
   PLUGIN_EXAMPLE_SCOPE: "*share_plus_example*"
 
 jobs:
+  analyze:
+    name: "Dart Analyzer"
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout repository"
+        uses: actions/checkout@v4
+      - name: "Install Flutter"
+        run: ./.github/workflows/scripts/install-flutter.sh stable
+      - name: "Install Tools"
+        run: |
+          ./.github/workflows/scripts/install-tools.sh
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
+      - name: "Run Dart Analyze"
+        uses: invertase/github-action-dart-analyzer@v3
+        with:
+          fatal-infos: false
+          fatal-warnings: true
+          annotate: true
+          working-directory: ./packages/share_plus
+
   android_build:
     runs-on: macos-14
     timeout-minutes: 30


### PR DESCRIPTION
## Description

Don't see much value in `analyze` for all packages as it would be more appropriate to analyze every individual package when changed. Thus, modified workflows to do exactly this.
Didn't change `infos` to `fatal` state as it seemed too much, but maybe forcing even infos might be good to be sure that we and other contributors resolve lint issues right away.

## Related Issues

Part of #2775 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

