### PR TITLE
docs(package_info_plus): doc ref links and unnecessary library names

### DIFF
--- a/packages/package_info_plus/package_info_plus/README.md
+++ b/packages/package_info_plus/package_info_plus/README.md
@@ -76,7 +76,7 @@ See https://github.com/fluttercommunity/plus_plugins/issues/309
 #### I see wrong version on Windows platform
 
 There was an [issue](https://github.com/flutter/flutter/issues/73652) in Flutter, which is already resolved since Flutter 3.3.
-If your project was created before Flutter 3.3 you need to migrate the project according to [this guide] (https://docs.flutter.dev/release/breaking-changes/windows-version-information) first to get correct version with `package_info_plus`
+If your project was created before Flutter 3.3 you need to migrate the project according to [this guide](https://docs.flutter.dev/release/breaking-changes/windows-version-information) first to get correct version with `package_info_plus`
 
 ### Web
 

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -53,8 +53,8 @@ class PackageInfo {
   ///
   ///     With this, the package will try to search the file in `https://cdn.domain.com/with/some/path/version.json`
   ///
-  ///   * The second option where it will search is the [assetBase] parameter
-  ///     that you can pass to the Flutter Web Engine when you initialize it.
+  ///   * The second option where it will search is the [assetBase](https://docs.flutter.dev/platform-integration/web/initialization#customize-the-flutter-loader)
+  ///     parameter that you can pass to the Flutter Web Engine when you initialize it.
   ///
   ///     ```javascript
   ///     _flutter.loader.loadEntrypoint({


### PR DESCRIPTION
## Description

This PR fixes two broken doc references: one in `src/package_info_plus_linux.dart` and one in `package_info_plus.dart`. Also fixes warnings from `flutter analyze` about unnecessary library names.

## Related Issues

No related issues.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

