### PR TITLE
fix(android_intent_plus): remove package name from AndroidManifest

### DIFF
--- a/packages/android_intent_plus/android/src/main/AndroidManifest.xml
+++ b/packages/android_intent_plus/android/src/main/AndroidManifest.xml
@@ -1,1 +1,1 @@
-<manifest package="dev.fluttercommunity.plus.androidintent"/>
+<manifest />


### PR DESCRIPTION
## Description

In gradle 8 ou higher setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.

## Related Issues

*[Question]: #2611 


## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.


