### PR TITLE
fix(share_plus): #2910 Handle user dismissing dialog on shareUri() in web

### DIFF
--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -56,6 +56,10 @@ class SharePlusWebPlugin extends SharePlatform {
     try {
       await _navigator.share(data).toDart;
     } on DOMException catch (e) {
+      if (e.name case 'AbortError') {
+        return _resultDismissed;
+      }
+
       developer.log(
         'Failed to share uri',
         error: '${e.name}: ${e.message}',


### PR DESCRIPTION
## Description

Adds the missing error handling that can be seen in the `share()` and `shareXFiles()` method.

## Related Issues

- Fix #2910

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

