### PR TITLE
feat(device_info_plus)!: Add cpu architecture to Windows device info

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
@@ -74,6 +74,8 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
 
       GetSystemInfo(systemInfo);
 
+      final cpuArchitecture = deriveCpuArch(systemInfo);
+
       // Use `RtlGetVersion` from `ntdll.dll` to get the Windows version.
       RtlGetVersion(osVersionInfo);
 
@@ -108,11 +110,31 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
         registeredOwner: registeredOwner,
         releaseId: releaseId,
         deviceId: machineId,
+        cpuArch: cpuArchitecture,
       );
       return data;
     } finally {
       free(systemInfo);
       free(osVersionInfo);
+    }
+  }
+
+  @visibleForTesting
+  String deriveCpuArch(Pointer<SYSTEM_INFO> systemInfo) {
+    final cpuArchInt = systemInfo.ref.wProcessorArchitecture;
+    switch (cpuArchInt) {
+      case PROCESSOR_ARCHITECTURE.PROCESSOR_ARCHITECTURE_AMD64:
+        return 'x64';
+      case PROCESSOR_ARCHITECTURE.PROCESSOR_ARCHITECTURE_ARM:
+        return 'arm';
+      case PROCESSOR_ARCHITECTURE.PROCESSOR_ARCHITECTURE_ARM64:
+        return 'arm64';
+      case PROCESSOR_ARCHITECTURE.PROCESSOR_ARCHITECTURE_IA64:
+        return 'ia64';
+      case PROCESSOR_ARCHITECTURE.PROCESSOR_ARCHITECTURE_INTEL:
+        return 'x86';
+      default:
+        return 'Unknown';
     }
   }
 

--- a/packages/device_info_plus/device_info_plus/lib/src/model/windows_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/windows_device_info.dart
@@ -35,6 +35,7 @@ class WindowsDeviceInfo implements BaseDeviceInfo {
     required this.registeredOwner,
     required this.releaseId,
     required this.deviceId,
+    required this.cpuArch,
   });
 
   /// The computer's fully-qualified DNS name, where available.
@@ -146,6 +147,9 @@ class WindowsDeviceInfo implements BaseDeviceInfo {
   /// `HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\SQMClient\MachineId` registry key.
   final String deviceId;
 
+  /// Displayed as "System Architecture" in Windows Settings.
+  final String cpuArch;
+
   @Deprecated('use [data] instead')
   @override
   Map<String, dynamic> toMap() {
@@ -175,6 +179,7 @@ class WindowsDeviceInfo implements BaseDeviceInfo {
       'registeredOwner': registeredOwner,
       'releaseId': releaseId,
       'deviceId': deviceId,
+      'cpuArch': cpuArch,
     };
   }
 

--- a/packages/device_info_plus/device_info_plus/test/device_info_plus_windows_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/device_info_plus_windows_test.dart
@@ -82,5 +82,7 @@ void main() {
     expect(windowsInfo.releaseId, isNotEmpty);
     // Check whether windowsInfo.deviceId is a valid non-empty string.
     expect(windowsInfo.deviceId, isNotEmpty);
+    // Check whether windowsInfo.cpuArch is a known variant.
+    expect(windowsInfo.cpuArch, isNot('Unknown'));
   });
 }

--- a/packages/device_info_plus/device_info_plus/test/model/windows_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/windows_device_info_test.dart
@@ -33,6 +33,7 @@ void main() {
         registeredOwner: 'registeredOwner',
         releaseId: 'releaseId',
         deviceId: 'deviceId',
+        cpuArch: 'x64',
       );
 
       expect(windowsDeviceInfo.data, {
@@ -61,6 +62,7 @@ void main() {
         'registeredOwner': 'registeredOwner',
         'releaseId': 'releaseId',
         'deviceId': 'deviceId',
+        'cpuArch': 'x64',
       });
     });
   });


### PR DESCRIPTION
## Description
This PR adds CPU architecture to Windows device info. This also brings it in line with the macOS implementation of the plugin.

## Related Issues

*Fixes #3367*

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

