### PR TITLE
refactor(all): Use range of flutter_lints for broader compatibility

### DIFF
--- a/packages/android_alarm_manager_plus/example/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/example/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ">=4.0.0 <6.0.0"
 
 flutter:
   uses-material-design: true

--- a/packages/android_intent_plus/example/pubspec.yaml
+++ b/packages/android_intent_plus/example/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ">=4.0.0 <6.0.0"
 
 # The following section is specific to Flutter.
 flutter:

--- a/packages/battery_plus/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/example/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ">=4.0.0 <6.0.0"
 
 flutter:
   uses-material-design: true

--- a/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
@@ -17,7 +17,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   test: ^1.16.4
-  flutter_lints: ^5.0.0
+  flutter_lints: ">=4.0.0 <6.0.0"
 
 flutter:
   uses-material-design: true

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -13,7 +13,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ">=4.0.0 <6.0.0"
 
 flutter:
   uses-material-design: true

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   win32_registry: ^1.1.0
 
 dev_dependencies:
-  flutter_lints: ">=2.0.1 <6.0.0"
+  flutter_lints: ">=4.0.0 <6.0.0"
   flutter_test:
     sdk: flutter
   mockito: ^5.4.0

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   plugin_platform_interface: ^2.1.4
 
 dev_dependencies:
-  flutter_lints: ">=2.0.1 <6.0.0"
+  flutter_lints: ">=4.0.0 <6.0.0"
   flutter_test:
     sdk: flutter
   mockito: ^5.4.0

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -16,7 +16,7 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   test: ^1.21.0
-  flutter_lints: ^5.0.0
+  flutter_lints: ">=4.0.0 <6.0.0"
 
 flutter:
   uses-material-design: true

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -48,4 +48,4 @@ dev_dependencies:
     sdk: flutter
   mockito: ^5.4.0
   plugin_platform_interface: ^2.1.4
-  flutter_lints: ">=2.0.1 <6.0.0"
+  flutter_lints: ">=4.0.0 <6.0.0"

--- a/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ">=2.0.1 <6.0.0"
+  flutter_lints: ">=4.0.0 <6.0.0"

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
     sdk: flutter
   flutter_driver:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ">=4.0.0 <6.0.0"
   flutter_test:
     sdk: flutter
   mockito: ^5.4.0

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   clock: ^1.1.1
 
 dev_dependencies:
-  flutter_lints: ">=2.0.1 <6.0.0"
+  flutter_lints: ">=4.0.0 <6.0.0"
   flutter_test:
     sdk: flutter
   test: ^1.22.0

--- a/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
@@ -14,7 +14,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.4.0
-  flutter_lints: ">=2.0.1 <6.0.0"
+  flutter_lints: ">=4.0.0 <6.0.0"
 
 environment:
   sdk: ">=2.18.0 <4.0.0"

--- a/packages/sensors_plus/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/example/pubspec.yaml
@@ -11,7 +11,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ">=4.0.0 <6.0.0"
   flutter_test:
     sdk: flutter
 

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -33,7 +33,7 @@ dev_dependencies:
   test: ^1.22.0
   flutter_test:
     sdk: flutter
-  flutter_lints: ">=2.0.1 <6.0.0"
+  flutter_lints: ">=4.0.0 <6.0.0"
 
 environment:
   sdk: ">=3.3.0 <4.0.0"

--- a/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus_platform_interface/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ">=2.0.1 <6.0.0"
+  flutter_lints: ">=4.0.0 <6.0.0"
   test: ^1.22.0
 
 environment:

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -15,7 +15,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_lints: ^5.0.0
+  flutter_lints: ">=4.0.0 <6.0.0"
 
 flutter:
   uses-material-design: true

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ">=2.0.1 <6.0.0"
+  flutter_lints: ">=4.0.0 <6.0.0"
 
 environment:
   sdk: ">=3.4.0 <4.0.0"

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -18,7 +18,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.4.0
-  flutter_lints: ">=2.0.1 <6.0.0"
+  flutter_lints: ">=4.0.0 <6.0.0"
   test: ^1.22.0
 
 environment:


### PR DESCRIPTION
## Description

Switching to a range for `flutter_lints` because 5.0.0 requires latest dart as it was mentioned in #3366, while we have no reasons to make min requirements that high.

## Related Issues

Fixes #3366

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

