### PR TITLE
chore(sensors_plus): update README and example app for units and platform specific recomendations

### DIFF
--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -172,6 +172,10 @@ The following lists the restrictions for the sensors on certain platforms due to
 >
 > Plugin won't crash the app in the case of usage on these platforms, but it is highly recommended to add onError() to handle such cases gracefully.
 
+- **Sampling periods for web**
+
+  Currently it is not possible to set sensors sampling rate on web. Calls to event streams at specied sampling periods will have the sampling period ignored. 
+
 - **Barometer sampling period limitation for iOS**
 
   On iOS devices, barometer updates are [CMAltimeter](https://developer.apple.com/documentation/coremotion/cmaltimeter) which provides updates at regular intervals that cannot be controlled by the user. Calls to `barometerEventStream` at specied sampling periods will have the sampling period ignored. 

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -31,8 +31,21 @@ barometer sensors.
 ## Usage
 
 Add `sensors_plus` as a dependency in your pubspec.yaml file.
+  
+On iOS you must also include a key called [`NSMotionUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsmotionusagedescription) in your app's `Info.plist` file. This key provides a message that tells the user why the app is requesting access to the device’s motion data. The plugin itself needs access to motion data to get barometer data.
 
-This will expose such classes of sensor events through a set of streams:
+Example Info.plist entry:
+
+```xml
+<key>NSMotionUsageDescription</key>
+<string>This app requires access to the barometer to provide altitude information.</string>
+```
+
+> [!CAUTION]
+>
+> Adding [`NSMotionUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsmotionusagedescription) is a requirement and not doing so will crash your app when it attempts to access motion data.
+
+The plugin exposes such classes of sensor events through a set of streams:
 
 - `UserAccelerometerEvent` describes the acceleration of the device, in m/s<sup>2</sup>.
   If the device is still, or is moving along a straight line at constant speed,
@@ -179,21 +192,6 @@ The following lists the restrictions for the sensors on certain platforms due to
 - **Barometer sampling period limitation for iOS**
 
   On iOS devices, barometer updates are [CMAltimeter](https://developer.apple.com/documentation/coremotion/cmaltimeter) which provides updates at regular intervals that cannot be controlled by the user. Calls to `barometerEventStream` at specied sampling periods will have the sampling period ignored. 
-
-- **Barometer requirements for iOS**
-
-  You must include a key called [`NSMotionUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsmotionusagedescription) in your app's `Info.plist` file. This key provides a message that tells the user why the app is requesting access to the device’s motion data.
-
-  Example Info.plist entry:
-
-  ```xml
-  <key>NSMotionUsageDescription</key>
-  <string>This app requires access to the barometer to provide altitude information.</string>
-  ```
-
-> [!IMPORTANT]
->
-> Adding [`NSMotionUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsmotionusagedescription) is a requirement and not doing so will crash your app when it attempts to access motion data.
 
 ## Learn more
 

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -168,9 +168,9 @@ The following lists the restrictions for the sensors on certain platforms due to
 
   Developers should consider alternative methods or inform users about the limitation when their application runs on a web platform. 
 
-  > [!NOTE]
-  >
-  > Plugin won't crash the app in the case of usage on these platforms, but it is highly recommended to add onError() to handle such cases gracefully.
+> [!NOTE]
+>
+> Plugin won't crash the app in the case of usage on these platforms, but it is highly recommended to add onError() to handle such cases gracefully.
 
 - **Barometer sampling period limitation for iOS**
 
@@ -187,9 +187,9 @@ The following lists the restrictions for the sensors on certain platforms due to
   <string>This app requires access to the barometer to provide altitude information.</string>
   ```
 
-  > [!NOTE]
-  > 
-  > Adding [`NSMotionUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsmotionusagedescription) is a requirement and not doing so will crash your app when it attempts to access motion data.
+> [!IMPORTANT]
+>
+> Adding [`NSMotionUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsmotionusagedescription) is a requirement and not doing so will crash your app when it attempts to access motion data.
 
 ## Learn more
 

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -54,7 +54,7 @@ This will expose such classes of sensor events through a set of streams:
 - `GyroscopeEvent` describes the rotation of the device.
 - `MagnetometerEvent` describes the ambient magnetic field surrounding the
   device. A compass is an example usage of this data.
-- `BarometerEvent` describes the atmospheric pressure surrounding the device. 
+- `BarometerEvent` describes the atmospheric pressure surrounding the device, in hPa. 
   An altimeter is an example usage of this data. Not supported on web browsers.
 
 These events are exposed through a `BroadcastStream`: `accelerometerEvents`,
@@ -132,7 +132,7 @@ barometerEvents.listen(
 // [BarometerEvent (pressure: 1000.0)]
 ```
 
-Alternatively, every stream allows to specify the sampling rate for its sensor using one of predefined constants or using a custom value
+Alternatively, every stream allows to specify the sampling rate for its sensor using one of predefined constants or using a custom value.
 
 > [!NOTE]
 >
@@ -155,6 +155,41 @@ magnetometerEvents(samplingPeriod: SensorInterval.normalInterval).listen(
 For more detailed instruction check out the documentation linked below.
 Also see the `example` subdirectory for an example application that uses the
 sensor data.
+
+### Platform Restrictions and Considerations
+
+The following lists the restrictions for the sensors on certain platforms due to limitations of the platform. 
+
+- **Magnetometer and Barometer missing for web**
+
+  The Magnetometer API is currently not supported by any modern web browsers. Check browser compatibility matrix on [MDN docs for Magnetormeter API](https://developer.mozilla.org/en-US/docs/Web/API/Magnetometer). 
+
+  The Barometer API does not exist for web platforms as can be seen at [MDN docs forn Sensors API](https://developer.mozilla.org/en-US/docs/Web/API/Sensor_APIs). 
+
+  Developers should consider alternative methods or inform users about the limitation when their application runs on a web platform. 
+
+  > [!NOTE]
+  >
+  > Plugin won't crash the app in the case of usage on these platforms, but it is highly recommended to add onError() to handle such cases gracefully.
+
+- **Barometer sampling period limitation for iOS**
+
+  On iOS devices, barometer updates are [CMAltimeter](https://developer.apple.com/documentation/coremotion/cmaltimeter) which provides updates at regular intervals that cannot be controlled by the user. Calls to `barometerEventStream` at specied sampling periods will have the sampling period ignored. 
+
+- **Barometer requirements for iOS**
+
+  You must include a key called [`NSMotionUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsmotionusagedescription) in your app's `Info.plist` file. This key provides a message that tells the user why the app is requesting access to the device’s motion data.
+
+  Example Info.plist entry:
+
+  ```xml
+  <key>NSMotionUsageDescription</key>
+  <string>This app requires access to the barometer to provide altitude information.</string>
+  ```
+
+  > [!NOTE]
+  > 
+  > Adding [`NSMotionUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsmotionusagedescription) is a requirement and not doing so will crash your app when it attempts to access motion data.
 
 ## Learn more
 

--- a/packages/sensors_plus/sensors_plus/example/lib/main.dart
+++ b/packages/sensors_plus/sensors_plus/example/lib/main.dart
@@ -194,7 +194,8 @@ class _MyHomePageState extends State<MyHomePage> {
                       padding: EdgeInsets.symmetric(vertical: 8.0),
                       child: Text('Barometer'),
                     ),
-                    Text('${_barometerEvent?.pressure.toStringAsFixed(1) ?? '?'} hPa'),
+                    Text(
+                        '${_barometerEvent?.pressure.toStringAsFixed(1) ?? '?'} hPa'),
                     Text('${_barometerLastInterval?.toString() ?? '?'} ms'),
                   ],
                 ),

--- a/packages/sensors_plus/sensors_plus/example/lib/main.dart
+++ b/packages/sensors_plus/sensors_plus/example/lib/main.dart
@@ -194,7 +194,7 @@ class _MyHomePageState extends State<MyHomePage> {
                       padding: EdgeInsets.symmetric(vertical: 8.0),
                       child: Text('Barometer'),
                     ),
-                    Text(_barometerEvent?.pressure.toStringAsFixed(1) ?? '?'),
+                    Text('${_barometerEvent?.pressure.toStringAsFixed(1) ?? '?'} hPa'),
                     Text('${_barometerLastInterval?.toString() ?? '?'} ms'),
                   ],
                 ),


### PR DESCRIPTION
## Description

Change sensors plus README.md to include:

1. Units for barometer
2. Web platform specific considerations for magnetometer and barometer due to it being missing.
4. iOS platform specific limitation for barometer not supporting custom sampling frequencies.
5. iOS platform requirement for `NSMotionUsageDescription`.

Change sensors plus example app to show pressure units.

## Related Issues

Building on PR #3079.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

