### PR TITLE
feat(battery_plus): Add battery save mode check on MacOS

### DIFF
--- a/packages/battery_plus/battery_plus/README.md
+++ b/packages/battery_plus/battery_plus/README.md
@@ -47,7 +47,7 @@ battery.onBatteryStateChanged.listen((BatteryState state) {
 });
 
 // Check if device in battery save mode
-// Currently available on Android, iOS and Windows platforms only
+// Currently available on Android, iOS, MacOS and Windows platforms only
 print(await battery.isInBatterySaveMode);
 ```
 

--- a/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
+++ b/packages/battery_plus/battery_plus/example/integration_test/battery_plus_test.dart
@@ -17,8 +17,10 @@ void main() {
       Platform.isMacOS ||
       Platform.isWindows ||
       Platform.isLinux;
-  final bool isInBatterySaveModeIsImplemented =
-      Platform.isAndroid || Platform.isIOS || Platform.isWindows;
+  final bool isInBatterySaveModeIsImplemented = Platform.isAndroid ||
+      Platform.isIOS ||
+      Platform.isMacOS ||
+      Platform.isWindows;
 
   /// Throws [PlatformException] on iOS simulator and Windows.
   /// Run on Android only.

--- a/packages/battery_plus/battery_plus/lib/battery_plus.dart
+++ b/packages/battery_plus/battery_plus/lib/battery_plus.dart
@@ -32,14 +32,14 @@ class Battery {
     return BatteryPlatform.instance;
   }
 
-  /// get battery level
+  /// Get battery level
   Future<int> get batteryLevel {
     return _platform.batteryLevel;
   }
 
-  /// check if device is on battery save mode
+  /// Check if device is on battery save mode
   ///
-  /// Currently only implemented on Android, iOS and Windows.
+  /// Currently only implemented on Android, iOS, MacOS and Windows.
   Future<bool> get isInBatterySaveMode {
     return _platform.isInBatterySaveMode;
   }

--- a/packages/battery_plus/battery_plus/macos/battery_plus/Sources/battery_plus/BatteryPlusMacosPlugin.swift
+++ b/packages/battery_plus/battery_plus/macos/battery_plus/Sources/battery_plus/BatteryPlusMacosPlugin.swift
@@ -12,39 +12,40 @@ public class BatteryPlusMacosPlugin: NSObject, FlutterPlugin {
 
     public static func register(with registrar: FlutterPluginRegistrar) {
         let channel = FlutterMethodChannel(name: "dev.fluttercommunity.plus/battery", binaryMessenger: registrar.messenger)
-        
+
         let eventChannel = FlutterEventChannel(name: "dev.fluttercommunity.plus/charging", binaryMessenger: registrar.messenger)
 
         let chargingHandler = BatteryPlusChargingHandler()
 
         let instance = BatteryPlusMacosPlugin(chargingHandler: chargingHandler)
         registrar.addMethodCallDelegate(instance, channel: channel)
-        
+
         eventChannel.setStreamHandler(chargingHandler)
     }
-    
+
     public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
         switch call.method {
         case "getBatteryLevel":
             handleGetBatteryLevelMethodCall(result)
         case "getBatteryState":
             handleGetBatteryStateMethodCall(result)
+        case "isInBatterySaveMode":
+            handleIsBatterySaveMode(result)
         default:
             result(FlutterMethodNotImplemented)
         }
     }
-    
-    private func handleGetBatteryLevelMethodCall(_ result: FlutterResult){
+
+    private func handleGetBatteryLevelMethodCall(_ result: FlutterResult) {
         let level = getBatteryLevel()
-        if(level != -1){
+        if (level != -1) {
             result(level)
-            
         } else {
             result("UNAVAILABLE")
         }
-        
+
     }
-    
+
     private func getBatteryLevel()-> Int {
         let powerSourceSnapshot = IOPSCopyPowerSourcesInfo().takeRetainedValue()
         let sources = IOPSCopyPowerSourcesList(powerSourceSnapshot).takeRetainedValue() as Array
@@ -58,8 +59,17 @@ public class BatteryPlusMacosPlugin: NSObject, FlutterPlugin {
         return -1
     }
 
-    private func handleGetBatteryStateMethodCall(_ result: FlutterResult){
+    private func handleGetBatteryStateMethodCall(_ result: FlutterResult) {
         let state = self.chargingHandler.getBatteryStatus()
         result(state);
+    }
+
+    private func handleIsBatterySaveMode(_ result: FlutterResult) {
+        if #available(macOS 12.0, *) {
+            result(ProcessInfo.processInfo.isLowPowerModeEnabled)
+        } else {
+            // Low Power Mode is not supported on macOS versions prior to 12.0
+            result(false)
+        }
     }
 }


### PR DESCRIPTION
## Description

While testing SPM for `battery_plus` was surprised that the check for battery save mode throws `Unimplemented....` on MacOS, because such check is available in MacOS since version 12.0: https://developer.apple.com/documentation/foundation/processinfo/1617047-islowpowermodeenabled
This PR adds implementation for this check and it seems to work fine:
<img width="600" alt="Screenshot 2024-10-21 at 11 07 11" src="https://github.com/user-attachments/assets/ce9c88aa-7565-4122-8c92-009b3d11452c">
<img width="600" alt="Screenshot 2024-10-21 at 11 07 25" src="https://github.com/user-attachments/assets/46b3bc00-3722-49d3-8bcf-0ab645394215">

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

