### PR TITLE
fix(package_info_plus): Resolve compilation issues with SPM enabled

### DIFF
--- a/packages/package_info_plus/package_info_plus/macos/package_info_plus/Package.swift
+++ b/packages/package_info_plus/package_info_plus/macos/package_info_plus/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
             dependencies: [],
             resources: [
                 .process("PrivacyInfo.xcprivacy")
-            ]
+            ],
             cSettings: [
                 .headerSearchPath("include/package_info_plus")
             ]


### PR DESCRIPTION
## Description

Same as #3405 but for package_info_plus.

P.S. Checked the rest of plugins and didn't find issues with missing or redundant separators.