### PR TITLE
fix(all): Add macOS Privacy Manifests

### DIFF
--- a/packages/battery_plus/battery_plus/macos/PrivacyInfo.xcprivacy
+++ b/packages/battery_plus/battery_plus/macos/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/battery_plus/battery_plus/macos/battery_plus.podspec
+++ b/packages/battery_plus/battery_plus/macos/battery_plus.podspec
@@ -19,4 +19,5 @@ A Flutter plugin for accessing information about the battery state(full, chargin
   s.platform = :osx, '10.14'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
+  s.resource_bundles = {'batery_plus_privacy' => ['PrivacyInfo.xcprivacy']}
 end

--- a/packages/device_info_plus/device_info_plus/macos/PrivacyInfo.xcprivacy
+++ b/packages/device_info_plus/device_info_plus/macos/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/device_info_plus/device_info_plus/macos/device_info_plus.podspec
+++ b/packages/device_info_plus/device_info_plus/macos/device_info_plus.podspec
@@ -19,4 +19,5 @@ https://github.com/flutter/flutter/issues/46618
 
   s.platform = :osx
   s.osx.deployment_target = '10.14'
+  s.resource_bundles = {'device_info_plus_privacy' => ['PrivacyInfo.xcprivacy']}
 end

--- a/packages/network_info_plus/network_info_plus/macos/PrivacyInfo.xcprivacy
+++ b/packages/network_info_plus/network_info_plus/macos/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/network_info_plus/network_info_plus/macos/network_info_plus.podspec
+++ b/packages/network_info_plus/network_info_plus/macos/network_info_plus.podspec
@@ -19,5 +19,6 @@ Pod::Spec.new do |s|
 
   s.platform = :osx
   s.osx.deployment_target = '10.14'
+  s.resource_bundles = {'network_info_plus_privacy' => ['PrivacyInfo.xcprivacy']}
 end
 

--- a/packages/package_info_plus/package_info_plus/macos/PrivacyInfo.xcprivacy
+++ b/packages/package_info_plus/package_info_plus/macos/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/package_info_plus/package_info_plus/macos/package_info_plus.podspec
+++ b/packages/package_info_plus/package_info_plus/macos/package_info_plus.podspec
@@ -17,4 +17,5 @@ Pod::Spec.new do |s|
   s.dependency 'FlutterMacOS'
   s.platform = :osx, '10.14'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.resource_bundles = {'package_info_plus_privacy' => ['PrivacyInfo.xcprivacy']}
 end

--- a/packages/share_plus/share_plus/macos/PrivacyInfo.xcprivacy
+++ b/packages/share_plus/share_plus/macos/PrivacyInfo.xcprivacy
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/packages/share_plus/share_plus/macos/share_plus.podspec
+++ b/packages/share_plus/share_plus/macos/share_plus.podspec
@@ -19,4 +19,5 @@ https://github.com/flutter/flutter/issues/46618
 
   s.platform = :osx
   s.osx.deployment_target = '10.14'
+  s.resource_bundles = {'share_plus_privacy' => ['PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
## Description

*This PR is to add privacy manifests to macOS.*

## Related Issues

- *Fix #3250*

## Checklist

- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

