### PR TITLE
docs: Add link to gradle plugin docs in COMPILATION.yaml

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.yaml
+++ b/.github/ISSUE_TEMPLATE/BUG.yaml
@@ -12,6 +12,8 @@ body:
         or consider asking a question on Stack Overflow:
         * https://plus.fluttercommunity.dev/docs/overview
 
+        If you have a **compilation issue**, please use the [Compile Issue Template](https://github.com/fluttercommunity/plus_plugins/issues/new?assignees=&labels=compile%2Ctriage&projects=&template=COMPILATION.yaml&title=%5BCompile%5D%3A+).
+
         If you have found a bug or if our documentation doesn't have an answer
         to what you're looking for, then fill our the template below.
      

--- a/.github/ISSUE_TEMPLATE/COMPILATION.yaml
+++ b/.github/ISSUE_TEMPLATE/COMPILATION.yaml
@@ -13,6 +13,7 @@ body:
         3. Search on Google or other general purpose search engines.
         4. Perform a `flutter upgrade`, followed by `flutter pub upgrade` and finally `flutter clean`, then try again.
         5. Perform a `flutter pub cache repair` to clean install of the packages in your system cache. See [`dart pub cache`](https://dart.dev/tools/pub/cmd/pub-cache) for more info.
+        6. Android compilation issues? Ensure your gradle configuration is up-to-date: https://docs.flutter.dev/release/breaking-changes/flutter-gradle-plugin-apply
 
         If you can prove that you have done all these steps and still have problems, proceed with the following template.
 


### PR DESCRIPTION
## Description

Maybe we avoid some of the Android compilation tickets we have been seeing recently.

