### PR TITLE
fix(package_info_plus): Address changed fields nullability on Android 15 (API 35)

### DIFF
--- a/packages/package_info_plus/package_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/packageinfo/PackageInfoPlugin.kt
+++ b/packages/package_info_plus/package_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/packageinfo/PackageInfoPlugin.kt
@@ -44,7 +44,7 @@ class PackageInfoPlugin : MethodCallHandler, FlutterPlugin {
                 infoMap.apply {
                     put("appName", info.applicationInfo?.loadLabel(packageManager)?.toString() ?: "")
                     put("packageName", applicationContext!!.packageName)
-                    put("version", info?.versionName ?: "")
+                    put("version", info.versionName ?: "")
                     put("buildNumber", getLongVersionCode(info).toString())
                     if (buildSignature != null) put("buildSignature", buildSignature)
                     if (installerPackage != null) put("installerStore", installerPackage)

--- a/packages/package_info_plus/package_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/packageinfo/PackageInfoPlugin.kt
+++ b/packages/package_info_plus/package_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/packageinfo/PackageInfoPlugin.kt
@@ -42,9 +42,9 @@ class PackageInfoPlugin : MethodCallHandler, FlutterPlugin {
 
                 val infoMap = HashMap<String, String>()
                 infoMap.apply {
-                    put("appName", info.applicationInfo.loadLabel(packageManager).toString())
+                    put("appName", info.applicationInfo?.loadLabel(packageManager)?.toString() ?: "")
                     put("packageName", applicationContext!!.packageName)
-                    put("version", info.versionName)
+                    put("version", info?.versionName ?: "")
                     put("buildNumber", getLongVersionCode(info).toString())
                     if (buildSignature != null) put("buildSignature", buildSignature)
                     if (installerPackage != null) put("installerStore", installerPackage)
@@ -105,7 +105,7 @@ class PackageInfoPlugin : MethodCallHandler, FlutterPlugin {
                 )
                 val signatures = packageInfo.signatures
 
-                if (signatures.isNullOrEmpty() || packageInfo.signatures.first() == null) {
+                if (signatures.isNullOrEmpty() || signatures.first() == null) {
                     null
                 } else {
                     signatureToSha256(signatures.first().toByteArray())


### PR DESCRIPTION
## Description

This plugin fails to compile with the latest nullability signatures for Android 35

The compilation error messages are:

```
PackageInfoPlugin.kt:45:56: error: [UNSAFE_CALL] Only safe (?.) or non-null asserted (!!.) calls are allowed on a nullable receiver of type ApplicationInfo?
                    put("appName", info.applicationInfo.loadLabel(packageManager).toString())
                                                       ^
PackageInfoPlugin.kt:47:36: error: [TYPE_MISMATCH] Type mismatch: inferred type is String? but String was expected
                    put("version", info.versionName)
                                   ^^^^^^^^^^^^^^^^
PackageInfoPlugin.kt:108:51: error: [SMARTCAST_IMPOSSIBLE] Smart cast to 'Array<(out) Signature!>' is impossible, because 'packageInfo.signatures' is a mutable property that could have been changed by this time
                if (signatures.isNullOrEmpty() || packageInfo.signatures.first() == null) {
```

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

