### PR TITLE
fix(share_plus): Update iOS privacy manifest

### DIFF
--- a/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/PrivacyInfo.xcprivacy
+++ b/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/PrivacyInfo.xcprivacy
@@ -4,6 +4,8 @@
 <dict>
 	<key>NSPrivacyTrackingDomains</key>
 	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array/>
 	<key>NSPrivacyCollectedDataTypes</key>
 	<array/>
 	<key>NSPrivacyTracking</key>


### PR DESCRIPTION
## Description

Same as #3323, but for `share_plus` plugin

