### PR TITLE
fix(android_intent_plus): set correct environment versions

### DIFF
--- a/packages/android_intent_plus/README.md
+++ b/packages/android_intent_plus/README.md
@@ -16,8 +16,8 @@ This plugin allows Flutter apps to launch arbitrary intents when the platform is
 
 ## Requirements
 
-- Flutter >=3.3.0
-- Dart >=2.18.0 <4.0.0
+- Flutter >=3.12.0
+- Dart >=3.1.0 <4.0.0
 - Android `compileSDK` 34
 - Java 17
 - Android Gradle Plugin >=8.3.0

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -10,8 +10,8 @@ topics:
   - utils
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.12.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Fix the declaration of the minimum compatible version.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

