### PR TITLE
ci(android_intent_plus): fix example package name

### DIFF
--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -15,7 +15,7 @@ on:
 
 env:
   PLUGIN_SCOPE: "*android_intent_plus*"
-  PLUGIN_EXAMPLE_SCOPE: "*android_intent_example*"
+  PLUGIN_EXAMPLE_SCOPE: "*android_intent_plus_example*"
 
 jobs:
   analyze:

--- a/packages/android_intent_plus/example/integration_test/android_intent_plus_test.dart
+++ b/packages/android_intent_plus/example/integration_test/android_intent_plus_test.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:android_intent_example/main.dart';
+import 'package:android_intent_plus_example/main.dart';
 import 'package:android_intent_plus/android_intent.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/packages/android_intent_plus/example/pubspec.yaml
+++ b/packages/android_intent_plus/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: android_intent_example
+name: android_intent_plus_example
 description: Demonstrates how to use the android_intent plugin.
 
 environment:


### PR DESCRIPTION
Because `android_intent_example` doesn't match `android_intent_plus`, the package is not properly bootstraped by melos, and so PRs that change the package and example fail to build.