### PR TITLE
feat(sensors_plus)!: add barometer support for all platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ package, such as CFBundleVersion on iOS or versionCode on Android.
 
 > [![sensors_plus][sensors_plus_badge_pub]][sensors_plus] [![pub points][sensors_plus_badge_pub_points]][sensors_plus_pub_points]
 
-Flutter plugin for accessing accelerometer, gyroscope, and magnetometer sensors.
+Flutter plugin for accessing accelerometer, gyroscope, magnetometer and barometer sensors.
 
 [[View Source][sensors_plus_code]]
 

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -6,8 +6,8 @@
 
 [<img src="../../../assets/flutter-favorite-badge.png" width="100" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
 
-A Flutter plugin to access the accelerometer, gyroscope, and magnetometer
-sensors.
+A Flutter plugin to access the accelerometer, gyroscope, magnetometer and 
+barometer sensors.
 
 ## Platform Support
 
@@ -54,9 +54,11 @@ This will expose such classes of sensor events through a set of streams:
 - `GyroscopeEvent` describes the rotation of the device.
 - `MagnetometerEvent` describes the ambient magnetic field surrounding the
   device. A compass is an example usage of this data.
+- `BarometerEvent` describes the atmospheric pressure surrounding the device. 
+  An altimeter is an example usage of this data.
 
 These events are exposed through a `BroadcastStream`: `accelerometerEvents`,
-`userAccelerometerEvents`, `gyroscopeEvents`, and `magnetometerEvents`,
+`userAccelerometerEvents`, `gyroscopeEvents`, `magnetometerEvents`, and `barometerEvents`,
 respectively.
 
 > [!NOTE]
@@ -116,6 +118,18 @@ magnetometerEvents.listen(
   cancelOnError: true,
 );
 // [MagnetometerEvent (x: -23.6, y: 6.2, z: -34.9)]
+
+barometerEvents.listen(
+  (BarometerEvent event) {
+    print(event);
+  },
+  onError: (error) {
+    // Logic to handle error
+    // Needed for Android in case sensor is not available
+    },
+  cancelOnError: true,
+);
+// [BarometerEvent (pressure: 1000.0)]
 ```
 
 Alternatively, every stream allows to specify the sampling rate for its sensor using one of predefined constants or using a custom value

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -55,7 +55,7 @@ This will expose such classes of sensor events through a set of streams:
 - `MagnetometerEvent` describes the ambient magnetic field surrounding the
   device. A compass is an example usage of this data.
 - `BarometerEvent` describes the atmospheric pressure surrounding the device. 
-  An altimeter is an example usage of this data.
+  An altimeter is an example usage of this data. Not supported on web browsers.
 
 These events are exposed through a `BroadcastStream`: `accelerometerEvents`,
 `userAccelerometerEvents`, `gyroscopeEvents`, `magnetometerEvents`, and `barometerEvents`,

--- a/packages/sensors_plus/sensors_plus/android/src/main/kotlin/dev/fluttercommunity/plus/sensors/SensorsPlugin.kt
+++ b/packages/sensors_plus/sensors_plus/android/src/main/kotlin/dev/fluttercommunity/plus/sensors/SensorsPlugin.kt
@@ -17,11 +17,13 @@ class SensorsPlugin : FlutterPlugin {
     private lateinit var userAccelChannel: EventChannel
     private lateinit var gyroscopeChannel: EventChannel
     private lateinit var magnetometerChannel: EventChannel
+    private lateinit var barometerChannel: EventChannel
 
     private lateinit var accelerometerStreamHandler: StreamHandlerImpl
     private lateinit var userAccelStreamHandler: StreamHandlerImpl
     private lateinit var gyroscopeStreamHandler: StreamHandlerImpl
     private lateinit var magnetometerStreamHandler: StreamHandlerImpl
+    private lateinit var barometerStreamHandler: StreamHandlerImpl
 
     override fun onAttachedToEngine(binding: FlutterPluginBinding) {
         setupMethodChannel(binding.binaryMessenger)
@@ -41,6 +43,7 @@ class SensorsPlugin : FlutterPlugin {
                 "setUserAccelerometerSamplingPeriod" -> userAccelStreamHandler
                 "setGyroscopeSamplingPeriod" -> gyroscopeStreamHandler
                 "setMagnetometerSamplingPeriod" -> magnetometerStreamHandler
+                "setBarometerSamplingPeriod" -> barometerStreamHandler
                 else -> null
             }
             streamHandler?.samplingPeriod = call.arguments as Int
@@ -86,6 +89,13 @@ class SensorsPlugin : FlutterPlugin {
             Sensor.TYPE_MAGNETIC_FIELD
         )
         magnetometerChannel.setStreamHandler(magnetometerStreamHandler)
+
+        barometerChannel = EventChannel(messenger, BAROMETER_CHANNEL_NAME)
+        barometerStreamHandler = StreamHandlerImpl(
+            sensorsManager,
+            Sensor.TYPE_PRESSURE
+        )
+        barometerChannel.setStreamHandler(barometerStreamHandler)
     }
 
     private fun teardownEventChannels() {
@@ -93,11 +103,13 @@ class SensorsPlugin : FlutterPlugin {
         userAccelChannel.setStreamHandler(null)
         gyroscopeChannel.setStreamHandler(null)
         magnetometerChannel.setStreamHandler(null)
+        barometerChannel.setStreamHandler(null)
 
         accelerometerStreamHandler.onCancel(null)
         userAccelStreamHandler.onCancel(null)
         gyroscopeStreamHandler.onCancel(null)
         magnetometerStreamHandler.onCancel(null)
+        barometerStreamHandler.onCancel(null)
     }
 
     companion object {
@@ -111,5 +123,7 @@ class SensorsPlugin : FlutterPlugin {
             "dev.fluttercommunity.plus/sensors/user_accel"
         private const val MAGNETOMETER_CHANNEL_NAME =
             "dev.fluttercommunity.plus/sensors/magnetometer"
+        private const val BAROMETER_CHANNEL_NAME =
+            "dev.fluttercommunity.plus/sensors/barometer"
     }
 }

--- a/packages/sensors_plus/sensors_plus/android/src/main/kotlin/dev/fluttercommunity/plus/sensors/StreamHandlerImpl.kt
+++ b/packages/sensors_plus/sensors_plus/android/src/main/kotlin/dev/fluttercommunity/plus/sensors/StreamHandlerImpl.kt
@@ -55,6 +55,7 @@ internal class StreamHandlerImpl(
             Sensor.TYPE_LINEAR_ACCELERATION -> "User Accelerometer"
             Sensor.TYPE_GYROSCOPE -> "Gyroscope"
             Sensor.TYPE_MAGNETIC_FIELD -> "Magnetometer"
+            Sensor.TYPE_PRESSURE -> "Barometer"
             else -> "Undefined"
         }
     }

--- a/packages/sensors_plus/sensors_plus/example/ios/Runner/Info.plist
+++ b/packages/sensors_plus/sensors_plus/example/ios/Runner/Info.plist
@@ -24,6 +24,10 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMotionUsageDescription</key>
+	<string>This app requires access to motion data as an example for the sensors plugin.</string>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/packages/sensors_plus/sensors_plus/example/lib/main.dart
+++ b/packages/sensors_plus/sensors_plus/example/lib/main.dart
@@ -104,7 +104,7 @@ class _MyHomePageState extends State<MyHomePage> {
             ),
           ),
           Padding(
-            padding: const EdgeInsets.all(20.0),
+            padding: const EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 0.0),
             child: Table(
               columnWidths: const {
                 0: FlexColumnWidth(4),
@@ -169,6 +169,25 @@ class _MyHomePageState extends State<MyHomePage> {
                     Text('${_magnetometerLastInterval?.toString() ?? '?'} ms'),
                   ],
                 ),
+              ],
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(20.0, 0.0, 20.0, 20.0),
+            child: Table(
+              columnWidths: const {
+                0: FlexColumnWidth(4),
+                1: FlexColumnWidth(3),
+                2: FlexColumnWidth(2),
+              },
+              children: [
+                const TableRow(
+                  children: [
+                    SizedBox.shrink(),
+                    Text('Pressure'),
+                    Text('Interval'),
+                  ],
+                ),
                 TableRow(
                   children: [
                     const Padding(
@@ -176,8 +195,6 @@ class _MyHomePageState extends State<MyHomePage> {
                       child: Text('Barometer'),
                     ),
                     Text(_barometerEvent?.pressure.toStringAsFixed(1) ?? '?'),
-                    const Text('?'),
-                    const Text('?'),
                     Text('${_barometerLastInterval?.toString() ?? '?'} ms'),
                   ],
                 ),

--- a/packages/sensors_plus/sensors_plus/example/lib/main.dart
+++ b/packages/sensors_plus/sensors_plus/example/lib/main.dart
@@ -60,16 +60,19 @@ class _MyHomePageState extends State<MyHomePage> {
   AccelerometerEvent? _accelerometerEvent;
   GyroscopeEvent? _gyroscopeEvent;
   MagnetometerEvent? _magnetometerEvent;
+  BarometerEvent? _barometerEvent;
 
   DateTime? _userAccelerometerUpdateTime;
   DateTime? _accelerometerUpdateTime;
   DateTime? _gyroscopeUpdateTime;
   DateTime? _magnetometerUpdateTime;
+  DateTime? _barometerUpdateTime;
 
   int? _userAccelerometerLastInterval;
   int? _accelerometerLastInterval;
   int? _gyroscopeLastInterval;
   int? _magnetometerLastInterval;
+  int? _barometerLastInterval;
   final _streamSubscriptions = <StreamSubscription<dynamic>>[];
 
   Duration sensorInterval = SensorInterval.normalInterval;
@@ -166,6 +169,18 @@ class _MyHomePageState extends State<MyHomePage> {
                     Text('${_magnetometerLastInterval?.toString() ?? '?'} ms'),
                   ],
                 ),
+                TableRow(
+                  children: [
+                    const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 8.0),
+                      child: Text('Barometer'),
+                    ),
+                    Text(_barometerEvent?.pressure.toStringAsFixed(1) ?? '?'),
+                    const Text('?'),
+                    const Text('?'),
+                    Text('${_barometerLastInterval?.toString() ?? '?'} ms'),
+                  ],
+                ),
               ],
             ),
           ),
@@ -209,6 +224,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     accelerometerEventStream(samplingPeriod: sensorInterval);
                     gyroscopeEventStream(samplingPeriod: sensorInterval);
                     magnetometerEventStream(samplingPeriod: sensorInterval);
+                    barometerEventStream(samplingPeriod: sensorInterval);
                   });
                 },
               ),
@@ -340,6 +356,35 @@ class _MyHomePageState extends State<MyHomePage> {
                   title: Text("Sensor Not Found"),
                   content: Text(
                       "It seems that your device doesn't support Magnetometer Sensor"),
+                );
+              });
+        },
+        cancelOnError: true,
+      ),
+    );
+    _streamSubscriptions.add(
+      barometerEventStream(samplingPeriod: sensorInterval).listen(
+        (BarometerEvent event) {
+          final now = DateTime.now();
+          setState(() {
+            _barometerEvent = event;
+            if (_barometerUpdateTime != null) {
+              final interval = now.difference(_barometerUpdateTime!);
+              if (interval > _ignoreDuration) {
+                _barometerLastInterval = interval.inMilliseconds;
+              }
+            }
+          });
+          _barometerUpdateTime = now;
+        },
+        onError: (e) {
+          showDialog(
+              context: context,
+              builder: (context) {
+                return const AlertDialog(
+                  title: Text("Sensor Not Found"),
+                  content: Text(
+                      "It seems that your device doesn't support Barometer Sensor"),
                 );
               });
         },

--- a/packages/sensors_plus/sensors_plus/ios/Classes/FPPSensorsPlusPlugin.swift
+++ b/packages/sensors_plus/sensors_plus/ios/Classes/FPPSensorsPlusPlugin.swift
@@ -51,6 +51,16 @@ public class FPPSensorsPlusPlugin: NSObject, FlutterPlugin {
         _eventChannels[magnetometerStreamHandlerName] = magnetometerChannel
         _streamHandlers[magnetometerStreamHandlerName] = magnetometerStreamHandler
 
+        let barometerStreamHandler = FPPBarometerStreamHandlerPlus()
+        let barometerStreamHandlerName = "dev.fluttercommunity.plus/sensors/barometer"
+        let barometerChannel = FlutterEventChannel(
+                name: barometerStreamHandlerName,
+                binaryMessenger: registrar.messenger()
+        )
+        barometerChannel.setStreamHandler(barometerStreamHandler)
+        _eventChannels[barometerStreamHandlerName] = barometerChannel
+        _streamHandlers[barometerStreamHandlerName] = barometerStreamHandler
+
         let methodChannel = FlutterMethodChannel(
                 name: "dev.fluttercommunity.plus/sensors/method",
                 binaryMessenger: registrar.messenger()
@@ -66,6 +76,8 @@ public class FPPSensorsPlusPlugin: NSObject, FlutterPlugin {
                 streamHandler = _streamHandlers[gyroscopeStreamHandlerName]
             case "setMagnetometerSamplingPeriod":
                 streamHandler = _streamHandlers[magnetometerStreamHandlerName]
+            case "setBarometerSamplingPeriod":
+                streamHandler = _streamHandlers[barometerStreamHandlerName]
             default:
                 return result(FlutterMethodNotImplemented)
             }

--- a/packages/sensors_plus/sensors_plus/ios/Classes/FPPStreamHandlerPlus.swift
+++ b/packages/sensors_plus/sensors_plus/ios/Classes/FPPStreamHandlerPlus.swift
@@ -257,7 +257,10 @@ class FPPBarometerStreamHandlerPlus: NSObject, MotionStreamHandler {
                 }
                 let pressure = data!.pressure.doubleValue * 10.0 // kPa to hPa (hectopascals)
                 DispatchQueue.main.async {
-                    sink(pressure)
+                let pressureArray: [Double] = [pressure]
+                pressureArray.withUnsafeBufferPointer { buffer in
+                    sink(FlutterStandardTypedData.init(float64: Data(buffer: buffer)))
+                    }
                 }
             }
         } else {

--- a/packages/sensors_plus/sensors_plus/ios/Classes/FPPStreamHandlerPlus.swift
+++ b/packages/sensors_plus/sensors_plus/ios/Classes/FPPStreamHandlerPlus.swift
@@ -6,7 +6,6 @@ import Foundation
 import Flutter
 import UIKit
 import CoreMotion
-import CoreLocation
 
 let GRAVITY = 9.81
 var _motionManager: CMMotionManager!

--- a/packages/sensors_plus/sensors_plus/ios/sensors_plus.podspec
+++ b/packages/sensors_plus/sensors_plus/ios/sensors_plus.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.version          = '0.0.1'
   s.summary          = 'Flutter Sensors'
   s.description      = <<-DESC
-Flutter plugin to access the accelerometer, gyroscope, magnetometer, and barometer sensors.
+Flutter plugin to access the accelerometer, gyroscope, magnetometer and barometer sensors.
                        DESC
   s.homepage         = 'https://github.com/fluttercommunity/plus_plugins'
   s.license          = { :type => 'BSD', :file => '../LICENSE' }

--- a/packages/sensors_plus/sensors_plus/ios/sensors_plus.podspec
+++ b/packages/sensors_plus/sensors_plus/ios/sensors_plus.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.version          = '0.0.1'
   s.summary          = 'Flutter Sensors'
   s.description      = <<-DESC
-Flutter plugin to access the accelerometer, gyroscope, and magnetometer sensors.
+Flutter plugin to access the accelerometer, gyroscope, magnetometer, and barometer sensors.
                        DESC
   s.homepage         = 'https://github.com/fluttercommunity/plus_plugins'
   s.license          = { :type => 'BSD', :file => '../LICENSE' }

--- a/packages/sensors_plus/sensors_plus/lib/sensors_plus.dart
+++ b/packages/sensors_plus/sensors_plus/lib/sensors_plus.dart
@@ -68,3 +68,12 @@ Stream<MagnetometerEvent> magnetometerEventStream({
 }) {
   return _sensors.magnetometerEventStream(samplingPeriod: samplingPeriod);
 }
+
+/// Returns a broadcast stream of events from the device barometer at the
+/// given sampling frequency.
+@override
+Stream<BarometerEvent> barometerEventStream({
+  Duration samplingPeriod = SensorInterval.normalInterval,
+}) {
+  return _sensors.barometerEventStream(samplingPeriod: samplingPeriod);
+}

--- a/packages/sensors_plus/sensors_plus/lib/src/sensors.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/sensors.dart
@@ -65,4 +65,17 @@ class Sensors extends SensorsPlatform {
   }) {
     return _platform.magnetometerEventStream(samplingPeriod: samplingPeriod);
   }
+
+  /// Returns a broadcast stream of events from the device barometer at the
+  /// given sampling frequency.
+  ///
+  /// This method always returning the same stream. If this method is called
+  /// again, the sampling period of the stream will be update. All previous
+  /// listener will also be affected.
+  @override
+  Stream<BarometerEvent> barometerEventStream({
+    Duration samplingPeriod = SensorInterval.normalInterval,
+  }) {
+    return _platform.barometerEventStream(samplingPeriod: samplingPeriod);
+  }
 }

--- a/packages/sensors_plus/sensors_plus/lib/src/sensors_plus_web.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/sensors_plus_web.dart
@@ -32,6 +32,12 @@ Stream<MagnetometerEvent> get magnetometerEvents {
   return _sensors.magnetometerEvents;
 }
 
+/// A broadcast stream of events from the device barometer.
+@Deprecated('Use barometerEventStream() instead.')
+Stream<BarometerEvent> get barometerEvents {
+  return _sensors.barometerEvents;
+}
+
 /// Returns a broadcast stream of events from the device accelerometer at the
 /// given sampling frequency.
 @override
@@ -66,4 +72,13 @@ Stream<MagnetometerEvent> magnetometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
   return _sensors.magnetometerEventStream(samplingPeriod: samplingPeriod);
+}
+
+/// Returns a broadcast stream of events from the device barometer at the
+/// given sampling frequency.
+@override
+Stream<BarometerEvent> barometerEventStream({
+  Duration samplingPeriod = SensorInterval.normalInterval,
+}) {
+  return _sensors.barometerEventStream(samplingPeriod: samplingPeriod);
 }

--- a/packages/sensors_plus/sensors_plus/lib/src/sensors_plus_web.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/sensors_plus_web.dart
@@ -32,12 +32,6 @@ Stream<MagnetometerEvent> get magnetometerEvents {
   return _sensors.magnetometerEvents;
 }
 
-/// A broadcast stream of events from the device barometer.
-@Deprecated('Use barometerEventStream() instead.')
-Stream<BarometerEvent> get barometerEvents {
-  return _sensors.barometerEvents;
-}
-
 /// Returns a broadcast stream of events from the device accelerometer at the
 /// given sampling frequency.
 @override

--- a/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
@@ -275,56 +275,13 @@ class WebSensorsPlugin extends SensorsPlatform {
     return _magnetometerResultStream;
   }
 
-  StreamController<BarometerEvent>? _barometerStreamController;
-  late Stream<BarometerEvent> _barometerResultStream;
-
   @override
   Stream<BarometerEvent> barometerEventStream({
     Duration samplingPeriod = SensorInterval.normalInterval,
   }) {
-    // The Barometer API does not exist and so not supported by any modern browser.
-    if (_barometerStreamController == null) {
-      _barometerStreamController = StreamController<BarometerEvent>();
-      _featureDetected(
-        () {
-          final barometerSensor = Barometer(
-            SensorOptions(
-              frequency: samplingPeriod.frequency,
-            ),
-          );
-
-          barometerSensor.start();
-
-          barometerSensor.onreading = (Event _) {
-            _barometerStreamController!.add(
-              BarometerEvent(
-                barometerSensor.pressure,
-              ),
-            );
-          }.toJS;
-
-          barometerSensor.onerror = (SensorErrorEvent e) {
-            developer.log(
-              'The Barometer API is supported but something is wrong!',
-              error: e,
-            );
-          }.toJS;
-        },
-        apiName: 'Barometer()',
-        permissionName: 'barometer',
-        onError: () {
-          _barometerStreamController!.add(BarometerEvent(0));
-        },
-      );
-      _barometerResultStream =
-          _barometerStreamController!.stream.asBroadcastStream();
-
-      _barometerStreamController!.onCancel = () {
-        _barometerStreamController!.close();
-      };
-    }
-
-    return _barometerResultStream;
+    // The Barometer API does not exist and so is not supported by any modern browser.
+    // Therefore, we simply return an empty stream.
+    return const Stream.empty();
   }
 }
 

--- a/packages/sensors_plus/sensors_plus/lib/src/web_sensors_interop.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/web_sensors_interop.dart
@@ -72,22 +72,6 @@ extension type Magnetometer._(JSObject _) implements JSObject {
   external void start();
 }
 
-/// Barometer not implemented
-/// https://developer.mozilla.org/en-US/docs/Web/API/Sensor
-@JS('Barometer')
-extension type Barometer._(JSObject _) implements JSObject {
-  external factory Barometer([
-    SensorOptions options,
-  ]);
-
-  external double get pressure;
-
-  external set onreading(JSFunction callback);
-  external set onerror(JSFunction callback);
-
-  external void start();
-}
-
 extension type SensorOptions._(JSObject _) implements JSObject {
   external factory SensorOptions({
     int frequency,

--- a/packages/sensors_plus/sensors_plus/lib/src/web_sensors_interop.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/web_sensors_interop.dart
@@ -72,6 +72,22 @@ extension type Magnetometer._(JSObject _) implements JSObject {
   external void start();
 }
 
+/// Barometer not implemented
+/// https://developer.mozilla.org/en-US/docs/Web/API/Sensor
+@JS('Barometer')
+extension type Barometer._(JSObject _) implements JSObject {
+  external factory Barometer([
+    SensorOptions options,
+  ]);
+
+  external double get pressure;
+
+  external set onreading(JSFunction callback);
+  external set onerror(JSFunction callback);
+
+  external void start();
+}
+
 extension type SensorOptions._(JSObject _) implements JSObject {
   external factory SensorOptions({
     int frequency,

--- a/packages/sensors_plus/sensors_plus/test/sensors_test.dart
+++ b/packages/sensors_plus/sensors_plus/test/sensors_test.dart
@@ -62,6 +62,17 @@ void main() {
     expect(event.y, sensorData[1]);
     expect(event.z, sensorData[2]);
   });
+
+  test('barometerEvents are streamed', () async {
+    const channelName = 'dev.fluttercommunity.plus/sensors/barometer';
+    const sensorData = <double>[1000.0];
+    _initializeFakeMethodChannel('setBarometerSamplingPeriod');
+    _initializeFakeSensorChannel(channelName, sensorData);
+
+    final event = await barometerEventStream().first;
+
+    expect(event.pressure, sensorData[0]);
+  });
 }
 
 void _initializeFakeMethodChannel(String methodName) {

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/sensors_plus_platform_interface.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/sensors_plus_platform_interface.dart
@@ -73,7 +73,7 @@ abstract class SensorsPlatform extends PlatformInterface {
 
   /// A broadcast stream of events from the device barometer.
   @nonVirtual
-  @Deprecated('Use magnetometerEventStream() instead.')
+  @Deprecated('Use barometerEventStream() instead.')
   Stream<BarometerEvent> get barometerEvents {
     return barometerEventStream();
   }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/sensors_plus_platform_interface.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/sensors_plus_platform_interface.dart
@@ -71,13 +71,6 @@ abstract class SensorsPlatform extends PlatformInterface {
     return magnetometerEventStream();
   }
 
-  /// A broadcast stream of events from the device barometer.
-  @nonVirtual
-  @Deprecated('Use barometerEventStream() instead.')
-  Stream<BarometerEvent> get barometerEvents {
-    return barometerEventStream();
-  }
-
   /// Returns a broadcast stream of events from the device accelerometer at the
   /// given sampling frequency.
   Stream<AccelerometerEvent> accelerometerEventStream({

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/sensors_plus_platform_interface.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/sensors_plus_platform_interface.dart
@@ -13,11 +13,13 @@ import 'src/accelerometer_event.dart';
 import 'src/gyroscope_event.dart';
 import 'src/magnetometer_event.dart';
 import 'src/user_accelerometer_event.dart';
+import 'src/barometer_event.dart';
 
 export 'src/accelerometer_event.dart';
 export 'src/gyroscope_event.dart';
 export 'src/magnetometer_event.dart';
 export 'src/user_accelerometer_event.dart';
+export 'src/barometer_event.dart';
 export 'src/sensor_interval.dart';
 
 /// The common platform interface for sensors.
@@ -69,6 +71,13 @@ abstract class SensorsPlatform extends PlatformInterface {
     return magnetometerEventStream();
   }
 
+  /// A broadcast stream of events from the device barometer.
+  @nonVirtual
+  @Deprecated('Use magnetometerEventStream() instead.')
+  Stream<BarometerEvent> get barometerEvents {
+    return barometerEventStream();
+  }
+
   /// Returns a broadcast stream of events from the device accelerometer at the
   /// given sampling frequency.
   Stream<AccelerometerEvent> accelerometerEventStream({
@@ -101,5 +110,13 @@ abstract class SensorsPlatform extends PlatformInterface {
     Duration samplingPeriod = SensorInterval.normalInterval,
   }) {
     throw UnimplementedError('magnetometerEvents has not been implemented.');
+  }
+
+  /// Returns a broadcast stream of events from the device barometer at the
+  /// given sampling frequency.
+  Stream<BarometerEvent> barometerEventStream({
+    Duration samplingPeriod = SensorInterval.normalInterval,
+  }) {
+    throw UnimplementedError('barometerEvents has not been implemented.');
   }
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/barometer_event.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/barometer_event.dart
@@ -1,0 +1,26 @@
+/// A sensor sample from a barometer.
+///
+/// Barometers measure the atmospheric pressure surrounding the sensor,
+/// returning values in hectopascals ***hPa***.
+///
+/// Consider that these samples may be affected by altitude and weather
+/// conditions, and can be used to predict short-term weather changes or
+/// determine altitude.
+///
+/// Note that water-resistant phones or similar sealed devices may experience
+/// pressure fluctuations as the device is held or used, due to changes in
+/// pressure caused by handling the device.
+///
+/// An altimeter is an example of a general utility for barometer data.
+class BarometerEvent {
+  /// Constructs a new instance with the given [pressure] value.
+  ///
+  /// See [BarometerEvent] for more information.
+  BarometerEvent(this.pressure);
+
+  /// The atmospheric pressure surrounding the sensor in hectopascals ***hPa***.
+  final double pressure;
+
+  @override
+  String toString() => '[BarometerEvent (pressure: $pressure hPa)]';
+}

--- a/packages/sensors_plus/sensors_plus_platform_interface/lib/src/method_channel_sensors.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/lib/src/method_channel_sensors.dart
@@ -25,11 +25,15 @@ class MethodChannelSensors extends SensorsPlatform {
   static const EventChannel _magnetometerEventChannel =
       EventChannel('dev.fluttercommunity.plus/sensors/magnetometer');
 
+  static const EventChannel _barometerEventChannel =
+      EventChannel('dev.fluttercommunity.plus/sensors/barometer');
+
   final logger = Logger('MethodChannelSensors');
   Stream<AccelerometerEvent>? _accelerometerEvents;
   Stream<GyroscopeEvent>? _gyroscopeEvents;
   Stream<UserAccelerometerEvent>? _userAccelerometerEvents;
   Stream<MagnetometerEvent>? _magnetometerEvents;
+  Stream<BarometerEvent>? _barometerEvents;
 
   /// Returns a broadcast stream of events from the device accelerometer at the
   /// given sampling frequency.
@@ -132,5 +136,30 @@ class MethodChannelSensors extends SensorsPlatform {
       return MagnetometerEvent(list[0]!, list[1]!, list[2]!);
     });
     return _magnetometerEvents!;
+  }
+
+  /// Returns a broadcast stream of events from the device barometer at the
+  /// given sampling frequency.
+  @override
+  Stream<BarometerEvent> barometerEventStream({
+    Duration samplingPeriod = SensorInterval.normalInterval,
+  }) {
+    var microseconds = samplingPeriod.inMicroseconds;
+    if (microseconds >= 1 && microseconds <= 3) {
+      logger.warning('The SamplingPeriod is currently set to $microsecondsμs, '
+          'which is a reserved value in Android. Please consider changing it '
+          'to either 0 or 4μs. See https://developer.android.com/reference/'
+          'android/hardware/SensorManager#registerListener(android.hardware.'
+          'SensorEventListener,%20android.hardware.Sensor,%20int) for more '
+          'information');
+      microseconds = 0;
+    }
+    _methodChannel.invokeMethod('setBarometerSamplingPeriod', microseconds);
+    _barometerEvents ??=
+        _barometerEventChannel.receiveBroadcastStream().map((dynamic event) {
+      final list = event.cast<double>();
+      return BarometerEvent(list[0]!);
+    });
+    return _barometerEvents!;
   }
 }

--- a/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
@@ -48,6 +48,15 @@ Stream<MagnetometerEvent> magnetometerEventStream({
   return methodChannel.magnetometerEventStream(samplingPeriod: samplingPeriod);
 }
 
+/// Returns a broadcast stream of events from the device magnetometer at the
+/// given sampling frequency.
+@override
+Stream<BarometerEvent> barometerEventStream({
+  Duration samplingPeriod = SensorInterval.normalInterval,
+}) {
+  return methodChannel.barometerEventStream(samplingPeriod: samplingPeriod);
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -101,6 +110,17 @@ void main() {
     expect(event.x, sensorData[0]);
     expect(event.y, sensorData[1]);
     expect(event.z, sensorData[2]);
+  });
+
+  test('barometerEvents are streamed', () async {
+    const channelName = 'dev.fluttercommunity.plus/sensors/barometer';
+    const sensorData = <double>[1000.0];
+    _initializeFakeMethodChannel('setBarometerSamplingPeriod');
+    _initializeFakeSensorChannel(channelName, sensorData);
+
+    final event = await barometerEventStream().first;
+
+    expect(event.pressure, sensorData[0]);
   });
 }
 


### PR DESCRIPTION
## Description

This PR implements barometer support for all platforms (Android, iOS, and web) within the `sensors_plus` plugin. The barometer sensor measures atmospheric pressure and can be used for various applications such as altimeters. 

Note: There are limitations for web platform, as according to [MZN docs](https://developer.mozilla.org/en-US/docs/Web/API/Sensor_APIs), there is no such support for barometer support. This has been implemented similarly to the magnetometer which is also not implemented on any modern browsers, so it handles and throws the right errors if used.

### Changes Made:

- Android Implementation (Tested): Updated Android specific methods and handlers for barometer sensor in:
  - `...sensors_plus\android\src\main\kotlin\dev\fluttercommunity\plus\sensors\SensorsPlugin.kt`
  - `...sensors_plus\android\src\main\kotlin\dev\fluttercommunity\plus\sensors\StreamHandlerImpl.kt`

- iOS Implementation (**Not Tested**): Updated `packages\sensors_plus\sensors_plus\ios\sensors_plus.podspec` to include barometer reference.
Added Android specific methods and handlers for barometer sensor in:
  - `...sensors_plus\ios\Classes\FPPSensorsPlusPlugin.swift`
  - `...sensors_plus\ios\Classes\FPPStreamHandlerPlus.swift`

- Web Implementation (Tested): Added placeholder implementation and error handling for web platform. There is no plan for this to be implemented on the web from my understanding, but the implementation here will allow appropriate handling to be implemented by users.

- Plugin Implementation (Tested): Added required implementations following the same pattern as used for other sensors for the barometer:
  - `BarometerEvent` class in `...sensors_plus_platform_interface\lib\src\barometer_event.dart`
  - `barometerEventStream` methods in `...sensors_plus\lib\src\sensors_plus_web.dart`, `...sensors_plus_platform_interface\lib\src\method_channel_sensors.dart`, `...sensors_plus\lib\src\sensors.dart`, `...sensors_plus\lib\src\web_sensors.dart`,  `...sensors_plus_platform_interface\lib\sensors_plus_platform_interface.dart` and `...sensors_plus\lib\sensors_plus.dart`
  - ~~**Deprecated** `barometerEvents` (not sure if this is needed, but there for consistency) in `...sensors_plus_platform_interface\lib\sensors_plus_platform_interface.dart` and `...sensors_plus\lib\sensors_plus.dart`~~
  - ~~JS Interoperability for non-existing Barometer API in `...sensors_plus\lib\src\web_sensors_interop.dart`~~

- Tests (Tested): Unit tests have been written for the barometer in:
  - `...sensors_plus\test\sensors_test.dart` 
  - `...sensors_plus_platform_interface\test\sensors_plus_platform_interface_test.dart` 

- Example App (Tested): Updated to include barometer readings in table in `...sensors_plus\example\lib\main.dart`.

- `README.md`: Updated to show barometer in example and reference it.

## Related Issues

Implements required functionality for barometer (#955)

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

Note: `flutter analyze` reports errors for deprecated constants for network_info_plus. Did not touch or modify these as it is not related to sensor_plus.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

