### PR TITLE
feat(device_info_plus): Add the isiOSAppOnMac property for the iOS platform.

### DIFF
--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -115,6 +115,7 @@ class _MyAppState extends State<MyApp> {
       'localizedModel': data.localizedModel,
       'identifierForVendor': data.identifierForVendor,
       'isPhysicalDevice': data.isPhysicalDevice,
+      'isiOSAppOnMac': data.isiOSAppOnMac,
       'utsname.sysname:': data.utsname.sysname,
       'utsname.nodename:': data.utsname.nodename,
       'utsname.release:': data.utsname.release,

--- a/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/FPPDeviceInfoPlusPlugin.m
+++ b/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/FPPDeviceInfoPlusPlugin.m
@@ -24,7 +24,7 @@
     NSNumber *isPhysicalNumber =
         [NSNumber numberWithBool:[self isDevicePhysical]];
     NSProcessInfo *info = [NSProcessInfo processInfo];
-    NSNumber *isiOSAppOnMac = [NSNumber numberWithBool:false];
+    NSNumber *isiOSAppOnMac = [NSNumber numberWithBool:NO];
     if (@available(iOS 14.0, *)) {
       isiOSAppOnMac = [NSNumber numberWithBool:[info isiOSAppOnMac]];
     }

--- a/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/FPPDeviceInfoPlusPlugin.m
+++ b/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/FPPDeviceInfoPlusPlugin.m
@@ -23,14 +23,17 @@
 
     NSNumber *isPhysicalNumber =
         [NSNumber numberWithBool:[self isDevicePhysical]];
+    NSProcessInfo *info = [NSProcessInfo processInfo];
+    NSNumber *isiOSAppOnMac = [NSNumber numberWithBool:false];
+    if (@available(iOS 14.0, *)) {
+      isiOSAppOnMac = [NSNumber numberWithBool:[info isiOSAppOnMac]];
+    }
     NSString *machine;
     if ([self isDevicePhysical]) {
       machine = @(un.machine);
     } else {
-      machine = [[NSProcessInfo processInfo]
-          environment][@"SIMULATOR_MODEL_IDENTIFIER"];
+      machine = [info environment][@"SIMULATOR_MODEL_IDENTIFIER"];
     }
-
     result(@{
       @"name" : [device name],
       @"systemName" : [device systemName],
@@ -40,6 +43,7 @@
       @"identifierForVendor" : [[device identifierForVendor] UUIDString]
           ?: [NSNull null],
       @"isPhysicalDevice" : isPhysicalNumber,
+      @"isiOSAppOnMac" : isiOSAppOnMac,
       @"utsname" : @{
         @"sysname" : @(un.sysname),
         @"nodename" : @(un.nodename),

--- a/packages/device_info_plus/device_info_plus/lib/src/model/ios_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/ios_device_info.dart
@@ -18,6 +18,7 @@ class IosDeviceInfo extends BaseDeviceInfo {
     required this.localizedModel,
     this.identifierForVendor,
     required this.isPhysicalDevice,
+    required this.isiOSAppOnMac,
     required this.utsname,
   }) : super(data);
 
@@ -52,6 +53,10 @@ class IosDeviceInfo extends BaseDeviceInfo {
   /// `false` if the application is running in a simulator, `true` otherwise.
   final bool isPhysicalDevice;
 
+  /// that indicates whether the process is an iPhone or iPad app running on a Mac.
+  /// https://developer.apple.com/documentation/foundation/nsprocessinfo/3608556-iosapponmac
+  final bool isiOSAppOnMac;
+
   /// Operating system information derived from `sys/utsname.h`.
   final IosUtsname utsname;
 
@@ -66,6 +71,7 @@ class IosDeviceInfo extends BaseDeviceInfo {
       localizedModel: map['localizedModel'],
       identifierForVendor: map['identifierForVendor'],
       isPhysicalDevice: map['isPhysicalDevice'],
+      isiOSAppOnMac: map['isiOSAppOnMac'],
       utsname:
           IosUtsname._fromMap(map['utsname']?.cast<String, dynamic>() ?? {}),
     );

--- a/packages/device_info_plus/device_info_plus/test/model/ios_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/ios_device_info_test.dart
@@ -20,6 +20,7 @@ void main() {
         'utsname': iosUtsnameMap,
         'systemName': 'systemName',
         'isPhysicalDevice': true,
+        'isiOSAppOnMac': true,
         'systemVersion': 'systemVersion',
         'localizedModel': 'localizedModel',
         'identifierForVendor': 'identifierForVendor',
@@ -32,6 +33,7 @@ void main() {
       expect(iosDeviceInfo.name, 'name');
       expect(iosDeviceInfo.model, 'model');
       expect(iosDeviceInfo.isPhysicalDevice, isTrue);
+      expect(iosDeviceInfo.isiOSAppOnMac, isTrue);
       expect(iosDeviceInfo.systemName, 'systemName');
       expect(iosDeviceInfo.systemVersion, 'systemVersion');
       expect(iosDeviceInfo.localizedModel, 'localizedModel');


### PR DESCRIPTION
I noticed someone mentioned adding the isiOSAppOnMac property for iOS. I think it's a good suggestion, so I created this request. If it's not appropriate, please let me know. Thanks!

- fix: https://github.com/fluttercommunity/plus_plugins/issues/3374

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

