### PR TITLE
fix(device_info_plus): Ignore `MissingPermission` lint error on Android

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/build.gradle
+++ b/packages/device_info_plus/device_info_plus/android/build.gradle
@@ -45,6 +45,7 @@ android {
 
     lintOptions {
         disable 'InvalidPackage'
+        disable 'MissingPermission'
     }
 
     dependencies {

--- a/packages/device_info_plus/device_info_plus/android/build.gradle
+++ b/packages/device_info_plus/device_info_plus/android/build.gradle
@@ -44,8 +44,7 @@ android {
     }
 
     lintOptions {
-        disable 'InvalidPackage'
-        disable 'MissingPermission'
+        disable 'InvalidPackage', 'MissingPermission'
     }
 
     dependencies {


### PR DESCRIPTION
## Description

when ./gradlew clean
./gradlew build --refresh-dependencies

run on any project including the example project, it throws an error and build fails. Adding lint option in user project does not fix the build, it must be in the package build.gradle.

## Related Issues

#3316 #1986 #3110 

## Checklist

- [X] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.

