### PR TITLE
ci(android_alarm_manager_plus): Fix integration test example package name

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -82,4 +82,4 @@ jobs:
           arch: x86_64
           force-avd-creation: false
           profile: Nexus 5X
-          script: ./.github/workflows/scripts/integration-test.sh android android_alarm_manager_example
+          script: ./.github/workflows/scripts/integration-test.sh android android_alarm_manager_plus_example


### PR DESCRIPTION
## Description

Package name in the CI workflow was incorrect, the `_plus_` in the name was missing, so the integration tests didn't run any code. 

## Related Issues

- None

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

