### PR TITLE
fix(device_info_plus): Fix type cast of digitalProductId on windows

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
@@ -56,7 +56,7 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
       final digitalProductId = digitalProductIdValue != null &&
               digitalProductIdValue.data is Uint8List
           ? digitalProductIdValue.data as Uint8List
-          : [] as Uint8List;
+          : Uint8List.fromList([]);
       final displayVersion =
           currentVersionKey.getValueAsString('DisplayVersion') ?? '';
       final editionId = currentVersionKey.getValueAsString('EditionID') ?? '';


### PR DESCRIPTION
## Description

This PR fixes a type cast error if `digitalProductId` does not exist. 

`[] as Uint8List` causes the following error: `type 'List<dynamic>' is not a subtype of type 'Uint8List' in type cast`

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

