### PR TITLE
chore(all): set `win32` dependency to `^5.5.3`

### DIFF
--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -38,9 +38,7 @@ dependencies:
     sdk: flutter
   meta: ^1.8.0
   web: ">=0.5.0 <2.0.0"
-
-  # win32 is compatible across v4 and v5 for Win32 only (not COM)
-  win32: ">=4.0.0 <6.0.0"
+  win32: "^5.5.3"
   win32_registry: ^1.1.0
 
 dev_dependencies:

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
     sdk: flutter
   meta: ^1.8.0
   web: ">=0.5.0 <2.0.0"
-  win32: "^5.5.3"
+  win32: ^5.5.3
   win32_registry: ^1.1.0
 
 dev_dependencies:

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
     sdk: flutter
   meta: ^1.8.0
   network_info_plus_platform_interface: ^2.0.1
-  win32: ^5.4.0
+  win32: ^5.5.3"
   ffi: ^2.0.1
 
 dev_dependencies:

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -40,7 +40,7 @@ dependencies:
     sdk: flutter
   meta: ^1.8.0
   network_info_plus_platform_interface: ^2.0.1
-  win32: ^5.5.3"
+  win32: ^5.5.3
   ffi: ^2.0.1
 
 dev_dependencies:

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   path: ^1.8.2
   package_info_plus_platform_interface: ^3.0.1
   web: ">=0.5.0 <2.0.0"
-  win32: "^5.5.3"
+  win32: ^5.5.3
   clock: ^1.1.1
 
 dev_dependencies:

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -38,9 +38,7 @@ dependencies:
   path: ^1.8.2
   package_info_plus_platform_interface: ^3.0.1
   web: ">=0.5.0 <2.0.0"
-
-  # win32 is compatible across v4 and v5 for Win32 only (not COM)
-  win32: ">=4.0.0 <6.0.0"
+  win32: "^5.5.3"
   clock: ^1.1.1
 
 dev_dependencies:

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   url_launcher_platform_interface: ^2.3.2
   ffi: ^2.1.2
   web: ^1.0.0
-  win32: "^5.5.3"
+  win32: ^5.5.3
 
 dev_dependencies:
   flutter_test:

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -43,9 +43,7 @@ dependencies:
   url_launcher_platform_interface: ^2.3.2
   ffi: ^2.1.2
   web: ^1.0.0
-
-  # win32 is compatible across v4 and v5 for Win32 only (not COM)
-  win32: ">=4.0.0 <6.0.0"
+  win32: "^5.5.3"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

Due to incompatibility with `web32 (<5.5.1)` and `dart (>=3.5.0)`, I changed the web32 version to use the latest version rather than a range.

## Related Issues

- Reported in #3259
- Mentioned here: https://github.com/halildurmus/win32/issues/887#issuecomment-2329109205

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

