### PR TITLE
fix(network_info_plus): Update privacy manifest path on MacOS

### DIFF
--- a/packages/network_info_plus/network_info_plus/macos/network_info_plus.podspec
+++ b/packages/network_info_plus/network_info_plus/macos/network_info_plus.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
 
   s.platform = :osx
   s.osx.deployment_target = '10.14'
-  s.resource_bundles = {'network_info_plus_privacy' => ['PrivacyInfo.xcprivacy']}
+  s.resource_bundles = {'network_info_plus_privacy' => ['network_info_plus/Sources/network_info_plus/PrivacyInfo.xcprivacy']}
 end


### PR DESCRIPTION
## Description

Should be the last in the series related to the issue #3346

## Related Issues

Part of #3346 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

