### PR TITLE
fix(share_plus): A function declaration without a prototype is deprecated in all versions of C

### DIFF
--- a/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
@@ -7,7 +7,7 @@
 
 static NSString *const PLATFORM_CHANNEL = @"dev.fluttercommunity.plus/share";
 
-static UIViewController *RootViewController() {
+static UIViewController *RootViewController(void) {
   if (@available(iOS 13, *)) { // UIApplication.keyWindow is deprecated
     NSSet *scenes = [[UIApplication sharedApplication] connectedScenes];
     for (UIScene *scene in scenes) {


### PR DESCRIPTION
Fix the warnings: "A function declaration without a prototype is deprecated in all versions of C"

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

