### PR TITLE
fix(package_info_plus): Update privacy manifest path

### DIFF
--- a/packages/package_info_plus/package_info_plus/macos/package_info_plus.podspec
+++ b/packages/package_info_plus/package_info_plus/macos/package_info_plus.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.dependency 'FlutterMacOS'
   s.platform = :osx, '10.14'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
-  s.resource_bundles = {'package_info_plus_privacy' => ['PrivacyInfo.xcprivacy']}
+  s.resource_bundles = {'package_info_plus_privacy' => ['package_info_plus/Sources/package_info_plus/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
## Description

Same as #3347 but for `package_info_plus`

## Related Issues

Part of #3346 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

