### PR TITLE
fix(device_info_plus): fix the error in the e2e test.

### DIFF
--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -67,7 +67,7 @@ void main() {
 
   testWidgets('Can get non-null iOS utsname fields',
       (WidgetTester tester) async {
-    expect(iosInfo.utsname.machine, 'iPhone15,4');
+    expect(iosInfo.utsname.machine, isNotNull);
     expect(iosInfo.utsname.nodename, isNotNull);
     expect(iosInfo.utsname.release, isNotNull);
     expect(iosInfo.utsname.sysname, isNotNull);


### PR DESCRIPTION
I'm not sure why this part is hardcoded. But if we do it this way, it means our local tests might not pass.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

