### PR TITLE
feat!: #1067 close share plus sheet

### DIFF
--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -249,6 +249,7 @@ class DemoAppState extends State<DemoApp> {
       if (shouldAutoClose) {
         Future.delayed(const Duration(seconds: 5), () async {
           await Share.close();
+          debugPrint('Share closed');
         });
       }
 

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -164,6 +164,22 @@ class DemoAppState extends State<DemoApp> {
                       foregroundColor: Theme.of(context).colorScheme.onPrimary,
                       backgroundColor: Theme.of(context).colorScheme.primary,
                     ),
+                    onPressed: text.isEmpty && imagePaths.isEmpty
+                        ? null
+                        : () =>
+                            _onShareWithResult(context, shouldAutoClose: true),
+                    child: const Text('Share with auto close in 5 seconds'),
+                  );
+                },
+              ),
+              const SizedBox(height: 16),
+              Builder(
+                builder: (BuildContext context) {
+                  return ElevatedButton(
+                    style: ElevatedButton.styleFrom(
+                      foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                      backgroundColor: Theme.of(context).colorScheme.primary,
+                    ),
                     onPressed: () {
                       _onShareXFileFromAssets(context);
                     },
@@ -200,7 +216,8 @@ class DemoAppState extends State<DemoApp> {
     });
   }
 
-  void _onShareWithResult(BuildContext context) async {
+  void _onShareWithResult(BuildContext context,
+      {bool shouldAutoClose = false}) async {
     // A builder is used to retrieve the context immediately
     // surrounding the ElevatedButton.
     //
@@ -229,6 +246,12 @@ class DemoAppState extends State<DemoApp> {
         sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
       );
     } else {
+      if (shouldAutoClose) {
+        Future.delayed(const Duration(seconds: 5), () async {
+          await Share.close();
+        });
+      }
+
       shareResult = await Share.share(
         text,
         subject: subject,

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -4,7 +4,11 @@ description: Demonstrates how to use the share_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  share_plus: ^9.0.0
+  share_plus:
+    git:
+      url: git@github.com:Pierre-Monier/plus_plugins.git
+      ref: feat/close-share-plus-sheet
+      path: packages/share_plus
   image_picker: ^1.0.0
   file_selector: ^1.0.0
 

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -5,10 +5,7 @@ dependencies:
   flutter:
     sdk: flutter
   share_plus:
-    git:
-      url: git@github.com:Pierre-Monier/plus_plugins.git
-      ref: feat/close-share-plus-sheet
-      path: packages/share_plus
+    path: ../
   image_picker: ^1.0.0
   file_selector: ^1.0.0
 

--- a/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
@@ -348,6 +348,18 @@ TopViewControllerForViewController(UIViewController *viewController) {
               withController:topViewController
                     atSource:originRect
                     toResult:result];
+        } else if ([@"close" isEqualToString:call.method]) {
+            UIViewController *rootViewController = RootViewController();
+            if (!rootViewController) {
+              result([FlutterError errorWithCode:@"error"
+                                         message:@"No root view controller found"
+                                         details:nil]);
+              return;
+            }
+            UIViewController *topViewController =
+                TopViewControllerForViewController(rootViewController);
+            
+            [topViewController dismissViewControllerAnimated:YES completion:nil];
         } else {
           result(FlutterMethodNotImplemented);
         }

--- a/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
@@ -359,7 +359,7 @@ TopViewControllerForViewController(UIViewController *viewController) {
             UIViewController *topViewController =
                 TopViewControllerForViewController(rootViewController);
             
-            [topViewController dismissViewControllerAnimated:YES completion:nil];
+            [topViewController dismissViewControllerAnimated:NO completion:nil];
             result(nil);
         } else {
           result(FlutterMethodNotImplemented);

--- a/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
@@ -360,6 +360,7 @@ TopViewControllerForViewController(UIViewController *viewController) {
                 TopViewControllerForViewController(rootViewController);
             
             [topViewController dismissViewControllerAnimated:YES completion:nil];
+            result(nil);
         } else {
           result(FlutterMethodNotImplemented);
         }

--- a/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/Classes/FPPSharePlusPlugin.m
@@ -359,7 +359,7 @@ TopViewControllerForViewController(UIViewController *viewController) {
             UIViewController *topViewController =
                 TopViewControllerForViewController(rootViewController);
             
-            [topViewController dismissViewControllerAnimated:NO completion:nil];
+            [topViewController dismissViewControllerAnimated:YES completion:nil];
             result(nil);
         } else {
           result(FlutterMethodNotImplemented);

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -133,7 +133,12 @@ class Share {
       subject: subject,
       text: text,
       sharePositionOrigin: sharePositionOrigin,
-      fileNameOverrides: fileNameOverrides,
+      // fileNameOverrides: fileNameOverrides,
     );
+  }
+
+  /// Closes the share sheet. Currently only supported on iOS.
+  static Future<void> close() async {
+    return _platform.close();
   }
 }

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -133,7 +133,7 @@ class Share {
       subject: subject,
       text: text,
       sharePositionOrigin: sharePositionOrigin,
-      // fileNameOverrides: fileNameOverrides,
+      fileNameOverrides: fileNameOverrides,
     );
   }
 

--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -74,4 +74,12 @@ class SharePlusLinuxPlugin extends SharePlatform {
       'shareXFiles() has not been implemented on Linux.',
     );
   }
+
+  /// Closes the share sheet. Currently only supported on iOS.
+  @override
+  Future<ShareResult> close() {
+    throw UnimplementedError(
+      'close() has not been implemented on Linux.',
+    );
+  }
 }

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -227,6 +227,14 @@ class SharePlusWebPlugin extends SharePlatform {
     }
   }
 
