### PR TITLE
chore(deps): revert bump com.android.application from 8.3.1 to 8.4.0 in android_alarm_manager_plus/example

### DIFF
--- a/packages/android_alarm_manager_plus/example/android/settings.gradle
+++ b/packages/android_alarm_manager_plus/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.4.0" apply false
+    id "com.android.application" version "8.3.1" apply false
     id "org.jetbrains.kotlin.android" version "1.9.23" apply false
 }
 


### PR DESCRIPTION
Reverts fluttercommunity/plus_plugins#2895

Reverting as it turned out that fresh AGP version requires newer Gradle version
<img width="727" alt="Screenshot 2024-05-03 at 11 45 00" src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/f0f9794d-1607-4ca8-83d4-750b7813edb2">
