### PR TITLE
fix(all): changed homepage url in pubspec.yaml

### DIFF
--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: android_alarm_manager_plus
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
 version: 4.0.3
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/android_alarm_manager_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/android_alarm_manager_plus
 

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
 version: 5.0.2
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/android_intent_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/android_intent_plus
 

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
 version: 6.0.1
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/battery_plus/battery_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/battery_plus
 

--- a/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
+++ b/packages/battery_plus/battery_plus_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: battery_plus_platform_interface
 description: A common platform interface for the battery_plus plugin.
 version: 2.0.0
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
 version: 6.0.3
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/connectivity_plus/connectivity_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/connectivity_plus
 

--- a/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: connectivity_plus_platform_interface
 description: A common platform interface for the connectivity_plus plugin.
 version: 2.0.0
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
 version: 10.1.0
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/device_info_plus/device_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus
 

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus_platform_interface
 description: A common platform interface for the device_info_plus plugin.
 version: 7.0.0
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 dependencies:

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
 version: 5.0.3
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/network_info_plus/network_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/network_info_plus
 

--- a/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: network_info_plus_platform_interface
 description: A common platform interface for the network_info_plus plugin.
 version: 2.0.0
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 environment:

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
 version: 8.0.0
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/package_info_plus/package_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/package_info_plus
 

--- a/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: package_info_plus_platform_interface
 description: A common platform interface for the package_info_plus plugin.
 version: 3.0.0
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 dependencies:

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -2,7 +2,7 @@ name: sensors_plus
 description: Flutter plugin for accessing accelerometer, gyroscope, and
   magnetometer sensors.
 version: 5.0.1
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/sensors_plus/sensors_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/sensors_plus
 

--- a/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sensors_plus_platform_interface
 description: A common platform interface for the sensors_plus plugin.
 version: 1.2.0
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 dependencies:

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
 version: 9.0.0
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/share_plus/share_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus
 

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -1,7 +1,7 @@
 name: share_plus_platform_interface
 description: A common platform interface for the share_plus plugin.
 version: 4.0.0
-homepage: https://plus.fluttercommunity.dev/
+homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 
 dependencies:


### PR DESCRIPTION
## Description

Homepage link was not working for any plugins, replace those like with [https://github.com/fluttercommunity/plus_plugins](https://github.com/fluttercommunity/plus_plugins)

## Related Issues

Fix #3092 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

