### PR TITLE
fix(device_info_plus): Update privacy manifest paths

### DIFF
--- a/packages/device_info_plus/device_info_plus/macos/device_info_plus.podspec
+++ b/packages/device_info_plus/device_info_plus/macos/device_info_plus.podspec
@@ -19,5 +19,5 @@ https://github.com/flutter/flutter/issues/46618
 
   s.platform = :osx
   s.osx.deployment_target = '10.14'
-  s.resource_bundles = {'device_info_plus_privacy' => ['PrivacyInfo.xcprivacy']}
+  s.resource_bundles = {'device_info_plus_privacy' => ['device_info_plus/Sources/device_info_plus/PrivacyInfo.xcprivacy']}
 end

--- a/packages/device_info_plus/device_info_plus/macos/device_info_plus/Package.swift
+++ b/packages/device_info_plus/device_info_plus/macos/device_info_plus/Package.swift
@@ -17,7 +17,8 @@ let package = Package(
             name: "device_info_plus",
             dependencies: [],
             resources: [
-            ]
+                .process("PrivacyInfo.xcprivacy"),
+            ],
         )
     ]
 )


### PR DESCRIPTION
## Description

Something that was overlooked during SPM migration PRs review - updated paths for privacy manifest files. This PR fixes the issue for `device_info_plus`.

## Related Issues

Part of #3346 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

