### PR TITLE
fix(example): Incorrect minimum version configuration.

### DIFF
--- a/packages/android_alarm_manager_plus/example/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: android_alarm_manager_plus_example
 description: Demonstrates how to use the android_alarm_manager_plus plugin.
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/android_intent_plus/example/pubspec.yaml
+++ b/packages/android_intent_plus/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: android_intent_plus_example
 description: Demonstrates how to use the android_intent plugin.
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/battery_plus/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: battery_plus_example
 description: Demonstrates how to use the battery_plus plugin.
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
-  flutter: '>=3.19.0'
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
@@ -2,7 +2,8 @@ name: connectivity_plus_example
 description: Demonstrates how to use the connectivity_plus plugin.
 
 environment:
-  sdk: '>=2.12.0 <4.0.0'
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -19,4 +19,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -2,7 +2,8 @@ name: network_info_plus_example
 description: Demonstrates how to use the network_info_plus plugin.
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   flutter:

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -4,7 +4,8 @@ version: 1.2.3+4
 publish_to: 'none'
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"
 
 dependencies:
   clock: ^1.1.1

--- a/packages/sensors_plus/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/example/pubspec.yaml
@@ -19,5 +19,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: '>=3.3.0 <4.0.0'
-  flutter: '>=3.19.0'
+  sdk: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"


### PR DESCRIPTION
## Description

Due to the dependency on flutter_lints: ^5.0.0, version 5.0.0 requires at least Dart SDK 3.5.

- fix: https://github.com/fluttercommunity/plus_plugins/issues/3366

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x]  I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x]  No, this is *not* a breaking change.

