### PR TITLE
docs(battery_plus): Update plugin requirements

### DIFF
--- a/packages/battery_plus/battery_plus/README.md
+++ b/packages/battery_plus/battery_plus/README.md
@@ -16,8 +16,8 @@ A Flutter plugin to access various information about the battery of the device t
 
 ## Requirements
 
-- Flutter >=3.3.0
-- Dart >=2.18.0 <4.0.0
+- Flutter >=3.19.0
+- Dart >=3.3.0 <4.0.0
 - iOS >=12.0
 - MacOS >=10.14
 - Android `compileSDK` 34


### PR DESCRIPTION
## Description

Requirements section was outdated, so this PR fixes it.
