### PR TITLE
fix(android): set title for chooser

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -62,6 +62,7 @@ internal class Share(
             putExtra(Intent.EXTRA_TEXT, text)
             if (subject != null) {
                 putExtra(Intent.EXTRA_SUBJECT, subject)
+                putExtra(Intent.EXTRA_TITLE, subject)
             }
         }
         // If we dont want the result we use the old 'createChooser'


### PR DESCRIPTION

## Description

This PR sets the EXTRA_TITLE data on Android Intents if a subject was given. This is used as the title for the chooser dialog as per [documentation](https://developer.android.com/reference/android/content/Intent.html#EXTRA_TITLE). It's also what Chromium uses for its Share API, see [here](https://source.chromium.org/chromium/chromium/src/+/main:components/browser_ui/share/android/java/src/org/chromium/components/browser_ui/share/ShareHelper.java;l=390;drc=e66b343b5554785a32ad988bfe5c3c524f5e1857)

Re: Contributing.md:
On iOS, the Chooser already shows the given subject as title. Just as additional input for contribution type 🟡 (Changing a platform implementation)

## Related Issues

Did not find nor file an issue for this yet

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing. _(at least local ones, let's see about workflow runs)_
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR. _(no new ones at least, it reports the same issues as on main)_

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