+  /// Close the share sheet. Currently only supported on iOS.
+  @override
+  Future<ShareResult> close() {
+    throw UnimplementedError(
+      'close() has not been implemented on Web.',
+    );
+  }
+
   static Future<web.File> _fromXFile(XFile file, {String? nameOverride}) async {
     final bytes = await file.readAsBytes();
     return web.File(

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -79,4 +79,12 @@ class SharePlusWindowsPlugin extends SharePlatform {
       'shareXFiles() is only available for Windows versions higher than 10.0.${VersionHelper.kWindows10RS5BuildNumber}.',
     );
   }
+
+  /// Closes the share sheet. Currently only supported on iOS.
+  @override
+  Future<ShareResult> close() {
+    throw UnimplementedError(
+      'close() has not been implemented on Windows.',
+    );
+  }
 }

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -35,7 +35,11 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  share_plus_platform_interface: ^4.0.0
+  share_plus_platform_interface:
+    git:
+      url: git@github.com:Pierre-Monier/plus_plugins.git
+      ref: feat/close-share-plus-sheet
+      path: packages/share_plus_platform_interface
   file: ">=6.1.4 <8.0.0"
   url_launcher_web: ^2.0.16
   url_launcher_windows: ^3.0.6

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
     git:
       url: git@github.com:Pierre-Monier/plus_plugins.git
       ref: feat/close-share-plus-sheet
-      path: packages/share_plus_platform_interface
+      path: packages/share_plus/share_plus_platform_interface
   file: ">=6.1.4 <8.0.0"
   url_launcher_web: ^2.0.16
   url_launcher_windows: ^3.0.6

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -4,16 +4,15 @@
 
 import 'dart:async';
 import 'dart:io';
-
 // Keep dart:ui for retrocompatiblity with Flutter <3.3.0
 // ignore: unnecessary_import
 import 'dart:ui';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:mime/mime.dart' show extensionFromMime, lookupMimeType;
-import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
 import 'package:uuid/uuid.dart';
 
 /// Plugin for summoning a platform share sheet.
@@ -113,6 +112,17 @@ class MethodChannelShare extends SharePlatform {
         'dev.fluttercommunity.plus/share/unavailable';
 
     return ShareResult(result, _statusFromResult(result));
+  }
+
+  /// Closes the share sheet. Currently only supported on iOS.
+  @override
+  Future<void> close() {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      // Currently not supported outside of iOS
+      return Future<void>.value();
+    }
+
+    return channel.invokeMethod<void>('close');
   }
 
   /// Ensure that a file is readable from the file system. Will create file on-demand under TemporaryDiectory and return the temporary file otherwise.

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -71,6 +71,11 @@ class SharePlatform extends PlatformInterface {
       fileNameOverrides: fileNameOverrides,
     );
   }
+
+  /// Close the share sheet. Currently only supported on iOS.
+  Future<void> close() {
+    return _instance.close();
+  }
 }
 
 /// The result of a share to determine what action the


### PR DESCRIPTION
## Description

*Add a `close` method to the `share_plus` plugin. Currently, it only works on iOS (this was my need for a project). This support only one platform, but after discussing in [this issue](https://github.com/fluttercommunity/plus_plugins/issues/1067) it appears to be ok to open a PR.*

## Related Issues

- *Related #1067*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

