### PR TITLE
fix(device_info_plus): Resolve compilation issues with SPM enabled

### DIFF
--- a/packages/device_info_plus/device_info_plus/macos/device_info_plus/Package.swift
+++ b/packages/device_info_plus/device_info_plus/macos/device_info_plus/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             dependencies: [],
             resources: [
                 .process("PrivacyInfo.xcprivacy"),
-            ],
+            ]
         )
     ]
 )


### PR DESCRIPTION
## Description

It is just separation into smaller commits of #3396 to generate meaningful changelogs during the next release.

I did testing for MacOS and iOS with Flutter 3.27.1 and enabled SPM and can confirm that the issue happens only on MacOS due to a redundant comma. 

I will do the same for `package_info_plus` and check the rest of plugins.

