### PR TITLE
fix(device_info_plus): Set correct Flutter and Dart versions requirements

### DIFF
--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -16,8 +16,8 @@ Get current device information from within the Flutter application.
 
 ## Requirements
 
-- Flutter >=3.3.0
-- Dart >=3.3.0 <4.0.0
+- Flutter >=3.22.0
+- Dart >=3.4.0 <4.0.0
 - iOS >=12.0
 - MacOS >=10.14
 - Android `compileSDK` 34

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -19,6 +19,7 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: '>=3.22.0'
 
 

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -19,4 +19,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.5.0 <4.0.0'
+  flutter: '>=3.24.0'

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -19,5 +19,6 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: '>=3.5.0 <4.0.0'
-  flutter: '>=3.24.0'
+  sdk: '>=3.0.0 <4.0.0'
+
+

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -49,5 +49,5 @@ dev_dependencies:
   test: ^1.22.0
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"


### PR DESCRIPTION
## Description

PR: https://github.com/fluttercommunity/plus_plugins/pull/3254 The upgraded web package requires version ^1.0.0, and since version 1.0.0 has a minimum SDK requirement of 3.4, the minimum Flutter version should be 3.22.0.

- Fix minimum version compatibility configuration.
- Fix documentation errors.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x]  I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x]  No, this is *not* a breaking change.

