### PR TITLE
ci(all): Remove Gradle Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,24 +28,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
-  - package-ecosystem: "gradle"
-    directory: "/packages/android_alarm_manager_plus/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/android_alarm_manager_plus/example/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
   - package-ecosystem: "pub"
     directory: "/packages/android_alarm_manager_plus/example"
     schedule:
@@ -83,24 +65,6 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/android_intent_plus/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/android_intent_plus/example/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
 
   # Battery Plus dependencies updates config
 
@@ -140,24 +104,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
-  - package-ecosystem: "gradle"
-    directory: "/packages/battery_plus/battery_plus/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  - package-ecosystem: "gradle"
-    directory: "packages/battery_plus/battery_plus/example/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
   # Connectivity Plus dependencies updates config
 
   - package-ecosystem: "pub"
@@ -195,24 +141,6 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/connectivity_plus/connectivity_plus/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/connectivity_plus/connectivity_plus/example/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
 
   # Device Info Plus dependencies updates config
 
@@ -252,24 +180,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
-  - package-ecosystem: "gradle"
-    directory: "/packages/device_info_plus/device_info_plus/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/device_info_plus/device_info_plus/example/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
   # Network Info Plus dependencies updates config
 
   - package-ecosystem: "pub"
@@ -307,24 +217,6 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/network_info_plus/network_info_plus/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/network_info_plus/network_info_plus/example/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
 
   # Package Info Plus dependencies updates config
 
@@ -364,24 +256,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
-  - package-ecosystem: "gradle"
-    directory: "/packages/package_info_plus/package_info_plus/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/package_info_plus/package_info_plus/example/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
   # Sensors Plus dependencies updates config
 
   - package-ecosystem: "pub"
@@ -420,24 +294,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
-  - package-ecosystem: "gradle"
-    directory: "/packages/sensors_plus/sensors_plus/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/sensors_plus/sensors_plus/example/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
   # Share Plus dependencies updates config
 
   - package-ecosystem: "pub"
@@ -475,21 +331,3 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/share_plus/share_plus/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  - package-ecosystem: "gradle"
-    directory: "/packages/share_plus/share_plus/example/android"
-    schedule:
-      interval: "monthly"
-    rebase-strategy: "disabled"
-    commit-message:
-      prefix: "chore"
-      include: "scope"


### PR DESCRIPTION
## Description

As discussed internally, we remove the Gradle dependabot config to avoid having an overwhelming amount of PRs opened every month.

Android dependencies should be updated manually, since not all versions are compatible with Flutter, so this requires extra work than just merging them.

## Related Issues

- See all Dependabot "java" PRs

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

