### PR TITLE
fix(share_plus) sharing content on huawei or honor vendor which changed the default intent of Intent.ACTION_SEND

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -81,7 +81,11 @@ internal class Share(
             } else {
                 Intent.createChooser(shareIntent, null /* dialog title optional */)
             }
-        startActivity(chooserIntent, withResult)
+        startActivity(chooserIntent.apply {
+            getAvailableOemChooser()?.let {
+                action = it.action
+            }
+        }, withResult)
     }
 
     @Throws(IOException::class)
@@ -155,7 +159,11 @@ internal class Share(
                 )
             }
         }
-        startActivity(chooserIntent, withResult)
+        startActivity(chooserIntent.apply {
+            getAvailableOemChooser()?.let {
+                action = it.action
+            }
+        }, withResult)
     }
 
     private fun startActivity(intent: Intent, withResult: Boolean) {
@@ -251,4 +259,20 @@ internal class Share(
         file.copyTo(newFile, true)
         return newFile
     }
+
+    enum class OemChooser(
+        val action: String,
+        val packageName: String,
+    ) {
+        HUAWEI("com.huawei.intent.action.hwCHOOSER", "com.huawei.android.internal.app"),
+        HIHONOR("com.hihonor.intent.action.hwCHOOSER", "com.hihonor.android.internal.app")
+    }
+
+
+    private fun getAvailableOemChooser(): OemChooser? =
+        OemChooser.values().firstOrNull {
+            val resolveInfo = context.packageManager.resolveActivity(Intent(it.action), PackageManager.MATCH_DEFAULT_ONLY)
+
+            return@firstOrNull resolveInfo?.activityInfo?.packageName == it.packageName
+        }
 }


### PR DESCRIPTION
fix(share_plus) sharing content on huawei or honor vendor which changed the default intent of Intent.ACTION_SEND

## Description

for those OEM vendor brand that changed default choose intent of  Intent.ACTION_SEND, I fixed Huawei and Honor vendor share intent

## Related Issues

- *Related #3186*
- *Related #1588*
- *Related #1030*
## Checklist

- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

