### PR TITLE
fix(share_plus): Set correct Flutter and Dart versions requirements

### DIFF
--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -26,8 +26,8 @@ Sharing files is not supported on Linux.
 
 ## Requirements
 
-- Flutter >=3.19.0
-- Dart >=3.3.0 <4.0.0
+- Flutter >=3.22.0
+- Dart >=3.4.0 <4.0.0
 - iOS >=12.0
 - MacOS >=10.14
 - Android `compileSDK` 34

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
     - assets/flutter_logo.png
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
-  flutter: '>=3.19.0'
+  sdk: '>=3.4.0 <4.0.0'
+  flutter: '>=3.22.0'

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -51,5 +51,6 @@ dev_dependencies:
   flutter_lints: ">=2.0.1 <6.0.0"
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  sdk: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"
+


### PR DESCRIPTION
## Description

Since it depends on web ^1.0.0, and web ^1.0.0 has a minimum SDK requirement of 3.4.

- Fix minimum version compatibility configuration.
- Fix documentation errors.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x]  I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x]  No, this is *not* a breaking change.

