### PR TITLE
fix(device_info_plus)!: fixed webasm compliance

### DIFF
--- a/packages/device_info_plus/device_info_plus/example/web/index.html
+++ b/packages/device_info_plus/device_info_plus/example/web/index.html
@@ -18,16 +18,6 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
-  <script>
-    if ('serviceWorker' in navigator) {
-      window.addEventListener('load', function () {
-        navigator.serviceWorker.register('flutter_service_worker.js');
-      });
-    }
-  </script>
-  <script src="main.dart.js" type="application/javascript"></script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>

--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:js_interop';
 import 'package:web/web.dart' as html show window, Navigator;
 
 import 'package:device_info_plus_platform_interface/device_info_plus_platform_interface.dart';
@@ -30,7 +31,7 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
           'appVersion': _navigator.appVersion,
           'deviceMemory': _navigator.deviceMemory,
           'language': _navigator.language,
-          'languages': _navigator.languages,
+          'languages': _navigator.languages.toDart,
           'platform': _navigator.platform,
           'product': _navigator.product,
           'productSub': _navigator.productSub,
@@ -47,7 +48,6 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
 
 /// Property is missing.
 /// Ticket: https://github.com/dart-lang/web/issues/192
-/// Probably won't be an int? in the future!
 extension on html.Navigator {
-  external int? get deviceMemory;
+  external double? get deviceMemory;
 }

--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
@@ -45,9 +45,3 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
     );
   }
 }
-
-/// Property is missing.
-/// Ticket: https://github.com/dart-lang/web/issues/192
-extension on html.Navigator {
-  external double? get deviceMemory;
-}

--- a/packages/device_info_plus/device_info_plus/lib/src/model/web_browser_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/web_browser_info.dart
@@ -71,7 +71,7 @@ class WebBrowserInfo implements BaseDeviceInfo {
   final String? appVersion;
 
   /// the amount of device memory in gigabytes. This value is an approximation given by rounding to the nearest power of 2 and dividing that number by 1024.
-  final int? deviceMemory;
+  final double? deviceMemory;
 
   /// a DOMString representing the preferred language of the user, usually the language of the browser UI. The null value is returned when this is unknown.
   final String? language;

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.8.0
-  web: ">=0.5.0 <2.0.0"
+  web: ^1.0.0
 
   # win32 is compatible across v4 and v5 for Win32 only (not COM)
   win32: ">=4.0.0 <6.0.0"

--- a/packages/device_info_plus/device_info_plus/test/model/web_browser_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/web_browser_info_test.dart
@@ -11,7 +11,7 @@ void main() {
         'appCodeName': 'appCodeName',
         'appName': 'appName',
         'appVersion': 'appVersion',
-        'deviceMemory': 42,
+        'deviceMemory': 42.0,
         'language': 'language',
         'languages': ['en', 'es'],
         'platform': 'platform',


### PR DESCRIPTION
## Description

This PR allows device_info_plus to be used in a web project compiled to webasm.

For that a type had to be changed (devicememory became a double?) and one converted from JStype to dart type.
I also took the liberty to update the example "index.html" file, as it was based on a deprecated template and not compatible with webasm compilation.

Most of this commit is a copy of what was done in https://github.com/fluttercommunity/plus_plugins/pull/3161 by @GiacomoPignoni . Credits go to him.

## Related Issues
- *Fix #3253*


## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR. => not directly on my modifications


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

