### PR TITLE
chore(all): Increase minSdk to 21 on all Android examples

### DIFF
--- a/packages/android_intent_plus/example/android/app/build.gradle
+++ b/packages/android_intent_plus/example/android/app/build.gradle
@@ -38,7 +38,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.androidintentexample"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         multiDexEnabled true
 

--- a/packages/battery_plus/battery_plus/example/android/app/build.gradle
+++ b/packages/battery_plus/battery_plus/example/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "io.flutter.plugins.batteryexample.example"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
@@ -42,7 +42,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.connectivityexample"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/device_info_plus/device_info_plus/example/android/app/build.gradle
+++ b/packages/device_info_plus/device_info_plus/example/android/app/build.gradle
@@ -46,7 +46,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.deviceinfoexample.example"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/network_info_plus/network_info_plus/example/android/app/build.gradle
+++ b/packages/network_info_plus/network_info_plus/example/android/app/build.gradle
@@ -41,7 +41,7 @@ android {
 
     defaultConfig {
         applicationId "dev.fluttercommunity.plus.network_info_plus_example"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/package_info_plus/package_info_plus/example/android/app/build.gradle
+++ b/packages/package_info_plus/package_info_plus/example/android/app/build.gradle
@@ -46,7 +46,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.packageinfoexample"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/sensors_plus/sensors_plus/example/android/app/build.gradle
+++ b/packages/sensors_plus/sensors_plus/example/android/app/build.gradle
@@ -41,7 +41,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.sensorsexample"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/packages/share_plus/share_plus/example/android/app/build.gradle
+++ b/packages/share_plus/share_plus/example/android/app/build.gradle
@@ -37,7 +37,7 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.shareexample"
-        minSdk 19
+        minSdk 21
         targetSdk 34
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName


### PR DESCRIPTION
## Description

`minSdk` must be `21` on Flutter  `3.22.0` since it is a requirement by `integration_test` package.

## Related Issues

- Some Dependabot PRs failed, e.g.: #2939 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

