### PR TITLE
feat(share_plus): add option to add custom link title on Android

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
@@ -29,6 +29,7 @@ internal class MethodCallHandler(
                         call.argument<Any>("uri") as String,
                         subject = null,
                         withResult = isWithResult,
+                        call.argument<Any>("title") as String?,
                     )
                     success(isWithResult, result)
                 }
@@ -38,6 +39,7 @@ internal class MethodCallHandler(
                         call.argument<Any>("text") as String,
                         call.argument<Any>("subject") as String?,
                         isWithResult,
+                        null,
                     )
                     success(isWithResult, result)
                 }

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -55,13 +55,16 @@ internal class Share(
         this.activity = activity
     }
 
-    fun share(text: String, subject: String?, withResult: Boolean) {
+    fun share(text: String, subject: String?, withResult: Boolean, title: String?) {
         val shareIntent = Intent().apply {
             action = Intent.ACTION_SEND
             type = "text/plain"
             putExtra(Intent.EXTRA_TEXT, text)
             if (subject != null) {
                 putExtra(Intent.EXTRA_SUBJECT, subject)
+            }
+            if (title != null) {
+                putExtra(Intent.EXTRA_TITLE, title)
             }
         }
         // If we dont want the result we use the old 'createChooser'
@@ -97,7 +100,7 @@ internal class Share(
         val shareIntent = Intent()
         when {
             (fileUris.isEmpty() && !text.isNullOrBlank()) -> {
-                share(text, subject, withResult)
+                share(text, subject, withResult, null)
                 return
             }
 

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -30,6 +30,9 @@ class Share {
   /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
   /// on other devices.
   ///
+  /// The optional [title] parameter can be used to specify a custom title for
+  /// the uri on Android. It has no effect on other devices.
+  ///
   /// May throw [PlatformException]
   /// from [MethodChannel].
   ///
@@ -37,10 +40,12 @@ class Share {
   static Future<ShareResult> shareUri(
     Uri uri, {
     Rect? sharePositionOrigin,
+    String? title,
   }) async {
     return _platform.shareUri(
       uri,
       sharePositionOrigin: sharePositionOrigin,
+      title: title,
     );
   }
 

--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -24,6 +24,7 @@ class SharePlusLinuxPlugin extends SharePlatform {
     String? subject,
     String? text,
     Rect? sharePositionOrigin,
+    String? title,
   }) async {
     throw UnimplementedError(
         'shareUri() has not been implemented on Linux. Use share().');

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -32,6 +32,7 @@ class SharePlusWebPlugin extends SharePlatform {
   Future<ShareResult> shareUri(
     Uri uri, {
     Rect? sharePositionOrigin,
+    String? title,
   }) async {
     final data = ShareData(
       url: uri.toString(),

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -29,6 +29,7 @@ class SharePlusWindowsPlugin extends SharePlatform {
     String? subject,
     String? text,
     Rect? sharePositionOrigin,
+    String? title,
   }) async {
     throw UnimplementedError(
         'shareUri() has not been implemented on Windows. Use share().');

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -27,6 +27,7 @@ class MethodChannelShare extends SharePlatform {
   Future<ShareResult> shareUri(
     Uri uri, {
     Rect? sharePositionOrigin,
+    String? title,
   }) async {
     final params = <String, dynamic>{'uri': uri.toString()};
 
@@ -35,6 +36,10 @@ class MethodChannelShare extends SharePlatform {
       params['originY'] = sharePositionOrigin.top;
       params['originWidth'] = sharePositionOrigin.width;
       params['originHeight'] = sharePositionOrigin.height;
+    }
+
+    if (title != null) {
+      params['title'] = title;
     }
 
     final result = await channel.invokeMethod<String>('shareUri', params) ??

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -35,10 +35,12 @@ class SharePlatform extends PlatformInterface {
   Future<ShareResult> shareUri(
     Uri uri, {
     Rect? sharePositionOrigin,
+    String? title,
   }) {
     return _instance.shareUri(
       uri,
       sharePositionOrigin: sharePositionOrigin,
+      title: title,
     );
   }
 


### PR DESCRIPTION
## Description

This adds the possibility to add a custom link title to URIs on Android. As far as I am aware this feature is not available on iOS, so I did not implement it. I only added it to the `shareURI` method, as this is already a mobile only and already has platform specific parameters (`sharePositionOrigin`).

## Related Issues

There is no open issue about it, I was thinking about opening one up but decided to implement it instead.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

