### PR TITLE
docs: Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -284,11 +284,11 @@ Some things to keep in mind before publishing the release:
 1. Switch to `main` branch locally.
 2. Run `git pull origin main`.
 3. Run `git pull --tags` to make sure all tags are fetched.
-4. Create new branch with the signature `release/[year]-[month]-[day]`.
+4. Create new branch with the signature `release/[year]-[month]-[day]` and push it without any commits to remote as otherwise Melos would fail to version changes on next steps.
 5. Run `melos version --no-git-commit-version` to automatically version packages and update Changelogs.
 6. Run `melos publish` to dry run and confirm all packages are publishable.
 7. After successful dry run, commit all changes with the signature "chore(release): prepare for release".
 8. Run `git push origin [RELEASE BRANCH NAME]` & open pull request for review on GitHub.
 9. After successful review and merge of the pull request, switch to main branch locally, & run `git pull origin main`.
-10. Run `melos publish --no-dry-run --git-tag-version` to now publish to Pub.dev.
+10. Run `melos publish --no-dry-run --git-tag-version` to now publish to pub.dev.
 11. Run `git push --tags` to push tags to repository.


### PR DESCRIPTION
## Description

Adding a mention for the required step during release creation. With new versions of Melos `melos version` will throw exception if the current branch is local only.