### PR TITLE
feat(share_plus): support rich preview on the share sheet

### DIFF
--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -60,6 +60,22 @@ sharing to email.
 Share.share('check out my website https://example.com', subject: 'Look what I made!');
 ```
 
+The optional `title` and `thumbnail` parameters enable
+[rich content preview](https://developer.android.com/training/sharing/send#adding-rich-content-previews)
+on Android when sharing text.
+
+On the web the `title` or the `subject` (when the `title` is omitted) is passed to the
+[Web Share API](https://web.dev/web-share/)'s title parameter.
+
+```dart
+Share.share('Content which will be shared', title: 'Preview title', thumbnail: XFile('path/to/thumbnail.png'));
+```
+
+> [!CAUTION]
+> For the `thumbnail` parameter the
+> [Sharing data created with XFile.fromData](#sharing-data-created-with-xfilefromdata)
+> limitation has to be considered.
+
 `share()` returns `status` object that allows to check the result of user action in the share sheet.
 
 ```dart

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/MethodCallHandler.kt
@@ -38,6 +38,8 @@ internal class MethodCallHandler(
                         call.argument<Any>("text") as String,
                         call.argument<Any>("subject") as String?,
                         isWithResult,
+                        title = call.argument<String?>("title"),
+                        thumbnailPath =  call.argument<String?>("thumbnailPath"),
                     )
                     success(isWithResult, result)
                 }

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -57,6 +57,14 @@ class Share {
   /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
   /// on other devices.
   ///
+  /// The optional [title] parameter can be used to specify a title for the shared text.
+  /// This works only on Android and on the Web for text only sharing as additional context.
+  /// It is not part of the shared data.
+  ///
+  /// The optional [thumbnail] parameter can be used to specify a thumbnail for
+  /// the shared text on Android. This is only displayed on the share sheet
+  /// for additional context, it is not part of the shared data.
+  ///
   /// May throw [PlatformException] or [FormatException]
   /// from [MethodChannel].
   ///
@@ -82,13 +90,17 @@ class Share {
   static Future<ShareResult> share(
     String text, {
     String? subject,
+    String? title,
     Rect? sharePositionOrigin,
+    XFile? thumbnail,
   }) async {
     assert(text.isNotEmpty);
     return _platform.share(
       text,
       subject: subject,
       sharePositionOrigin: sharePositionOrigin,
+      title: title,
+      thumbnail: thumbnail,
     );
   }
 

--- a/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_linux.dart
@@ -34,7 +34,9 @@ class SharePlusLinuxPlugin extends SharePlatform {
   Future<ShareResult> share(
     String text, {
     String? subject,
+    String? title,
     Rect? sharePositionOrigin,
+    XFile? thumbnail,
   }) async {
     final queryParameters = {
       if (subject != null) 'subject': subject,

--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -75,12 +75,16 @@ class SharePlusWebPlugin extends SharePlatform {
   Future<ShareResult> share(
     String text, {
     String? subject,
+    String? title,
     Rect? sharePositionOrigin,
+    XFile? thumbnail,
   }) async {
     final ShareData data;
-    if (subject != null && subject.isNotEmpty) {
+    final hasSubject = subject != null && subject.isNotEmpty;
+    final hasTitle = title != null && title.isNotEmpty;
+    if (hasTitle || hasSubject) {
       data = ShareData(
-        title: subject,
+        title: hasTitle ? title : subject!,
         text: text,
       );
     } else {

--- a/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_windows.dart
@@ -39,7 +39,9 @@ class SharePlusWindowsPlugin extends SharePlatform {
   Future<ShareResult> share(
     String text, {
     String? subject,
+    String? title,
     Rect? sharePositionOrigin,
+    XFile? thumbnail,
   }) async {
     final queryParameters = {
       if (subject != null) 'subject': subject,

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:io';
-
 // Keep dart:ui for retrocompatiblity with Flutter <3.3.0
 // ignore: unnecessary_import
 import 'dart:ui';
@@ -12,8 +11,8 @@ import 'dart:ui';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart' show visibleForTesting;
 import 'package:mime/mime.dart' show extensionFromMime, lookupMimeType;
-import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
 import 'package:path_provider/path_provider.dart';
+import 'package:share_plus_platform_interface/share_plus_platform_interface.dart';
 import 'package:uuid/uuid.dart';
 
 /// Plugin for summoning a platform share sheet.
@@ -48,12 +47,15 @@ class MethodChannelShare extends SharePlatform {
   Future<ShareResult> share(
     String text, {
     String? subject,
+    String? title,
     Rect? sharePositionOrigin,
+    XFile? thumbnail,
   }) async {
     assert(text.isNotEmpty);
     final params = <String, dynamic>{
       'text': text,
       'subject': subject,
+      'title': title,
     };
 
     if (sharePositionOrigin != null) {
@@ -61,6 +63,11 @@ class MethodChannelShare extends SharePlatform {
       params['originY'] = sharePositionOrigin.top;
       params['originWidth'] = sharePositionOrigin.width;
       params['originHeight'] = sharePositionOrigin.height;
+    }
+
+    if (thumbnail != null) {
+      final thumbnailFile = await _getFile(thumbnail);
+      params['thumbnailPath'] = thumbnailFile.path;
     }
 
     final result = await channel.invokeMethod<String>('share', params) ??

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -46,12 +46,16 @@ class SharePlatform extends PlatformInterface {
   Future<ShareResult> share(
     String text, {
     String? subject,
+    String? title,
     Rect? sharePositionOrigin,
+    XFile? thumbnail,
   }) async {
     return await _instance.share(
       text,
       subject: subject,
       sharePositionOrigin: sharePositionOrigin,
+      title: title,
+      thumbnail: thumbnail,
     );
   }
 

--- a/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
+++ b/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
@@ -76,17 +76,32 @@ void main() {
 
     await sharePlatform.share(
       'some text to share',
-      subject: 'some subject to share',
-      sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
     );
     verify(mockChannel.invokeMethod<String>('share', <String, dynamic>{
       'text': 'some text to share',
-      'subject': 'some subject to share',
-      'originX': 1.0,
-      'originY': 2.0,
-      'originWidth': 3.0,
-      'originHeight': 4.0,
+      'subject': null,
+      'title': null,
     }));
+
+    await withFile('tempfile-thumbnail123.png', (File fd) async {
+      await sharePlatform.share(
+        'some text to share',
+        subject: 'some subject to share',
+        title: 'some title to share',
+        sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
+        thumbnail: XFile(fd.path),
+      );
+      verify(mockChannel.invokeMethod<String>('share', <String, dynamic>{
+        'text': 'some text to share',
+        'subject': 'some subject to share',
+        'title': 'some title to share',
+        'originX': 1.0,
+        'originY': 2.0,
+        'originWidth': 3.0,
+        'originHeight': 4.0,
+        'thumbnailPath': fd.path,
+      }));
+    });
 
     await withFile('tempfile-83649a.png', (File fd) async {
       await sharePlatform.shareXFiles(
@@ -154,11 +169,13 @@ void main() {
     await sharePlatform.share(
       'some text to share',
       subject: 'some subject to share',
+      title: 'some title to share',
       sharePositionOrigin: const Rect.fromLTWH(1.0, 2.0, 3.0, 4.0),
     );
     verify(mockChannel.invokeMethod<String>('share', <String, dynamic>{
       'text': 'some text to share',
       'subject': 'some subject to share',
+      'title': 'some title to share',
       'originX': 1.0,
       'originY': 2.0,
       'originWidth': 3.0,


### PR DESCRIPTION
## Description

Support [rich preview](https://developer.android.com/training/sharing/send#adding-rich-content-previews) on Android with the help of the new `title` and `thumbnail` parameters. The `title` is also used for the Web Share API's `title` parameter in favor of the `subject`, but falls back to the `subject` for backward compatibility (as the previous code used the `subject` for this).

The contribution guide says features for only one platform won't be accepted, but I still want to try.

## Related Issues

- Fix #3307 
- Fix #1221
- Related #1099

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

