### PR TITLE
feat(android_intent_plus): adds getResolvedActivity method

### DIFF
--- a/packages/android_intent_plus/README.md
+++ b/packages/android_intent_plus/README.md
@@ -83,6 +83,25 @@ of integers or strings.
 > ACTION_VIEW intents for Android, however this intent plugin also allows
 > clients to set extra parameters for the intent.
 
+### Querying activities
+`canResolveActivity()` and `getResolvedActivity()` can be used to query whether an activity can handle an intent,
+or get the details of the activity that can handle the intent.
+
+```dart
+final intent = AndroidIntent(
+      action: 'action_view',
+      data: Uri.encodeFull('http://'),
+    );
+
+// can this intent be handled by an activity
+final canHandleIntent = await intent.canResolveActivity();
+
+// get the details of the activity that will handle this intent
+final details = await intent.getResolvedActivity();
+
+print(details.packageName); // prints com.google.chrome
+```
+
 ## Android 11 package visibility
 
 Android 11 introduced new permissions for package visibility.

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
@@ -119,6 +119,8 @@ public final class MethodCallHandlerImpl implements MethodCallHandler {
       result.success(null);
     } else if ("canResolveActivity".equalsIgnoreCase(call.method)) {
       result.success(sender.canResolveActivity(intent));
+    } else if ("getResolvedActivity".equalsIgnoreCase(call.method)) {
+      result.success(sender.getResolvedActivity(intent));
     } else {
       result.notImplemented();
     }

--- a/packages/android_intent_plus/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/android_intent_plus/example/android/app/src/main/AndroidManifest.xml
@@ -8,7 +8,18 @@
        flutter needs it to communicate with the running application
        to allow setting breakpoints, to provide hot reload, etc.
     -->
-  <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.INTERNET"/>
+
+  <queries>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <data android:scheme="http"/>
+    </intent>
+    <intent>
+      <action android:name="android.intent.action.VIEW"/>
+      <data android:scheme="https"/>
+    </intent>
+  </queries>
 
   <application
     android:name="${applicationName}"

--- a/packages/android_intent_plus/example/integration_test/android_intent_plus_test.dart
+++ b/packages/android_intent_plus/example/integration_test/android_intent_plus_test.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
-import 'package:android_intent_plus_example/main.dart';
 import 'package:android_intent_plus/android_intent.dart';
+import 'package:android_intent_plus_example/main.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -106,5 +106,24 @@ void main() {
       (WidgetTester tester) async {
     const intent = AndroidIntent(action: 'LAUNCH', package: 'foobar');
     await expectLater(await intent.canResolveActivity(), isFalse);
+  }, skip: !Platform.isAndroid);
+
+  testWidgets(
+      'getResolvedActivity return activity details when example Activity is found',
+      (WidgetTester tester) async {
+    final intent = AndroidIntent(
+      action: 'action_view',
+      data: Uri.encodeFull('http://'),
+    );
+    await expectLater(await intent.getResolvedActivity(), isNotNull);
+  }, skip: !Platform.isAndroid);
+
+  testWidgets('getResolvedActivity returns null when no Activity is found',
+      (WidgetTester tester) async {
+    final intent = AndroidIntent(
+      action: 'action_view',
+      data: Uri.encodeFull('mycustomscheme://'),
+    );
+    await expectLater(await intent.getResolvedActivity(), isNull);
   }, skip: !Platform.isAndroid);
 }

--- a/packages/android_intent_plus/example/lib/main.dart
+++ b/packages/android_intent_plus/example/lib/main.dart
@@ -202,6 +202,20 @@ class ExplicitIntentsWidget extends StatelessWidget {
     intent.launch();
   }
 
