### PR TITLE
fix(device_info_plus): fix type casting for WASM

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:js_interop';
 import 'package:web/web.dart' as html show window, Navigator;
 
 import 'package:device_info_plus_platform_interface/device_info_plus_platform_interface.dart';
@@ -30,7 +31,7 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
           'appVersion': _navigator.appVersion,
           'deviceMemory': _navigator.deviceMemory,
           'language': _navigator.language,
-          'languages': _navigator.languages,
+          'languages': _navigator.languages.toDart,
           'platform': _navigator.platform,
           'product': _navigator.product,
           'productSub': _navigator.productSub,
@@ -49,5 +50,5 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
 /// Ticket: https://github.com/dart-lang/web/issues/192
 /// Probably won't be an int? in the future!
 extension on html.Navigator {
-  external int? get deviceMemory;
+  external double? get deviceMemory;
 }

--- a/packages/device_info_plus/device_info_plus/lib/src/model/web_browser_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/web_browser_info.dart
@@ -71,7 +71,7 @@ class WebBrowserInfo implements BaseDeviceInfo {
   final String? appVersion;
 
   /// the amount of device memory in gigabytes. This value is an approximation given by rounding to the nearest power of 2 and dividing that number by 1024.
-  final int? deviceMemory;
+  final double? deviceMemory;
 
   /// a DOMString representing the preferred language of the user, usually the language of the browser UI. The null value is returned when this is unknown.
   final String? language;


### PR DESCRIPTION
## Description

Fix some types casting on web implementation for WASM compilation

## Related Issues

- FIX #2966

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

