### PR TITLE
feat(connectivity_plus): Return multiple active types on MacOS/iOS when available

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/darwin/Classes/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/darwin/Classes/PathMonitorConnectivityProvider.swift
@@ -11,24 +11,25 @@ public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
 
   private func connectivityFrom(path: NWPath) -> [ConnectivityType] {
     var types: [ConnectivityType] = []
-    
-    // Check for connectivity and append to types array as necessary
-    if path.status == .satisfied {
-      if path.usesInterfaceType(.wifi) {
-        types.append(.wifi)
-      }
-      if path.usesInterfaceType(.cellular) {
-        types.append(.cellular)
-      }
-      if path.usesInterfaceType(.wiredEthernet) {
-        types.append(.wiredEthernet)
-      }
-      if path.usesInterfaceType(.other) {
-        types.append(.other)
-      }
-    }
-    
-    return types.isEmpty ? [.none] : types
+
+     for interface in path.availableInterfaces {
+            switch interface.type {
+            case .wifi:
+                types.append(.wifi)
+            case .wiredEthernet:
+                types.append(.wiredEthernet)
+            case .cellular:
+                types.append(.cellular)
+            case .loopback:
+                types.append(.other)
+            case .other:
+                types.append(.other)
+            @unknown default:
+                types.append(.other)
+            }
+        }
+
+        return types.isEmpty ? [.none] : types
   }
 
   public var currentConnectivityTypes: [ConnectivityType] {

--- a/packages/connectivity_plus/connectivity_plus/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/connectivity_plus/connectivity_plus/example/macos/Runner.xcodeproj/project.pbxproj
@@ -259,7 +259,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C80D4294CF70F00263BE5 = {

--- a/packages/connectivity_plus/connectivity_plus/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/connectivity_plus/connectivity_plus/example/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/connectivity_plus.dart
@@ -46,7 +46,7 @@ class Connectivity {
   /// case where [ConnectivityResult.none] is present.
   ///
   /// This method applies [Stream.distinct] over the received events to ensure
-  /// only emiting when connectivity changes.
+  /// only emitting when connectivity changes.
   Stream<List<ConnectivityResult>> get onConnectivityChanged {
     return _platform.onConnectivityChanged.distinct((a, b) => a.equals(b));
   }
@@ -54,8 +54,7 @@ class Connectivity {
   /// Checks the connection status of the device.
   ///
   /// Do not use the result of this function to decide whether you can reliably
-  /// make a network request, it only gives you the radio status. Instead, listen
-  /// for connectivity changes via [onConnectivityChanged] stream.
+  /// make a network request, as it only provides network interfaces status, but not an Internet availability.
   ///
   /// The returned list is never empty. In case of no connectivity, the list contains
   /// a single element of [ConnectivityResult.none]. Note also that this is the only


### PR DESCRIPTION
## Description

Switching from check for active used connection on iOS/MacOS to available connections to return multiple connection types when such are available. Tested with a dongle for MacBook which has Ethernet port and looks like getting results as expected:
<img width="957" alt="Screenshot 2024-07-09 at 18 08 41" src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/ca0f7553-baf8-4899-bd28-5318cd553e90">
Here is a screenshot from a few more test cases where I tried to connect/disconnect both Wi-Fi and Ethernet
<img width="673" alt="Screenshot 2024-07-09 at 18 13 41" src="https://github.com/fluttercommunity/plus_plugins/assets/13467769/3d6f4cf3-7a47-4c94-aa10-a93d58cd261b">

Additionally did a few changes to the API documentation comments.

## Related Issues

Closes #3073

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

