### PR TITLE
fix(network_info_plus): Avoid usage of unsupported package:win32 versions

### DIFF
--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
     sdk: flutter
   meta: ^1.8.0
   network_info_plus_platform_interface: ^2.0.1
-  win32: ^5.3.0
+  win32: ^5.4.0
   ffi: ^2.0.1
 
 dev_dependencies:

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -40,8 +40,7 @@ dependencies:
     sdk: flutter
   meta: ^1.8.0
   network_info_plus_platform_interface: ^2.0.1
-  # win32 is compatible across v4 and v5 for Win32 only (not COM)
-  win32: ">=4.0.0 <6.0.0"
+  win32: ^5.3.0
   ffi: ^2.0.1
 
 dev_dependencies:


### PR DESCRIPTION
## Description

Thanks to analyzer on pub.dev I found out that we declared incorrect range of supported win32 versions, so users with `win32` v4 would see errors as some constants are not available there. 
<img width="819" alt="Screenshot 2024-08-13 at 13 21 47" src="https://github.com/user-attachments/assets/9d0c12f7-30b6-4ee6-af6e-d974513e42ef">

I did the check with `flutter pub downgrade` which brought me win32 v4 
<img width="212" alt="Screenshot 2024-08-13 at 18 36 49" src="https://github.com/user-attachments/assets/00054a67-d9a4-4a58-bd4b-390081e2234c">

and `flutter analyze` to see the same set of issues as reported on pub.dev:
<img width="1400" alt="Screenshot 2024-08-13 at 18 36 40" src="https://github.com/user-attachments/assets/6110a457-7ec0-49cd-af2a-f08591ef6e97">

It looks like not a lot of people had codebases with old win32 versions, so we saw no reports for this issue so far (or I missed them).
In any case in this PR I declared win32 with min 5.4.0 where the constants in question are already in their new place.
I expect this change to be non-breaking for the same reason as why we haven't seen reports for the issue - not a lot of people rely on old win32 version.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

