### PR TITLE
feat(share_plus)!: Introduce optional parameter `nameOverride` to `shareXFiles`.

### DIFF
--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -103,7 +103,7 @@ Share.shareXFiles([XFile('assets/hello.txt')], text: 'Great picture');
 
 #### Share Data
 
-You can also share files that you dynamically generated from its data using [`XFile.fromData`](https://pub.dev/documentation/share_plus/latest/share_plus/XFile/XFile.fromData.html).
+You can also share files that you dynamically generate from its data using [`XFile.fromData`](https://pub.dev/documentation/share_plus/latest/share_plus/XFile/XFile.fromData.html).
 
 To set the name of these files, use the `fileNameOverrides` parameter, otherwise the file name will be a random UUID string.
 

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -90,7 +90,7 @@ if (result.status == ShareResultStatus.dismissed) {
 }
 ```
 
-On web, you can use `SharePlus.shareXFiles()`. This uses the [Web Share API](https://web.dev/web-share/)
+On web, this uses the [Web Share API](https://web.dev/web-share/)
 if it's available. Otherwise it falls back to downloading the shared files.
 See [Can I Use - Web Share API](https://caniuse.com/web-share) to understand
 which browsers are supported. This builds on the [`cross_file`](https://pub.dev/packages/cross_file)
@@ -101,13 +101,18 @@ package.
 Share.shareXFiles([XFile('assets/hello.txt')], text: 'Great picture');
 ```
 
-#### Share data as Files
+#### Share Data
 
 You can also share files that you dynamically generated from its data using [`XFile.fromData`](https://pub.dev/documentation/share_plus/latest/share_plus/XFile/XFile.fromData.html).
+
 To set the name of these files, use the `fileNameOverrides` parameter, otherwise the file name will be a random UUID string.
+
 ```dart
 Share.shareXFiles([XFile.fromData(utf8.encode(text), mimeType: 'text/plain')], fileNameOverrides: ['myfile.txt']);
 ```
+
+> [!CAUTION]
+> The `name` parameter in the `XFile.fromData` method is ignored in most platforms. Use `fileNameOverrides` instead.
 
 ### Share URI
 

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -101,6 +101,14 @@ package.
 Share.shareXFiles([XFile('assets/hello.txt')], text: 'Great picture');
 ```
 
+#### Share data as Files
+
+You can also share files that you dynamically generated from its data using [`XFile.fromData`](https://pub.dev/documentation/share_plus/latest/share_plus/XFile/XFile.fromData.html).
+To set the name of these files, use the `fileNameOverrides` parameter, otherwise the file name will be a random UUID string.
+```dart
+Share.shareXFiles([XFile.fromData(utf8.encode(text), mimeType: 'text/plain')], fileNameOverrides: ['myfile.txt']);
+```
+
 ### Share URI
 
 iOS supports fetching metadata from a URI when shared using `UIActivityViewController`.

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -105,7 +105,7 @@ Share.shareXFiles([XFile('assets/hello.txt')], text: 'Great picture');
 
 You can also share files that you dynamically generate from its data using [`XFile.fromData`](https://pub.dev/documentation/share_plus/latest/share_plus/XFile/XFile.fromData.html).
 
-To set the name of these files, use the `fileNameOverrides` parameter, otherwise the file name will be a random UUID string.
+To set the name of such files, use the `fileNameOverrides` parameter, otherwise the file name will be a random UUID string.
 
 ```dart
 Share.shareXFiles([XFile.fromData(utf8.encode(text), mimeType: 'text/plain')], fileNameOverrides: ['myfile.txt']);

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -256,6 +256,7 @@ class DemoAppState extends State<DemoApp> {
 
     scaffoldMessenger.showSnackBar(getResultSnackBar(shareResult));
   }
+
   void _onShareTextAsXFile(BuildContext context) async {
     final box = context.findRenderObject() as RenderBox?;
     final scaffoldMessenger = ScaffoldMessenger.of(context);

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: public_member_api_docs
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:file_selector/file_selector.dart'
@@ -32,6 +33,7 @@ class DemoAppState extends State<DemoApp> {
   String text = '';
   String subject = '';
   String uri = '';
+  String fileName = '';
   List<String> imageNames = [];
   List<String> imagePaths = [];
 
@@ -87,6 +89,18 @@ class DemoAppState extends State<DemoApp> {
                 maxLines: null,
                 onChanged: (String value) {
                   setState(() => uri = value);
+                },
+              ),
+              const SizedBox(height: 16),
+              TextField(
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Share Filename',
+                  hintText: 'Enter the filename you want to share your text as',
+                ),
+                maxLines: null,
+                onChanged: (String value) {
+                  setState(() => fileName = value);
                 },
               ),
               const SizedBox(height: 16),
@@ -157,6 +171,21 @@ class DemoAppState extends State<DemoApp> {
                   );
                 },
               ),
+              const SizedBox(height: 16),
+              Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                    ),
+                    onPressed: fileName.isEmpty || text.isEmpty
+                        ? null
+                        : () => _onShareTextAsXFile(context),
+                    child: const Text('Share text as XFile'),
+                  );
+                },
+              ),
             ],
           ),
         ),
