### PR TITLE
fix(share_plus): #3322 Image preview on iOS downscale to avoid issues

### DIFF
--- a/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
@@ -228,11 +228,10 @@ TopViewControllerForViewController(UIViewController *viewController) {
     // https://stackoverflow.com/questions/60563773/ios-13-share-sheet-changing-subtitle-item-description
     metadata.originalURL = [NSURL fileURLWithPath:description];
     if (_mimeType && [_mimeType hasPrefix:@"image/"]) {
-      
-      // When using iPhone 13, there may be a situation where it cannot be awakened
       UIImage *image = [UIImage imageWithContentsOfFile:_path];
-      metadata.imageProvider = [[NSItemProvider alloc] initWithObject:[self imageWithImage:image 
-                                                                              scaledToSize:CGSizeMake(120,120)]];
+      metadata.imageProvider = [[NSItemProvider alloc]
+          initWithObject:[self imageWithImage:image
+                                 scaledToSize:CGSizeMake(120, 120)]];
     }
   }
 

--- a/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
@@ -228,8 +228,11 @@ TopViewControllerForViewController(UIViewController *viewController) {
     // https://stackoverflow.com/questions/60563773/ios-13-share-sheet-changing-subtitle-item-description
     metadata.originalURL = [NSURL fileURLWithPath:description];
     if (_mimeType && [_mimeType hasPrefix:@"image/"]) {
-      metadata.imageProvider = [[NSItemProvider alloc]
-          initWithObject:[UIImage imageWithContentsOfFile:_path]];
+      
+      // When using iPhone 13, there may be a situation where it cannot be awakened
+      UIImage *image = [UIImage imageWithContentsOfFile:_path];
+      metadata.imageProvider = [[NSItemProvider alloc] initWithObject:[self imageWithImage:image 
+                                                                              scaledToSize:CGSizeMake(120,120)]];
     }
   }
 


### PR DESCRIPTION
## Description

On iPhone 13, when sharing an image and the image is very large, the sharing box may occasionally fail to be awakened.

## Related Issues

- fix: #3322

## Checklist

- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.
