### PR TITLE
ci: Automatically lock issues and PRs older than a year

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,8 +30,5 @@ jobs:
           exempt-issue-labels: enhancement
           exempt-pr-labels: keep-open
           operations-per-run: 1000
-      - name: Lock closed issues and PRs (defaults to 365 days)
-        uses: dessant/lock-threads@v5.0.1
-        with:
-          process-only: 'issues, prs' # Ignore Discussions
-          
+      - name: Lock closed issues and PRs
+        uses: dessant/lock-threads@v5

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest
@@ -26,3 +30,8 @@ jobs:
           exempt-issue-labels: enhancement
           exempt-pr-labels: keep-open
           operations-per-run: 1000
+      - name: Lock closed issues and PRs (defaults to 365 days)
+        uses: dessant/lock-threads@v5.0.1
+        with:
+          process-only: 'issues, prs' # Ignore Discussions
+          


### PR DESCRIPTION
## Description

This GH action closes PRs and Issues that have been closed and without activity for a year.

This is to avoid spam on older issues and force users to create new tickets if they have problems.

The default is 365 days since last activity. We can lower this value to something shorter e.g. 90 days.

## Related Issues

- None

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