+  void _getResolvedActivity(BuildContext context) async {
+    final intent = AndroidIntent(
+      action: 'action_view',
+      data: Uri.encodeFull('http://'),
+    );
+
+    final details = await intent.getResolvedActivity();
+    if (details != null && context.mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text("${details.appName} - ${details.packageName}")),
+      );
+    }
+  }
+
   void _openGmail() {
     const intent = AndroidIntent(
       action: 'android.intent.action.SEND',
@@ -274,6 +288,13 @@ class ExplicitIntentsWidget extends StatelessWidget {
                 onPressed: _openApplicationDetails,
                 child: const Text(
                   'Tap here to open Application Details',
+                ),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => _getResolvedActivity(context),
+                child: const Text(
+                  'Tap here to get default resolved activity',
                 ),
               ),
               const SizedBox(height: 16),

--- a/packages/android_intent_plus/lib/android_intent.dart
+++ b/packages/android_intent_plus/lib/android_intent.dart
@@ -207,6 +207,31 @@ class AndroidIntent {
     );
   }
 
+  /// Get the default activity that will resolve the intent
+  ///
+  /// Note: ensure the calling app's AndroidManifest contains queries that match the intent.
+  /// See: https://developer.android.com/guide/topics/manifest/queries-element
+  Future<ResolvedActivity?> getResolvedActivity() async {
+    if (!_platform.isAndroid) {
+      return null;
+    }
+
+    final result = await _channel.invokeMethod<Map<Object?, Object?>>(
+      'getResolvedActivity',
+      _buildArguments(),
+    );
+
+    if (result != null) {
+      return ResolvedActivity(
+        appName: result["appName"] as String,
+        activityName: result["activityName"] as String,
+        packageName: result["packageName"] as String,
+      );
+    }
+
+    return null;
+  }
+
   /// Constructs the map of arguments which is passed to the plugin.
   Map<String, dynamic> _buildArguments() {
     return {
@@ -222,5 +247,35 @@ class AndroidIntent {
       },
       if (type != null) 'type': type,
     };
+  }
+}
+
+class ResolvedActivity {
+  final String appName;
+  final String activityName;
+  final String packageName;
+
+  ResolvedActivity({
+    required this.appName,
+    required this.activityName,
+    required this.packageName,
+  });
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ResolvedActivity &&
+          runtimeType == other.runtimeType &&
+          appName == other.appName &&
+          activityName == other.activityName &&
+          packageName == other.packageName;
+
+  @override
+  int get hashCode =>
+      appName.hashCode ^ activityName.hashCode ^ packageName.hashCode;
+
+  @override
+  String toString() {
+    return 'ResolvedActivity{appName: $appName, activityName: $activityName, packageName: $packageName}';
   }
 }

--- a/packages/android_intent_plus/test/android_intent_test.dart
+++ b/packages/android_intent_plus/test/android_intent_test.dart
@@ -141,6 +141,86 @@ void main() {
       });
     });
 
+    group('getResolvedActivity', () {
+      test('pass right params', () async {
+        androidIntent = AndroidIntent.private(
+            action: 'action_view',
+            data: Uri.encodeFull('https://flutter.dev'),
+            flags: <int>[Flag.FLAG_ACTIVITY_NEW_TASK],
+            channel: mockChannel,
+            platform: FakePlatform(operatingSystem: 'android'),
+            type: 'video/*');
+        await androidIntent.getResolvedActivity();
+        verify(mockChannel
+            .invokeMethod<void>('getResolvedActivity', <String, Object>{
+          'action': 'action_view',
+          'data': Uri.encodeFull('https://flutter.dev'),
+          'flags':
+              androidIntent.convertFlags(<int>[Flag.FLAG_ACTIVITY_NEW_TASK]),
+          'type': 'video/*',
+        }));
+      });
+
+      test('returns a ResolvedActivity', () async {
+        androidIntent = AndroidIntent.private(
+          action: 'action_view',
+          data: Uri.encodeFull('https://flutter.dev'),
+          channel: mockChannel,
+          platform: FakePlatform(operatingSystem: 'android'),
+        );
+
+        when(mockChannel.invokeMethod("getResolvedActivity", any))
+            .thenAnswer((_) async => <String, dynamic>{
+                  "activityName": "activity name",
+                  "appName": "App Name",
+                  "packageName": "com.packagename",
+                });
+
+        final result = await androidIntent.getResolvedActivity();
+
+        expect(result?.activityName, equals("activity name"));
+        expect(result?.appName, equals("App Name"));
+        expect(result?.packageName, equals("com.packagename"));
+      });
+
+      test('can send Intent with an action and no component', () async {
+        androidIntent = AndroidIntent.private(
+          action: 'action_view',
+          channel: mockChannel,
+          platform: FakePlatform(operatingSystem: 'android'),
+        );
+        await androidIntent.getResolvedActivity();
+        verify(mockChannel
+            .invokeMethod<void>('getResolvedActivity', <String, Object>{
+          'action': 'action_view',
+        }));
+      });
+
+      test('can send Intent with a component and no action', () async {
+        androidIntent = AndroidIntent.private(
+          package: 'packageName',
+          componentName: 'componentName',
+          channel: mockChannel,
+          platform: FakePlatform(operatingSystem: 'android'),
+        );
+        await androidIntent.getResolvedActivity();
+        verify(mockChannel
+            .invokeMethod<void>('getResolvedActivity', <String, Object>{
+          'package': 'packageName',
+          'componentName': 'componentName',
+        }));
+      });
+
+      test('call in ios platform', () async {
+        androidIntent = AndroidIntent.private(
+            action: 'action_view',
+            channel: mockChannel,
+            platform: FakePlatform(operatingSystem: 'ios'));
+        await androidIntent.getResolvedActivity();
+        verifyZeroInteractions(mockChannel);
+      });
+    });
+
     group('launchChooser', () {
       test('pass title', () async {
         androidIntent = AndroidIntent.private(


### PR DESCRIPTION
## Description

Adds getResolvedActivity to return app name, activity name and package name of the default activity that will be resolved for a given intent.

## Related Issues

## Checklist

- [x ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

