### PR TITLE
fix(all): Clean up macOS Privacy Manifests

### DIFF
--- a/packages/battery_plus/battery_plus/macos/PrivacyInfo.xcprivacy
+++ b/packages/battery_plus/battery_plus/macos/PrivacyInfo.xcprivacy
@@ -4,8 +4,6 @@
 <dict>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyTracking</key>

--- a/packages/device_info_plus/device_info_plus/macos/PrivacyInfo.xcprivacy
+++ b/packages/device_info_plus/device_info_plus/macos/PrivacyInfo.xcprivacy
@@ -4,8 +4,6 @@
 <dict>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyTracking</key>

--- a/packages/network_info_plus/network_info_plus/macos/PrivacyInfo.xcprivacy
+++ b/packages/network_info_plus/network_info_plus/macos/PrivacyInfo.xcprivacy
@@ -4,8 +4,6 @@
 <dict>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyTracking</key>

--- a/packages/package_info_plus/package_info_plus/macos/PrivacyInfo.xcprivacy
+++ b/packages/package_info_plus/package_info_plus/macos/PrivacyInfo.xcprivacy
@@ -4,8 +4,6 @@
 <dict>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyTracking</key>

--- a/packages/share_plus/share_plus/macos/PrivacyInfo.xcprivacy
+++ b/packages/share_plus/share_plus/macos/PrivacyInfo.xcprivacy
@@ -4,8 +4,6 @@
 <dict>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
-	<key>NSPrivacyAccessedAPITypes</key>
-	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyTracking</key>


### PR DESCRIPTION
## Description

Clean up macOS manifests

## Related Issues

- *Fix #3263*

## Checklist

- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.

