### PR TITLE
test(package_info_plus): Fix integration test for Android

### DIFF
--- a/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_test.dart
+++ b/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_test.dart
@@ -85,13 +85,22 @@ void main() {
       expect(find.text('not available'), findsOneWidget);
     } else {
       if (Platform.isAndroid) {
+        final androidVersionInfo = await DeviceInfoPlugin().androidInfo;
+
         expect(find.text('package_info_example'), findsOneWidget);
         expect(find.text('4'), findsOneWidget);
         expect(
-            find.text('io.flutter.plugins.packageinfoexample'), findsOneWidget);
+          find.text('io.flutter.plugins.packageinfoexample'),
+          findsOneWidget,
+        );
         expect(find.text('1.2.3'), findsOneWidget);
         expect(find.text('Not set'), findsNothing);
-        expect(find.text('not available'), findsOneWidget);
+        // Since Android 14 (API 34) OS returns com.android.shell when app is installed via package installer
+        if (androidVersionInfo.version.sdkInt >= android14SDK) {
+          expect(find.text('com.android.shell'), findsOneWidget);
+        } else {
+          expect(find.text('not available'), findsOneWidget);
+        }
       } else if (Platform.isIOS) {
         expect(find.text('Package Info Plus Example'), findsOneWidget);
         expect(find.text('4'), findsOneWidget);

--- a/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_test.dart
+++ b/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_test.dart
@@ -27,7 +27,6 @@ void main() {
       expect(info.version, '1.2.3');
       expect(info.installerStore, null);
     } else {
-
       if (Platform.isAndroid) {
         final androidVersionInfo = await DeviceInfoPlugin().androidInfo;
 

--- a/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_test.dart
+++ b/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_test.dart
@@ -4,11 +4,14 @@
 
 import 'dart:io';
 
+import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:package_info_plus_example/main.dart';
+
+const android14SDK = 34;
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
@@ -24,13 +27,21 @@ void main() {
       expect(info.version, '1.2.3');
       expect(info.installerStore, null);
     } else {
+
       if (Platform.isAndroid) {
+        final androidVersionInfo = await DeviceInfoPlugin().androidInfo;
+
         expect(info.appName, 'package_info_example');
         expect(info.buildNumber, '4');
         expect(info.buildSignature, isNotEmpty);
         expect(info.packageName, 'io.flutter.plugins.packageinfoexample');
         expect(info.version, '1.2.3');
-        expect(info.installerStore, null);
+        // Since Android 14 (API 34) OS returns com.android.shell when app is installed via package installer
+        if (androidVersionInfo.version.sdkInt >= android14SDK) {
+          expect(info.installerStore, 'com.android.shell');
+        } else {
+          expect(info.installerStore, null);
+        }
       } else if (Platform.isIOS) {
         expect(info.appName, 'Package Info Plus Example');
         expect(info.buildNumber, '4');

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.3.3
+  device_info_plus: ^10.1.0
   integration_test:
     sdk: flutter
   flutter_driver:


### PR DESCRIPTION
## Description

Fixing tests for `installerStore` value on Android as it seems like since Android 14 OS returns `com.android.shell` for apps installed via package manager, adb command (I suppose so) instead of `null`. Don't see any mentions of it in the documentation. Earlier we didn't see this test failing because we had no API 34 in our build matrix.
Checked with emulators and real phone with Android 14 - on Android 13 I see `null`, while on 14 for both virtual and real device see `com.android.shell` when installing example via Android Studio. I believe this fix for the integration test should be correct.

<img width="700" alt="Screenshot 2024-07-09 at 14 32 20" src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/5428a490-4655-4094-a300-2588b2a60c6c">



