### PR TITLE
 Android system cannot obtain AndroidID

### DIFF
--- a/packages/android_intent_plus/android/build.gradle
+++ b/packages/android_intent_plus/android/build.gradle
@@ -50,5 +50,5 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.11.0'
     testImplementation 'androidx.test:core:1.5.0'
-    testImplementation 'org.robolectric:robolectric:4.12.1'
+    testImplementation 'org.robolectric:robolectric:4.12'
 }

--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -8,6 +8,10 @@
 
 Get current device information from within the Flutter application.
 
+Add androidId to android device 
+针对Android系统部分手机获取不到AndroidID或者用户卸载后重新安装AndroidID改变的问题，插件做了SPUtil本地存储，卸载重装后会先取本地存储的值
+针对IOS系统，用户每次卸载重装都会得到不一样的UUID的问题，针对这个问题处理方案是把首次获取的UUID通过 keychain 存储下来，
+
 ## Platform Support
 
 | Android | iOS | MacOS | Web | Linux | Windows |

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
@@ -23,6 +23,7 @@ class DeviceInfoPlusPlugin : FlutterPlugin {
 
     private fun setupMethodChannel(messenger: BinaryMessenger, context: Context) {
         methodChannel = MethodChannel(messenger, "dev.fluttercommunity.plus/device_info")
+        App.context = context;
         val packageManager: PackageManager = context.packageManager
         val activityManager: ActivityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
         val handler = MethodCallHandlerImpl(packageManager, activityManager)

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
@@ -12,6 +12,9 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import kotlin.collections.HashMap
 
+import android.content.Context;
+
+
 /**
  * The implementation of [MethodChannel.MethodCallHandler] for the plugin. Responsible for
  * receiving method calls from method channel.
@@ -19,12 +22,12 @@ import kotlin.collections.HashMap
 internal class MethodCallHandlerImpl(
     private val packageManager: PackageManager,
     private val activityManager: ActivityManager,
+
 ) : MethodCallHandler {
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
         if (call.method.equals("getDeviceInfo")) {
             val build: MutableMap<String, Any> = HashMap()
-
             build["board"] = Build.BOARD
             build["bootloader"] = Build.BOOTLOADER
             build["brand"] = Build.BRAND
@@ -34,6 +37,7 @@ internal class MethodCallHandlerImpl(
             build["hardware"] = Build.HARDWARE
             build["host"] = Build.HOST
             build["id"] = Build.ID
+            build["androidId"] =SPUtils.getAndroidId()
             build["manufacturer"] = Build.MANUFACTURER
             build["model"] = Build.MODEL
             build["product"] = Build.PRODUCT

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/SPUtils.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/SPUtils.kt
@@ -1,0 +1,68 @@
+package dev.fluttercommunity.plus.device_info
+import android.annotation.SuppressLint
+
+import android.content.Context
+import android.provider.Settings
+import java.util.UUID
+
+@SuppressLint("StaticFieldLeak")
+object App{
+    lateinit var context: Context
+}
+
+object SPUtils {
+    val SP by lazy {
+        App.context.getSharedPreferences("default", Context.MODE_PRIVATE)
+    }
+
+    //读 SP 存储项
+    fun <T> getValue(key: String, default: T): T = with(SP) {
+        val res: Any = when (default) {
+            is Long -> getLong(key, default)
+            is String -> getString(key, default) ?: ""
+            is Int -> getInt(key, default)
+            is Boolean -> getBoolean(key, default)
+            is Float -> getFloat(key, default)
+            else -> throw java.lang.IllegalArgumentException()
+        }
+        @Suppress("UNCHECKED_CAST")
+        res as T
+    }
+
+    //写 SP 存储项
+    @SuppressLint("ApplySharedPref")
+    fun <T> putValue(key: String, value: T, isCommit: Boolean = false) = with(SP.edit()) {
+        val editor = when (value) {
+            is Long -> putLong(key, value)
+            is String -> putString(key, value)
+            is Int -> putInt(key, value)
+            is Boolean -> putBoolean(key, value)
+            is Float -> putFloat(key, value)
+            else -> throw IllegalArgumentException("This type can't be saved into Preferences")
+        }
+        if (isCommit) {
+            editor.commit()
+        } else {
+            editor.apply()
+        }
+
+    }
+
+
+    @SuppressLint("HardwareIds")
+     fun getAndroidId(): String {
+        var deviceId:String = SPUtils.getValue("deviceId","")
+        if (deviceId.isEmpty()){
+            val androidId = Settings.Secure.getString( App.context.contentResolver, Settings.Secure.ANDROID_ID)
+            if(androidId.isNullOrEmpty()){
+                val uuid = UUID.randomUUID().toString()
+                deviceId  =  uuid.replace("-","");
+            }else{
+                deviceId = androidId
+            }
+        }
+        SPUtils.putValue("deviceId", deviceId, false)
+        return  deviceId
+    }
+
+}

--- a/packages/device_info_plus/device_info_plus/ios/Classes/FPPDeviceInfoPlusPlugin.m
+++ b/packages/device_info_plus/device_info_plus/ios/Classes/FPPDeviceInfoPlusPlugin.m
@@ -4,7 +4,7 @@
 
 #import "FPPDeviceInfoPlusPlugin.h"
 #import <sys/utsname.h>
-
+#import "KeychainManager.h"
 @implementation FPPDeviceInfoPlusPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   FlutterMethodChannel *channel = [FlutterMethodChannel
@@ -30,6 +30,15 @@
       machine = [[NSProcessInfo processInfo]
           environment][@"SIMULATOR_MODEL_IDENTIFIER"];
     }
+      
+      
+      
+
+           NSString *uuid = [KeychainManager readDataFromKeyChain:@"UUID"];
+        if(!uuid){
+            uuid =  [[device identifierForVendor] UUIDString];
+            [KeychainManager saveDataForKeyChain:uuid identifier:@"UUID"];
+        }
 
     result(@{
       @"name" : [device name],
@@ -37,7 +46,7 @@
       @"systemVersion" : [device systemVersion],
       @"model" : [device model],
       @"localizedModel" : [device localizedModel],
-      @"identifierForVendor" : [[device identifierForVendor] UUIDString]
+      @"identifierForVendor" : uuid
           ?: [NSNull null],
       @"isPhysicalDevice" : isPhysicalNumber,
       @"utsname" : @{

--- a/packages/device_info_plus/device_info_plus/ios/Classes/KeychainManager.h
+++ b/packages/device_info_plus/device_info_plus/ios/Classes/KeychainManager.h
@@ -1,0 +1,47 @@
+//
+//  KeychainUUID.h
+//  Runner
+//
+//  Created by Kang on 2024/5/11.
+//
+
+#import <Foundation/Foundation.h>
+//
+NS_ASSUME_NONNULL_BEGIN
+
+@interface KeychainManager : NSObject
+
+//+ (instancetype)sharedManager;
+
+/*
+ 保存数据
+ 
+ @data  要存储的数据
+ @identifier 存储数据的标示
+ */
++(BOOL)saveDataForKeyChain:(id)data identifier:(NSString*)identifier;
+
+/*
+ 读取数据
+ 
+ @identifier 存储数据的标示
+ */
++(id)readDataFromKeyChain:(NSString*)identifier;
+
+/*
+ 更新数据
+ 
+ @data  要更新的数据
+ @identifier 数据存储时的标示
+ */
++(BOOL)updataForKeyChain:(id)data identifier:(NSString*)identifier;
+
+/*
+ 删除数据
+ 
+ @identifier 数据存储时的标示
+ */
++(BOOL)keyChainDelete:(NSString*)identifier;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/device_info_plus/device_info_plus/ios/Classes/KeychainManager.m
+++ b/packages/device_info_plus/device_info_plus/ios/Classes/KeychainManager.m
@@ -1,0 +1,143 @@
+//
+//  KeychainUUID.m
+//  Runner
+//
+//  Created by Kang on 2024/5/11.
+//
+
+#import "KeychainManager.h"
+//#import <Security/Security.h>
+@implementation KeychainManager
+
+//+ (instancetype)sharedManager {
+//    static dispatch_once_t onceToken;
+//    static KeychainSaveData *manager;
+//    dispatch_once(&onceToken, ^{
+//        manager = [[self alloc] initKeyChainManager];
+//    });
+//    return manager;
+//}
+
+//- (instancetype)init {
+//    NSAssert(NO, @"Singleton class, use shared method");
+//    return nil;
+//}
+
+//- (instancetype)initKeyChainManager {
+//    self = [super init];
+//    if (!self) return nil;
+//    return self;
+//}
+
+
++(NSMutableDictionary*)keyChainIdentifier:(NSString*)identifier
+{
+    NSMutableDictionary * keyChainInfo = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                                                       (id)kSecClassGenericPassword,kSecClass,
+                                                      [ [NSBundle mainBundle] bundleIdentifier],kSecAttrService,
+                                                       identifier,kSecAttrAccount,
+                                                       (id)kSecAttrAccessibleAfterFirstUnlock,kSecAttrAccessible, nil];
+    return keyChainInfo;
+}
+
+
+/*
+ 保存数据
+ 
+ @data  要存储的数据
+ @identifier 存储数据的唯一标示
+ */
++(BOOL)saveDataForKeyChain:(id)data identifier:(NSString*)identifier
+{
+    //获取存储数据的必要条件
+    NSMutableDictionary *saveQueryInfo = [self keyChainIdentifier:identifier];
+    //删除旧的数据
+    SecItemDelete((CFDictionaryRef)saveQueryInfo);
+    //设置需要存储的新的数据
+    [saveQueryInfo setObject:[NSKeyedArchiver archivedDataWithRootObject:data requiringSecureCoding:YES error:nil] forKey:(id)kSecValueData];
+//    [saveQueryInfo setObject:
+//     [NSKeyedArchiver archivedDataWithRootObject:data] forKey:(id)kSecValueData];
+    //添加数据，saveState返回添加数据是否成功状态
+    OSStatus saveState = SecItemAdd((CFDictionaryRef)saveQueryInfo, nil);
+    if (saveState == errSecSuccess) {
+        return YES;
+    }
+    return NO;
+}
+
+/*
+ 读取数据
+ 
+ @identifier 存储数据的标示
+ */
++(id)readDataFromKeyChain:(NSString*)identifier
+{
+    id objc = nil ;
+    //通过标记获取数据查询条件
+    NSMutableDictionary *readQueryInfo = [self keyChainIdentifier:identifier];
+    // 设置搜索条件：这是获取数据的时，必须提供的两个属性
+    // 查询结果返回类型为： kSecValueData
+    [readQueryInfo setObject:(id)kCFBooleanTrue forKey:(id)kSecReturnData];
+    // 只返回搜索到的第一条数据
+    [readQueryInfo setObject:(id)kSecMatchLimitOne forKey:(id)kSecMatchLimit];
+    // 创建一个数据对象
+    CFDataRef keyChainData = nil ;
+    // 通过条件查询数据
+    if (SecItemCopyMatching((CFDictionaryRef)readQueryInfo , (CFTypeRef *)&keyChainData) == noErr){
+        @try {
+            NSError *err = nil;
+            objc = [NSKeyedUnarchiver unarchivedObjectOfClasses:[NSSet setWithArray:@[NSArray.class,NSDictionary.class, NSString.class,NSMutableArray.class, NSMutableDictionary.class, NSMutableString.class, NSMutableData.class, NSData.class, NSNull.class, NSValue.class,NSDate.class]] fromData:(__bridge NSData *)(keyChainData) error:&err];
+                
+           /* [NSKeyedUnarchiver unarchiveObjectWithData:(__bridge NSData *)(keyChainData)]*/;
+        } @catch (NSException * exception){
+            NSLog(@"Unarchive of search data where %@ failed of %@ ",identifier,exception);
+        }
+    }
+    if (keyChainData) {
+        CFRelease(keyChainData);
+    }
+    return objc;
+}
+
+
+/*
+ 更新数据
+ 
+ @data  要更新的数据
+ @identifier 数据存储时的标示
+ */
++(BOOL)updataForKeyChain:(id)data identifier:(NSString*)identifier
+{
+    // 通过标记获取数据更新的必要条件
+    NSMutableDictionary * updataQueryInfo = [self keyChainIdentifier:identifier];
+    // 创建更新数据字典
+    NSMutableDictionary * updataInfo = [NSMutableDictionary dictionaryWithCapacity:0];
+    // 存储数据
+    [updataInfo setObject:[NSKeyedArchiver archivedDataWithRootObject:data requiringSecureCoding:YES error:nil] forKey:(id)kSecValueData];
+    // 获取更新存储的状态
+    OSStatus  updataStatus = SecItemUpdate((CFDictionaryRef)updataQueryInfo, (CFDictionaryRef)updataInfo);
+    if (updataStatus == errSecSuccess) {
+        return  YES ;
+    }
+    return NO;
+}
+
+/*
+ 删除数据
+ 
+ @identifier 数据存储时的标示
+ */
++(BOOL)keyChainDelete:(NSString*)identifier
+{
+    // 获取删除数据的查询条件
+    NSMutableDictionary * deleteQueryInfo = [self keyChainIdentifier:identifier];
+    // 删除指定条件的数据
+    OSStatus  updataStatus = SecItemDelete((CFDictionaryRef)deleteQueryInfo);
+    if (updataStatus == errSecSuccess) {
+        return  YES ;
+    }
+    return NO;
+}
+
+
+@end

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -32,6 +32,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
     required List<String> systemFeatures,
     required this.serialNumber,
     required this.isLowRamDevice,
+    required this.androidId,
   })  : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
         supported64BitAbis = List<String>.unmodifiable(supported64BitAbis),
         supportedAbis = List<String>.unmodifiable(supportedAbis),
@@ -76,6 +77,8 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
   /// Either a changelist number, or a label like "M4-rc20".
   /// https://developer.android.com/reference/android/os/Build#ID
   final String id;
+
+  final String androidId;
 
   /// The manufacturer of the product/hardware.
   /// https://developer.android.com/reference/android/os/Build#MANUFACTURER
@@ -167,6 +170,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
       systemFeatures: _fromList(map['systemFeatures'] ?? []),
       serialNumber: map['serialNumber'],
       isLowRamDevice: map['isLowRamDevice'],
+      androidId:  map['androidId'] ?? '',
     );
   }
 

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 10.1.0
+version: 10.1.3
 homepage: https://plus.fluttercommunity.dev/
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/device_info_plus/device_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus


### PR DESCRIPTION
## Description
Aiming at the problem that some phones of the Android system cannot obtain AndroidID or the user reinstalls AndroidID after uninstalling, the plugin makes SPUtil local storage, which will first take the local storage value after uninstalling and reinstalling 
For the IOS system, users will get a different UUID each time they uninstall and reinstall. The solution to this problem is to store the UUID obtained for the first time through the keychain.

