### PR TITLE
fix(network_info_plus)!: Do not ignore errors on Android

### DIFF
--- a/packages/network_info_plus/network_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/network_info/NetworkInfo.kt
+++ b/packages/network_info_plus/network_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/network_info/NetworkInfo.kt
@@ -105,39 +105,32 @@ internal class NetworkInfo(
         )
 
     private fun getIPv4Subnet(inetAddress: InetAddress): String {
-        try {
-            val ni = NetworkInterface.getByInetAddress(inetAddress)
-            val intAddresses = ni.interfaceAddresses
-            for (ia in intAddresses) {
-                if (!ia.address.isLoopbackAddress && ia.address is Inet4Address) {
-                    val networkPrefix =
-                        getIPv4SubnetFromNetPrefixLength(ia.networkPrefixLength.toInt())
-                    if (networkPrefix != null) {
-                        return networkPrefix.hostAddress!!
-                    }
+        val ni = NetworkInterface.getByInetAddress(inetAddress)
+        val intAddresses = ni.interfaceAddresses
+        for (ia in intAddresses) {
+            if (!ia.address.isLoopbackAddress && ia.address is Inet4Address) {
+                val networkPrefix =
+                    getIPv4SubnetFromNetPrefixLength(ia.networkPrefixLength.toInt())
+                if (networkPrefix != null) {
+                    return networkPrefix.hostAddress!!
                 }
             }
-        } catch (ignored: Exception) {
         }
         return ""
     }
 
     private fun getIPv4SubnetFromNetPrefixLength(netPrefixLength: Int): InetAddress? {
-        try {
-            var shift = 1 shl 31
-            for (i in netPrefixLength - 1 downTo 1) {
-                shift = shift shr 1
-            }
-            val subnet = ((shift shr 24 and 255)
-                .toString() + "."
-                + (shift shr 16 and 255)
-                + "."
-                + (shift shr 8 and 255)
-                + "."
-                + (shift and 255))
-            return InetAddress.getByName(subnet)
-        } catch (ignored: Exception) {
+        var shift = 1 shl 31
+        for (i in netPrefixLength - 1 downTo 1) {
+            shift = shift shr 1
         }
-        return null
+        val subnet = ((shift shr 24 and 255)
+            .toString() + "."
+            + (shift shr 16 and 255)
+            + "."
+            + (shift shr 8 and 255)
+            + "."
+            + (shift and 255))
+        return InetAddress.getByName(subnet)
     }
 }


### PR DESCRIPTION
## Description

The Android implementation of `network_info_plus` has been ignoring certain internal errors, making it impossible to debug why the methods return `null`.

e.g. https://github.com/fluttercommunity/plus_plugins/issues/1553#issuecomment-2216680660

This PR removes the try/catch.

According to `MethodHandler` docs:

> Any uncaught exception thrown by this method will be caught by the channel implementation and logged, and an error result will be sent back to Flutter.

In this case, the exceptions will be sent to the Flutter layer, and devs will have to handle them.

This is marked a BREAKING CHANGE, because I think this can cause unwanted errors for apps using this plugin (or a plugin that depends on this plugin), and so the code should be changed to handle these errors.

## Related Issues

- Related #1553 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

