### PR TITLE
fix(device_info_plus): device memory null error on Safari and Firefox

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
@@ -46,6 +46,7 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
   }
 }
 
+// TODO: Remove when https://github.com/dart-lang/web/issues/326 is resolved
 extension SafeNavigationGetterExtensions on html.Navigator {
   double? safeDeviceMemory() {
     try {

--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
@@ -17,8 +17,7 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
   /// Factory method that initializes the DeviceInfoPlus plugin platform
   /// with an instance of the plugin for the web.
   static void registerWith(Registrar registrar) {
-    DeviceInfoPlatform.instance =
-        DeviceInfoPlusWebPlugin(html.window.navigator);
+    DeviceInfoPlatform.instance = DeviceInfoPlusWebPlugin(html.window.navigator);
   }
 
   @override
@@ -29,7 +28,7 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
           'appCodeName': _navigator.appCodeName,
           'appName': _navigator.appName,
           'appVersion': _navigator.appVersion,
-          'deviceMemory': _navigator.deviceMemory,
+          'deviceMemory': _navigator.safeDeviceMemory(),
           'language': _navigator.language,
           'languages': _navigator.languages.toDart,
           'platform': _navigator.platform,
@@ -43,5 +42,15 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
         },
       ),
     );
+  }
+}
+
+extension SafeNavigationGetterExtensions on html.Navigator {
+  double? safeDeviceMemory() {
+    try {
+      return deviceMemory;
+    } catch (e) {
+      return 0.0;
+    }
   }
 }

--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
@@ -17,7 +17,8 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
   /// Factory method that initializes the DeviceInfoPlus plugin platform
   /// with an instance of the plugin for the web.
   static void registerWith(Registrar registrar) {
-    DeviceInfoPlatform.instance = DeviceInfoPlusWebPlugin(html.window.navigator);
+    DeviceInfoPlatform.instance =
+        DeviceInfoPlusWebPlugin(html.window.navigator);
   }
 
   @override

--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
@@ -52,7 +52,7 @@ extension SafeNavigationGetterExtensions on html.Navigator {
     try {
       return deviceMemory;
     } catch (e) {
-      return 0.0;
+      return null;
     }
   }
 }

--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
@@ -49,9 +49,9 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
 /// Some Navigator properties are not fully supported in all browsers.
 /// However, package:web does not provide a safe way to access these properties,
 /// and assumes they are always not null.
-/// 
+///
 /// This extension provides a safe way to access these properties.
-/// 
+///
 /// See: https://github.com/dart-lang/web/issues/326
 ///      https://github.com/fluttercommunity/plus_plugins/issues/3391
 extension SafeNavigationGetterExtensions on html.Navigator {

--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
@@ -29,7 +29,7 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
           'appCodeName': _navigator.appCodeName,
           'appName': _navigator.appName,
           'appVersion': _navigator.appVersion,
-          'deviceMemory': _navigator.safeDeviceMemory(),
+          'deviceMemory': _navigator.safeDeviceMemory,
           'language': _navigator.language,
           'languages': _navigator.languages.toDart,
           'platform': _navigator.platform,
@@ -46,13 +46,15 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
   }
 }
 
-// TODO: Remove when https://github.com/dart-lang/web/issues/326 is resolved
+/// Some Navigator properties are not fully supported in all browsers.
+/// However, package:web does not provide a safe way to access these properties,
+/// and assumes they are always not null.
+/// 
+/// This extension provides a safe way to access these properties.
+/// 
+/// See: https://github.com/dart-lang/web/issues/326
+///      https://github.com/fluttercommunity/plus_plugins/issues/3391
 extension SafeNavigationGetterExtensions on html.Navigator {
-  double? safeDeviceMemory() {
-    try {
-      return deviceMemory;
-    } catch (e) {
-      return null;
-    }
-  }
+  @JS('deviceMemory')
+  external double? get safeDeviceMemory;
 }


### PR DESCRIPTION
## Description

Fixes *type 'Null' is not a subtype of type 'double'* for deviceMemory in webBrowserInfo on Safari and Firefox

## Related Issues
- Fix #3391 
- Related: https://github.com/dart-lang/web/issues/326

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a ! in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

