### PR TITLE
ci(android_alarm_manager_plus): fix example package name

### DIFF
--- a/packages/android_alarm_manager_plus/example/integration_test/android_alarm_manager_plus_test.dart
+++ b/packages/android_alarm_manager_plus/example/integration_test/android_alarm_manager_plus_test.dart
@@ -5,7 +5,7 @@
 import 'dart:isolate';
 import 'dart:ui';
 
-import 'package:android_alarm_manager_example/main.dart';
+import 'package:android_alarm_manager_plus_example/main.dart';
 import 'package:android_alarm_manager_plus/android_alarm_manager_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/android_alarm_manager_plus/example/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/example/pubspec.yaml
@@ -1,4 +1,4 @@
-name: android_alarm_manager_example
+name: android_alarm_manager_plus_example
 description: Demonstrates how to use the android_alarm_manager_plus plugin.
 
 environment:


### PR DESCRIPTION
## Description

Fix similar to #2973 as we had the same problem for the `android_alarm_manager_plus` (for example, issue is mentioned here https://github.com/fluttercommunity/plus_plugins/pull/2898#issuecomment-2089880624) plugin as well with bootstrapping and building the example app on CI.


