### PR TITLE
fix(battery_plus): Fix type conversion

### DIFF
--- a/packages/battery_plus/battery_plus/lib/src/battery_plus_web.dart
+++ b/packages/battery_plus/battery_plus/lib/src/battery_plus_web.dart
@@ -44,7 +44,7 @@ class BatteryPlusWebPlugin extends BatteryPlatform {
 
     // level is a number representing the system's battery charge level scaled to a value between 0.0 and 1.0
     final level = batteryManager.level;
-    return level * 100 as int;
+    return (level * 100).toInt();
   }
 
   /// Returns the current battery state.


### PR DESCRIPTION
## Description

When wasm is used, there is a complete distinction between double and int. For this reason, casting a double type to an int type with `as` will cause a crash in the wasm environment. Fix this problem by changing from `as int` to `toInt()`.

---

https://github.com/flutter/flutter/pull/146231

Starting with flutter 3.24, the `flutter run --wasm` command makes it easy to try out the wasm version of the app at local.

## Related Issues

- Related https://github.com/fluttercommunity/plus_plugins/pull/3103#issuecomment-2273891732

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

