### PR TITLE
feat: add support to open sim profile settings

### DIFF
--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
@@ -142,6 +142,8 @@ public final class MethodCallHandlerImpl implements MethodCallHandler {
         return Settings.ACTION_LOCATION_SOURCE_SETTINGS;
       case "action_application_details_settings":
         return Settings.ACTION_APPLICATION_DETAILS_SETTINGS;
+      case "action_manage_all_sim_profiles_settings":
+        return Settings.ACTION_MANAGE_ALL_SIM_PROFILES_SETTINGS;
       default:
         return action;
     }

--- a/packages/android_intent_plus/example/lib/main.dart
+++ b/packages/android_intent_plus/example/lib/main.dart
@@ -194,6 +194,13 @@ class ExplicitIntentsWidget extends StatelessWidget {
     intent.launch();
   }
 
+  void _openSimSettings() {
+    const AndroidIntent intent = AndroidIntent(
+      action: 'action_manage_all_sim_profiles_settings',
+    );
+    intent.launch();
+  }
+
   void _openApplicationDetails() {
     const intent = AndroidIntent(
       action: 'action_application_details_settings',
@@ -303,6 +310,11 @@ class ExplicitIntentsWidget extends StatelessWidget {
                 child: const Text(
                   'Tap here to open gmail app with details',
                 ),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: () => _openSimSettings(),
+                child: const Text('Tap here to open sim profiles.'),
               ),
             ],
           ),


### PR DESCRIPTION
## Description

I couldn't open `Settings.ACTION_MANAGE_ALL_SIM_PROFILES_SETTINGS` from the intent plugin or it was not clear from the documentation how to do it so I decided to implement a shortcut like you did in location settings. 

Thought could be useful to add this one to the list.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

