### PR TITLE
ci(all): Do not fail fast on Android integration tests failure

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -59,6 +59,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         android-api-level: [22, 26, 31, 34]
 

--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -59,6 +59,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         android-api-level: [ 22, 26, 31, 34 ]
 

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -63,6 +63,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         android-api-level: [ 22, 26, 31, 34 ]
 

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -63,6 +63,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         android-api-level: [ 21, 26, 31, 34]
 

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -63,6 +63,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         android-api-level: [ 22, 26, 31, 34 ]
 

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -62,6 +62,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         android-api-level: [ 22, 26, 31, 34 ]
 

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -63,6 +63,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         android-api-level: [ 22, 26, 31, 34 ]
 

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -59,6 +59,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         android-api-level: [ 22, 26, 31, 34 ]
 

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -62,6 +62,7 @@ jobs:
     runs-on: macos-13
     timeout-minutes: 30
     strategy:
+      fail-fast: false
       matrix:
         android-api-level: [ 22, 26, 31, 34 ]
 


### PR DESCRIPTION
## Description

This is a minor change to not automatically cancel all jobs in the integration tests matrix on Android as we currently have.
In most cases it is API 22 that causes the trouble, but I believe we are still interested in rest of APIs passing without the need to do some manual re-tries ourselves.
<img width="245" alt="Screenshot 2024-04-29 at 14 15 42" src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/761544e5-ec52-43cf-9692-efff1f3da1ff">

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