@@ -223,6 +252,24 @@ class DemoAppState extends State<DemoApp> {
         ),
       ],
       sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+    );
+
+    scaffoldMessenger.showSnackBar(getResultSnackBar(shareResult));
+  }
+  void _onShareTextAsXFile(BuildContext context) async {
+    final box = context.findRenderObject() as RenderBox?;
+    final scaffoldMessenger = ScaffoldMessenger.of(context);
+    final data = utf8.encode(text);
+    final shareResult = await Share.shareXFiles(
+      [
+        XFile.fromData(
+          data,
+          // name: fileName, // Notice, how setting the name here does not work.
+          mimeType: 'text/plain',
+        ),
+      ],
+      sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+      fileNameOverrides: [fileName],
     );
 
     scaffoldMessenger.showSnackBar(getResultSnackBar(shareResult));

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -95,7 +95,7 @@ class DemoAppState extends State<DemoApp> {
               TextField(
                 decoration: const InputDecoration(
                   border: OutlineInputBorder(),
-                  labelText: 'Share Filename',
+                  labelText: 'Share Text as File',
                   hintText: 'Enter the filename you want to share your text as',
                 ),
                 maxLines: null,

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -111,6 +111,12 @@ class Share {
   /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
   /// on other devices.
   ///
+  /// The optional parameter [fileNameOverrides] can be used to override the file names
+  /// used for the shared files.
+  /// If set, the length must match the length of [files].
+  /// This is useful when sharing files that were created by [`XFile.fromData`](https://github.com/flutter/packages/blob/754de1918a339270b70971b6841cf1e04dd71050/packages/cross_file/lib/src/types/io.dart#L43),
+  /// because name property will be ignored by  [`cross_file`](https://pub.dev/packages/cross_file) on all platforms except on web.
+  ///
   /// May throw [PlatformException] or [FormatException]
   /// from [MethodChannel].
   ///
@@ -120,6 +126,7 @@ class Share {
     String? subject,
     String? text,
     Rect? sharePositionOrigin,
+    List<String>? fileNameOverrides,
   }) async {
     assert(files.isNotEmpty);
     return _platform.shareXFiles(
@@ -127,6 +134,7 @@ class Share {
       subject: subject,
       text: text,
       sharePositionOrigin: sharePositionOrigin,
+      fileNameOverrides: fileNameOverrides,
     );
   }
 }

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -112,7 +112,7 @@ class Share {
   /// on other devices.
   ///
   /// The optional parameter [fileNameOverrides] can be used to override the names of shared files
-  /// If set, the length must match the length of [files].
+  /// When set, the list length must match the number of [files] to share.
   /// This is useful when sharing files that were created by [`XFile.fromData`](https://github.com/flutter/packages/blob/754de1918a339270b70971b6841cf1e04dd71050/packages/cross_file/lib/src/types/io.dart#L43),
   /// because name property will be ignored by  [`cross_file`](https://pub.dev/packages/cross_file) on all platforms except on web.
   ///

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -111,8 +111,7 @@ class Share {
   /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
   /// on other devices.
   ///
-  /// The optional parameter [fileNameOverrides] can be used to override the file names
-  /// used for the shared files.
+  /// The optional parameter [fileNameOverrides] can be used to override the names of shared files
   /// If set, the length must match the length of [files].
   /// This is useful when sharing files that were created by [`XFile.fromData`](https://github.com/flutter/packages/blob/754de1918a339270b70971b6841cf1e04dd71050/packages/cross_file/lib/src/types/io.dart#L43),
   /// because name property will be ignored by  [`cross_file`](https://pub.dev/packages/cross_file) on all platforms except on web.

--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -68,6 +68,7 @@ class SharePlusLinuxPlugin extends SharePlatform {
     String? subject,
     String? text,
     Rect? sharePositionOrigin,
+    List<String>? fileNameOverrides,
   }) {
     throw UnimplementedError(
       'shareXFiles() has not been implemented on Linux.',

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -161,15 +161,10 @@ class SharePlusWebPlugin extends SharePlatform {
     assert(
         fileNameOverrides == null || files.length == fileNameOverrides.length);
     final webFiles = <web.File>[];
-    if (fileNameOverrides != null) {
-      for (final entry in files.asMap().entries) {
-        webFiles.add(await _fromXFile(entry.value,
-            nameOverride: fileNameOverrides[entry.key]));
-      }
-    } else {
-      for (final xFile in files) {
-        webFiles.add(await _fromXFile(xFile));
-      }
+    for (var index = 0; index < files.length; index++) {
+      final xFile = files[index];
+      final filename = fileNameOverrides?.elementAt(index);
+      webFiles.add(await _fromXFile(xFile, nameOverride: filename));
     }
 
     final ShareData data;

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -156,10 +156,19 @@ class SharePlusWebPlugin extends SharePlatform {
     String? subject,
     String? text,
     Rect? sharePositionOrigin,
+    List<String>? fileNameOverrides,
   }) async {
+    assert(fileNameOverrides == null || files.length == fileNameOverrides.length);
     final webFiles = <web.File>[];
-    for (final xFile in files) {
-      webFiles.add(await _fromXFile(xFile));
+    if (fileNameOverrides != null) {
+      for (final entry in files.asMap().entries) {
+        webFiles.add(await _fromXFile(entry.value,
+            nameOverride: fileNameOverrides[entry.key]));
+      }
+    } else {
+      for (final xFile in files) {
+        webFiles.add(await _fromXFile(xFile));
+      }
     }
 
     final ShareData data;
@@ -222,11 +231,11 @@ class SharePlusWebPlugin extends SharePlatform {
     }
   }
 
-  static Future<web.File> _fromXFile(XFile file) async {
+  static Future<web.File> _fromXFile(XFile file, {String? nameOverride}) async {
     final bytes = await file.readAsBytes();
     return web.File(
       [bytes.buffer.toJS].toJS,
-      file.name,
+      nameOverride ?? file.name,
       web.FilePropertyBag()
         ..type = file.mimeType ?? _mimeTypeForPath(file, bytes),
     );

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -158,7 +158,8 @@ class SharePlusWebPlugin extends SharePlatform {
     Rect? sharePositionOrigin,
     List<String>? fileNameOverrides,
   }) async {
-    assert(fileNameOverrides == null || files.length == fileNameOverrides.length);
+    assert(
+        fileNameOverrides == null || files.length == fileNameOverrides.length);
     final webFiles = <web.File>[];
     if (fileNameOverrides != null) {
       for (final entry in files.asMap().entries) {

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -73,6 +73,7 @@ class SharePlusWindowsPlugin extends SharePlatform {
     String? subject,
     String? text,
     Rect? sharePositionOrigin,
+    List<String>? fileNameOverrides,
   }) {
     throw UnimplementedError(
       'shareXFiles() is only available for Windows versions higher than 10.0.${VersionHelper.kWindows10RS5BuildNumber}.',

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -145,7 +145,7 @@ class MethodChannelShare extends SharePlatform {
       final tempSubfolderPath = "$tempRoot/${const Uuid().v4()}";
       await Directory(tempSubfolderPath).create(recursive: true);
 
-      // True if filename exists, or the filename has a valid extension
+      // True if filename exists or the filename has a valid extension
       final filenameNotEmptyOrHasValidExt =
           file.name.isNotEmpty || lookupMimeType(file.name) != null;
 

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -79,7 +79,8 @@ class MethodChannelShare extends SharePlatform {
     List<String>? fileNameOverrides,
   }) async {
     assert(files.isNotEmpty);
-    assert(fileNameOverrides == null || files.length == fileNameOverrides.length);
+    assert(
+        fileNameOverrides == null || files.length == fileNameOverrides.length);
     final filesWithPath = await _getFiles(files, fileNameOverrides);
     assert(filesWithPath.every((element) => element.path.isNotEmpty));
 
@@ -118,7 +119,8 @@ class MethodChannelShare extends SharePlatform {
   /// then make new file in TemporaryDirectory and return with path
   /// the system will automatically delete files in this
   /// TemporaryDirectory as disk space is needed elsewhere on the device
-  Future<XFile> _getFile(XFile file, {String? tempRoot, String? nameOverride}) async {
+  Future<XFile> _getFile(XFile file,
+      {String? tempRoot, String? nameOverride}) async {
     if (file.path.isNotEmpty) {
       return file;
     } else {
@@ -140,12 +142,13 @@ class MethodChannelShare extends SharePlatform {
 
       //Per Issue [#3032](https://github.com/fluttercommunity/plus_plugins/issues/3032): use overriden name when avaiable.
       //Per Issue [#1548](https://github.com/fluttercommunity/plus_plugins/issues/1548): attempt to use XFile.name when available
-      final filename = nameOverride ?? (file.name.isNotEmpty // If filename exists
-              ||
-              lookupMimeType(file.name) !=
-                  null //If the filename has a valid extension
-          ? file.name
-          : "${const Uuid().v1().substring(10)}.$extension");
+      final filename = nameOverride ??
+          (file.name.isNotEmpty // If filename exists
+                  ||
+                  lookupMimeType(file.name) !=
+                      null //If the filename has a valid extension
+              ? file.name
+              : "${const Uuid().v1().substring(10)}.$extension");
 
       final path = "$tempSubfolderPath/$filename";
 
@@ -157,7 +160,8 @@ class MethodChannelShare extends SharePlatform {
   }
 
   /// A wrapper of [MethodChannelShare._getFile] for multiple files.
-  Future<List<XFile>> _getFiles(List<XFile> files, List<String>? fileNameOverrides) async =>
+  Future<List<XFile>> _getFiles(
+          List<XFile> files, List<String>? fileNameOverrides) async =>
       (fileNameOverrides == null)
           ? await Future.wait(files.map((entry) => _getFile(entry)))
           : await Future.wait(files.asMap().entries.map((entry) => _getFile(

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -80,7 +80,9 @@ class MethodChannelShare extends SharePlatform {
   }) async {
     assert(files.isNotEmpty);
     assert(
-        fileNameOverrides == null || files.length == fileNameOverrides.length);
+      fileNameOverrides == null || files.length == fileNameOverrides.length,
+      "fileNameOverrides list must be equal size as file list.",
+    );
     final filesWithPath = await _getFiles(files, fileNameOverrides);
     assert(filesWithPath.every((element) => element.path.isNotEmpty));
 
@@ -121,7 +123,7 @@ class MethodChannelShare extends SharePlatform {
   /// TemporaryDirectory as disk space is needed elsewhere on the device
   Future<XFile> _getFile(
     XFile file, {
-    String? tempRoot, 
+    String? tempRoot,
     String? nameOverride,
   }) async {
     if (file.path.isNotEmpty) {
@@ -165,14 +167,17 @@ class MethodChannelShare extends SharePlatform {
 
   /// A wrapper of [MethodChannelShare._getFile] for multiple files.
   Future<List<XFile>> _getFiles(
-    List<XFile> files, 
+    List<XFile> files,
     List<String>? fileNameOverrides,
-  ) async =>
-      (fileNameOverrides == null)
-          ? await Future.wait(files.map((entry) => _getFile(entry)))
-          : await Future.wait(files.asMap().entries.map((entry) => _getFile(
-              entry.value,
-              nameOverride: fileNameOverrides[entry.key])));
+  ) async {
+    return Future.wait([
+      for (var index = 1; index < files.length; index++)
+        _getFile(
+          files[index],
+          nameOverride: fileNameOverrides?.elementAt(index),
+        )
+    ]);
+  }
 
   static String _mimeTypeForPath(String path) {
     return lookupMimeType(path) ?? 'application/octet-stream';

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -81,7 +81,7 @@ class MethodChannelShare extends SharePlatform {
     assert(files.isNotEmpty);
     assert(
       fileNameOverrides == null || files.length == fileNameOverrides.length,
-      "fileNameOverrides list must be equal size as file list.",
+      "fileNameOverrides list must have the same length as files list.",
     );
     final filesWithPath = await _getFiles(files, fileNameOverrides);
     assert(filesWithPath.every((element) => element.path.isNotEmpty));

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -119,8 +119,11 @@ class MethodChannelShare extends SharePlatform {
   /// then make new file in TemporaryDirectory and return with path
   /// the system will automatically delete files in this
   /// TemporaryDirectory as disk space is needed elsewhere on the device
-  Future<XFile> _getFile(XFile file,
-      {String? tempRoot, String? nameOverride}) async {
+  Future<XFile> _getFile(
+    XFile file, {
+    String? tempRoot, 
+    String? nameOverride,
+  }) async {
     if (file.path.isNotEmpty) {
       return file;
     } else {
@@ -162,7 +165,9 @@ class MethodChannelShare extends SharePlatform {
 
   /// A wrapper of [MethodChannelShare._getFile] for multiple files.
   Future<List<XFile>> _getFiles(
-          List<XFile> files, List<String>? fileNameOverrides) async =>
+    List<XFile> files, 
+    List<String>? fileNameOverrides,
+  ) async =>
       (fileNameOverrides == null)
           ? await Future.wait(files.map((entry) => _getFile(entry)))
           : await Future.wait(files.asMap().entries.map((entry) => _getFile(

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -76,10 +76,11 @@ class MethodChannelShare extends SharePlatform {
     String? subject,
     String? text,
     Rect? sharePositionOrigin,
+    List<String>? fileNameOverrides,
   }) async {
     assert(files.isNotEmpty);
-
-    final filesWithPath = await _getFiles(files);
+    assert(fileNameOverrides == null || files.length == fileNameOverrides.length);
+    final filesWithPath = await _getFiles(files, fileNameOverrides);
     assert(filesWithPath.every((element) => element.path.isNotEmpty));
 
     final mimeTypes = filesWithPath
@@ -117,7 +118,7 @@ class MethodChannelShare extends SharePlatform {
   /// then make new file in TemporaryDirectory and return with path
   /// the system will automatically delete files in this
   /// TemporaryDirectory as disk space is needed elsewhere on the device
-  Future<XFile> _getFile(XFile file, {String? tempRoot}) async {
+  Future<XFile> _getFile(XFile file, {String? tempRoot, String? nameOverride}) async {
     if (file.path.isNotEmpty) {
       return file;
     } else {
@@ -137,13 +138,14 @@ class MethodChannelShare extends SharePlatform {
       final tempSubfolderPath = "$tempRoot/${const Uuid().v4()}";
       await Directory(tempSubfolderPath).create(recursive: true);
 
+      //Per Issue [#3032](https://github.com/fluttercommunity/plus_plugins/issues/3032): use overriden name when avaiable.
       //Per Issue [#1548](https://github.com/fluttercommunity/plus_plugins/issues/1548): attempt to use XFile.name when available
-      final filename = file.name.isNotEmpty // If filename exists
+      final filename = nameOverride ?? (file.name.isNotEmpty // If filename exists
               ||
               lookupMimeType(file.name) !=
                   null //If the filename has a valid extension
           ? file.name
-          : "${const Uuid().v1().substring(10)}.$extension";
+          : "${const Uuid().v1().substring(10)}.$extension");
 
       final path = "$tempSubfolderPath/$filename";
 
@@ -155,8 +157,12 @@ class MethodChannelShare extends SharePlatform {
   }
 
   /// A wrapper of [MethodChannelShare._getFile] for multiple files.
-  Future<List<XFile>> _getFiles(List<XFile> files) async =>
-      await Future.wait(files.map((entry) => _getFile(entry)));
+  Future<List<XFile>> _getFiles(List<XFile> files, List<String>? fileNameOverrides) async =>
+      (fileNameOverrides == null)
+          ? await Future.wait(files.map((entry) => _getFile(entry)))
+          : await Future.wait(files.asMap().entries.map((entry) => _getFile(
+              entry.value,
+              nameOverride: fileNameOverrides[entry.key])));
 
   static String _mimeTypeForPath(String path) {
     return lookupMimeType(path) ?? 'application/octet-stream';

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -140,13 +140,14 @@ class MethodChannelShare extends SharePlatform {
       final tempSubfolderPath = "$tempRoot/${const Uuid().v4()}";
       await Directory(tempSubfolderPath).create(recursive: true);
 
-      //Per Issue [#3032](https://github.com/fluttercommunity/plus_plugins/issues/3032): use overriden name when avaiable.
+      // True if filename exists, or the filename has a valid extension
+      final filenameNotEmptyOrHasValidExt =
+          file.name.isNotEmpty || lookupMimeType(file.name) != null;
+
+      //Per Issue [#3032](https://github.com/fluttercommunity/plus_plugins/issues/3032): use overridden name when available.
       //Per Issue [#1548](https://github.com/fluttercommunity/plus_plugins/issues/1548): attempt to use XFile.name when available
       final filename = nameOverride ??
-          (file.name.isNotEmpty // If filename exists
-                  ||
-                  lookupMimeType(file.name) !=
-                      null //If the filename has a valid extension
+          (filenameNotEmptyOrHasValidExt
               ? file.name
               : "${const Uuid().v1().substring(10)}.$extension");
 

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -171,7 +171,7 @@ class MethodChannelShare extends SharePlatform {
     List<String>? fileNameOverrides,
   ) async {
     return Future.wait([
-      for (var index = 1; index < files.length; index++)
+      for (var index = 0; index < files.length; index++)
         _getFile(
           files[index],
           nameOverride: fileNameOverrides?.elementAt(index),

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -61,12 +61,14 @@ class SharePlatform extends PlatformInterface {
     String? subject,
     String? text,
     Rect? sharePositionOrigin,
+    List<String>? fileNameOverrides,
   }) async {
     return _instance.shareXFiles(
       files,
       subject: subject,
       text: text,
       sharePositionOrigin: sharePositionOrigin,
+      fileNameOverrides: fileNameOverrides,
     );
   }
 }


### PR DESCRIPTION
## Description

* Adds parameter `nameOverride` to funciton `shareXFiles`
* If set the values in  `nameOverride` will be used as the file names for the files share
* Also added new button in example that demonstrates this behavior.
* This is needed because `XFile.fromData` ignores `name` parameter on platforms other than web.

## Related Issues
- *Fix #3032*
- *Related #1548*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

