### PR TITLE
fix(package_info_plus): add support for file scheme on web

### DIFF
--- a/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_web_test.dart
+++ b/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_web_test.dart
@@ -217,6 +217,25 @@ void main() {
               'chrome-extension://abcdefgh/a/b/c/version.json?cachebuster=1'),
         );
       });
+
+      testWidgets('Get correct versionJsonUrl for file', (tester) async {
+        expect(
+          plugin.versionJsonUrl('file://abcdefgh', 1),
+          Uri.parse('file:///version.json?cachebuster=1'),
+        );
+        expect(
+          plugin.versionJsonUrl('file://abcdefgh/a/b/c', 1),
+          Uri.parse('file:///a/b/c/version.json?cachebuster=1'),
+        );
+        expect(
+          plugin.versionJsonUrl('file://abcdefgh/#my-page', 1),
+          Uri.parse('file:///version.json?cachebuster=1'),
+        );
+        expect(
+          plugin.versionJsonUrl('file://abcdefgh/a/b/c/#my-page', 1),
+          Uri.parse('file:///a/b/c/version.json?cachebuster=1'),
+        );
+      });
     },
   );
 

--- a/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/package_info_plus_web.dart
@@ -123,6 +123,8 @@ extension _UriOrigin on Uri {
   String get _origin {
     if (isScheme('chrome-extension')) {
       return '$scheme://$host';
+    } else if (isScheme('file')) {
+      return '$scheme://';
     }
     return origin;
   }


### PR DESCRIPTION
## Description

Web apps using file scheme cannot retrieve version.json, `PackageInfoPlusWebPlugin.versionJsonUrl` calls Uri.origin which throws `StateError` if scheme is not `http` or `https`

## Checklist

- [X] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.

