### PR TITLE
fix(battery_plus): Bring back entry needed by the iOS privacy manifest

### DIFF
--- a/packages/battery_plus/battery_plus/ios/battery_plus/Sources/battery_plus/PrivacyInfo.xcprivacy
+++ b/packages/battery_plus/battery_plus/ios/battery_plus/Sources/battery_plus/PrivacyInfo.xcprivacy
@@ -4,6 +4,8 @@
 <dict>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyTracking</key>


### PR DESCRIPTION
## Description

While working on #3154 occasionally removed one of keys that is need for iOS privacy manifests.
This PR brings it back.
