### PR TITLE
chore(deps): revert bump com.android.tools.build:gradle from 8.3.1 to 8.4.0 network_info_plus

### DIFF
--- a/packages/network_info_plus/network_info_plus/android/build.gradle
+++ b/packages/network_info_plus/network_info_plus/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.4.0'
+        classpath 'com.android.tools.build:gradle:8.3.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }


### PR DESCRIPTION
Reverts fluttercommunity/plus_plugins#2894

Reverting as new AGP requires Gradle 8.6
<img width="727" alt="Screenshot 2024-05-03 at 11 45 00" src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/ea289c06-1848-414e-bc5a-c39598db4fc4">
