### PR TITLE
Update SystemUUID.swift

### DIFF
--- a/packages/device_info_plus/device_info_plus/macos/Classes/SystemUUID.swift
+++ b/packages/device_info_plus/device_info_plus/macos/Classes/SystemUUID.swift
@@ -6,11 +6,13 @@ public struct SystemUUID {
         let dev = IOServiceMatching("IOPlatformExpertDevice")
         
         var platformExpert: io_service_t
-        if #available(macOS 12, *) {
+        #if MACOS12_OR_LATER
+            print("Running on macOS 12 or newer")
             platformExpert = IOServiceGetMatchingService(kIOMainPortDefault, dev)
-        } else {
+        #else
+            print("Running on an older version of macOS")
             platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault, dev)
-        }
+        #endif
         
         let serialNumberAsCFString = IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformUUIDKey as CFString, kCFAllocatorDefault, 0)
         IOObjectRelease(platformExpert)


### PR DESCRIPTION
Fix For older Maxos platforms.
#available(macOS 12, *) is not available on runtime for older platforms it must be replaced by Compiletime directive #if MACOS12_OR_LATER

## Description

I have an older laptop and I can't compile this code because  if #available(macOS 12, *) { this function is not available on older mac platforms. Ater I replaced it with compile time directive it start to works.



