### PR TITLE
fix(network_info_plus): Improve Wi-Fi IP address retrieval on iOS to avoid null

### DIFF
--- a/packages/network_info_plus/network_info_plus/example/ios/Runner/AppDelegate.swift
+++ b/packages/network_info_plus/network_info_plus/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,


### PR DESCRIPTION
## Description

Based on information provided in https://github.com/fluttercommunity/plus_plugins/issues/1652#issuecomment-2373580942 changed the iOS implementation to retrieve IP address to get values even when device uses not `en0` interface for Wi-Fi.

Additionally did minor improvements with log entry when interfaces info retrieval fails and changed the comparison to simplify it a bit.

## Related Issues

Fixes #1652

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

