### PR TITLE
fix(share_plus): Update privacy manifest path

### DIFF
--- a/packages/share_plus/share_plus/macos/share_plus.podspec
+++ b/packages/share_plus/share_plus/macos/share_plus.podspec
@@ -19,5 +19,5 @@ https://github.com/flutter/flutter/issues/46618
 
   s.platform = :osx
   s.osx.deployment_target = '10.14'
-  s.resource_bundles = {'share_plus_privacy' => ['PrivacyInfo.xcprivacy']}
+  s.resource_bundles = {'share_plus_privacy' => ['share_plus/Sources/share_plus/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
## Description

Same as #3348 and #3347, but for `share_plus`.

## Related Issues

Part of #3346 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

