### PR TITLE
fix(sensors_plus): corrected iOS magnetometer source

### DIFF
--- a/packages/sensors_plus/sensors_plus/ios/Classes/FPPStreamHandlerPlus.swift
+++ b/packages/sensors_plus/sensors_plus/ios/Classes/FPPStreamHandlerPlus.swift
@@ -192,7 +192,10 @@ class FPPMagnetometerStreamHandlerPlus: NSObject, MotionStreamHandler {
             eventSink sink: @escaping FlutterEventSink
     ) -> FlutterError? {
         _initMotionManager()
-        _motionManager.startMagnetometerUpdates(to: OperationQueue()) { data, error in
+        _motionManager.showsDeviceMovementDisplay = true
+        _motionManager.startDeviceMotionUpdates(
+            using: CMAttitudeReferenceFrame.xArbitraryCorrectedZVertical, to: OperationQueue()
+        ) { data, error in
             if _isCleanUp {
                 return
             }
@@ -204,7 +207,7 @@ class FPPMagnetometerStreamHandlerPlus: NSObject, MotionStreamHandler {
                 ))
                 return
             }
-            let magneticField = data!.magneticField
+            let magneticField = data!.magneticField.field
             sendTriplet(x: magneticField.x, y: magneticField.y, z: magneticField.z, sink: sink)
         }
         return nil


### PR DESCRIPTION
Obtain magnetometer events from DeviceMotion rather than raw startMagnetometerUpdates(). This also makes the magnetometer onCancel() method now correct.<sup>1</sup> Added set `showsDeviceMovementDisplay` to true for magnetometer.

<sup>1</sup> While working on the changes, I noticed the current implementation in `onCancel()` calls `_motionManager.stopDeviceMotionUpdates()`. This is interesting, because the correct course *is to obtain* events from MotionManager, but the current implementation is not. Because it currently calls `startMagnetometerUpdates()`, the `onCancel()` method ought to call `stopMagnetometerUpdates()`. Current users of sensors_plus, after obtaining magnetometer readings, could never have the sensor correctly canceled, [to my understanding](https://developer.apple.com/documentation/coremotion/cmmotionmanager/1615968-startmagnetometerupdatestoqueue#discussion).

At any rate, the onCancel gets to stay as it is while the source of the events is corrected.

## Description

When this package was converted to Swift, a [previous fix that corrected magnetometer](https://github.com/fluttercommunity/plus_plugins/pull/812) source to `DeviceMotion` was reverted to using `startMagnetometerUpdates()`.

This pull aims to restore the calibrated magnetometer readings that users are expecting.

As before, I have no way to test this code (no iOS device), and would appreciate someone's assitance in verifying the functionality.

## Related Issues

- *Fix #2655*
- *Refix #781*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.
  - Fixes incorrect behavior with no API changes.

