### PR TITLE
feat(package_info_plus): add install time

### DIFF
--- a/packages/package_info_plus/package_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/packageinfo/PackageInfoPlugin.kt
+++ b/packages/package_info_plus/package_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/packageinfo/PackageInfoPlugin.kt
@@ -39,6 +39,7 @@ class PackageInfoPlugin : MethodCallHandler, FlutterPlugin {
                 val buildSignature = getBuildSignature(packageManager)
 
                 val installerPackage = getInstallerPackageName()
+                val installTimeMillis = getInstallTimeMillis()
 
                 val infoMap = HashMap<String, String>()
                 infoMap.apply {
@@ -48,6 +49,7 @@ class PackageInfoPlugin : MethodCallHandler, FlutterPlugin {
                     put("buildNumber", getLongVersionCode(info).toString())
                     if (buildSignature != null) put("buildSignature", buildSignature)
                     if (installerPackage != null) put("installerStore", installerPackage)
+                    if (installTimeMillis != null) put("installTime", installTimeMillis.toString())
                 }.also { resultingMap ->
                     result.success(resultingMap)
                 }
@@ -71,6 +73,22 @@ class PackageInfoPlugin : MethodCallHandler, FlutterPlugin {
         } else {
             @Suppress("DEPRECATION")
             packageManager.getInstallerPackageName(packageName)
+        }
+    }
+
+    private fun getInstallTimeMillis(): Long? {
+        return try {
+            val packageManager = applicationContext!!.packageManager
+            val packageName = applicationContext!!.packageName
+            val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                packageManager.getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
+            } else {
+                packageManager.getPackageInfo(packageName, 0)
+            }
+
+            packageInfo.firstInstallTime
+        } catch (e: PackageManager.NameNotFoundException) {
+            null
         }
     }
 

--- a/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_test.dart
+++ b/packages/package_info_plus/package_info_plus/example/integration_test/package_info_plus_test.dart
@@ -16,6 +16,8 @@ const android14SDK = 34;
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
+  final testStartTime = DateTime.now();
+
   testWidgets('fromPlatform', (WidgetTester tester) async {
     final info = await PackageInfo.fromPlatform();
     // These tests are based on the example app. The tests should be updated if any related info changes.
@@ -26,6 +28,7 @@ void main() {
       expect(info.packageName, 'package_info_plus_example');
       expect(info.version, '1.2.3');
       expect(info.installerStore, null);
+      expect(info.installTime, null);
     } else {
       if (Platform.isAndroid) {
         final androidVersionInfo = await DeviceInfoPlugin().androidInfo;
@@ -41,6 +44,14 @@ void main() {
         } else {
           expect(info.installerStore, null);
         }
+        expect(
+          info.installTime,
+          isA<DateTime>().having(
+            (d) => d.difference(DateTime.now()).inMinutes,
+            'Was just installed',
+            lessThanOrEqualTo(1),
+          ),
+        );
       } else if (Platform.isIOS) {
         expect(info.appName, 'Package Info Plus Example');
         expect(info.buildNumber, '4');
@@ -48,6 +59,14 @@ void main() {
         expect(info.packageName, 'io.flutter.plugins.packageInfoExample');
         expect(info.version, '1.2.3');
         expect(info.installerStore, 'com.apple.simulator');
+        expect(
+          info.installTime,
+          isA<DateTime>().having(
+            (d) => d.difference(DateTime.now()).inMinutes,
+            'Was just installed',
+            lessThanOrEqualTo(1),
+          ),
+        );
       } else if (Platform.isMacOS) {
         expect(info.appName, 'Package Info Plus Example');
         expect(info.buildNumber, '4');
@@ -55,12 +74,14 @@ void main() {
         expect(info.packageName, 'io.flutter.plugins.packageInfoExample');
         expect(info.version, '1.2.3');
         expect(info.installerStore, null);
+        expect(info.installTime, null);
       } else if (Platform.isLinux) {
         expect(info.appName, 'package_info_plus_example');
         expect(info.buildNumber, '4');
         expect(info.buildSignature, isEmpty);
         expect(info.packageName, 'package_info_plus_example');
         expect(info.version, '1.2.3');
+        expect(info.installTime, null);
       } else if (Platform.isWindows) {
         expect(info.appName, 'example');
         expect(info.buildNumber, '4');
@@ -68,6 +89,7 @@ void main() {
         expect(info.packageName, 'example');
         expect(info.version, '1.2.3');
         expect(info.installerStore, null);
+        expect(info.installTime, null);
       } else {
         throw (UnsupportedError('platform not supported'));
       }
@@ -83,7 +105,16 @@ void main() {
       expect(find.text('4'), findsOneWidget);
       expect(find.text('Not set'), findsOneWidget);
       expect(find.text('not available'), findsOneWidget);
+      expect(find.text('Install time not available'), findsOneWidget);
     } else {
+      final expectedInstallTimeIso = testStartTime.toIso8601String();
+      final installTimeRegex = RegExp(
+        expectedInstallTimeIso.replaceAll(
+          RegExp(r'\d:\d\d\..+$'),
+          r'.+$',
+        ),
+      );
+
       if (Platform.isAndroid) {
         final androidVersionInfo = await DeviceInfoPlugin().androidInfo;
 
@@ -101,6 +132,7 @@ void main() {
         } else {
           expect(find.text('not available'), findsOneWidget);
         }
+        expect(find.textContaining(installTimeRegex), findsOneWidget);
       } else if (Platform.isIOS) {
         expect(find.text('Package Info Plus Example'), findsOneWidget);
         expect(find.text('4'), findsOneWidget);
@@ -109,6 +141,7 @@ void main() {
         expect(find.text('1.2.3'), findsOneWidget);
         expect(find.text('Not set'), findsOneWidget);
         expect(find.text('com.apple.simulator'), findsOneWidget);
+        expect(find.textContaining(installTimeRegex), findsOneWidget);
       } else if (Platform.isMacOS) {
         expect(find.text('Package Info Plus Example'), findsOneWidget);
         expect(find.text('4'), findsOneWidget);
@@ -117,17 +150,20 @@ void main() {
         expect(find.text('1.2.3'), findsOneWidget);
         expect(find.text('Not set'), findsOneWidget);
         expect(find.text('not available'), findsOneWidget);
+        expect(find.text('Install time not available'), findsOneWidget);
       } else if (Platform.isLinux) {
         expect(find.text('package_info_plus_example'), findsNWidgets(2));
         expect(find.text('1.2.3'), findsOneWidget);
         expect(find.text('4'), findsOneWidget);
         expect(find.text('Not set'), findsOneWidget);
+        expect(find.text('Install time not available'), findsOneWidget);
       } else if (Platform.isWindows) {
         expect(find.text('example'), findsNWidgets(2));
         expect(find.text('1.2.3'), findsOneWidget);
         expect(find.text('4'), findsOneWidget);
         expect(find.text('Not set'), findsOneWidget);
         expect(find.text('not available'), findsOneWidget);
+        expect(find.text('Install time not available'), findsOneWidget);
       } else {
         throw (UnsupportedError('platform not supported'));
       }

--- a/packages/package_info_plus/package_info_plus/example/lib/main.dart
+++ b/packages/package_info_plus/package_info_plus/example/lib/main.dart
@@ -84,6 +84,11 @@ class _MyHomePageState extends State<MyHomePage> {
             'Installer store',
             _packageInfo.installerStore ?? 'not available',
           ),
+          _infoTile(
+            'Install time',
+            _packageInfo.installTime?.toIso8601String() ??
+                'Install time not available',
+          ),
         ],
       ),
     );

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -1,10 +1,10 @@
 name: package_info_plus_example
 description: Demonstrates how to use the package_info_plus plugin.
 version: 1.2.3+4
-publish_to: 'none'
+publish_to: "none"
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: ">=2.18.0 <4.0.0"
 
 dependencies:
   clock: ^1.1.1

--- a/packages/package_info_plus/package_info_plus/ios/package_info_plus/Sources/package_info_plus/FPPPackageInfoPlusPlugin.m
+++ b/packages/package_info_plus/package_info_plus/ios/package_info_plus/Sources/package_info_plus/FPPPackageInfoPlusPlugin.m
@@ -26,6 +26,12 @@
             ? @"com.apple.testflight"
             : @"com.apple";
 
+    NSURL* urlToDocumentsFolder = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
+    __autoreleasing NSError *error;
+    NSDate *installDate = [[[NSFileManager defaultManager] attributesOfItemAtPath:urlToDocumentsFolder.path error:&error] objectForKey:NSFileCreationDate];
+    NSNumber *installTimeMillis = installDate ? @((long long)([installDate timeIntervalSince1970] * 1000)) : [NSNull null];
+
+
     result(@{
       @"appName" : [[NSBundle mainBundle]
           objectForInfoDictionaryKey:@"CFBundleDisplayName"]
@@ -39,8 +45,10 @@
       @"buildNumber" : [[NSBundle mainBundle]
           objectForInfoDictionaryKey:@"CFBundleVersion"]
           ?: [NSNull null],
-      @"installerStore" : installerStore
+      @"installerStore" : installerStore,
+      @"installTime" : installTimeMillis ? [installTimeMillis stringValue] : [NSNull null]
     });
+
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -27,6 +27,7 @@ class PackageInfo {
     required this.buildNumber,
     this.buildSignature = '',
     this.installerStore,
+    this.installTime,
   });
 
   static PackageInfo? _fromPlatform;
@@ -88,6 +89,7 @@ class PackageInfo {
       buildNumber: platformData.buildNumber,
       buildSignature: platformData.buildSignature,
       installerStore: platformData.installerStore,
+      installTime: platformData.installTime,
     );
     return _fromPlatform!;
   }
@@ -147,6 +149,13 @@ class PackageInfo {
   /// The installer store. Indicates through which store this application was installed.
   final String? installerStore;
 
+  /// The time when the application was installed on the device.
+  ///
+  /// Checks the creation date of the Documents directory on iOS
+  /// or returns `packageInfo.firstInstallTime` on Android.
+  /// Otherwise returns null.
+  final DateTime? installTime;
+
   /// Initializes the application metadata with mock values for testing.
   ///
   /// If the singleton instance has been initialized already, it is overwritten.
@@ -158,6 +167,7 @@ class PackageInfo {
     required String buildNumber,
     required String buildSignature,
     String? installerStore,
+    DateTime? installTime,
   }) {
     _fromPlatform = PackageInfo(
       appName: appName,
@@ -166,6 +176,7 @@ class PackageInfo {
       buildNumber: buildNumber,
       buildSignature: buildSignature,
       installerStore: installerStore,
+      installTime: installTime,
     );
   }
 
@@ -180,7 +191,8 @@ class PackageInfo {
           version == other.version &&
           buildNumber == other.buildNumber &&
           buildSignature == other.buildSignature &&
-          installerStore == other.installerStore;
+          installerStore == other.installerStore &&
+          installTime == other.installTime;
 
   /// Overwrite hashCode for value equality
   @override
@@ -190,11 +202,12 @@ class PackageInfo {
       version.hashCode ^
       buildNumber.hashCode ^
       buildSignature.hashCode ^
-      installerStore.hashCode;
+      installerStore.hashCode ^
+      installTime.hashCode;
 
   @override
   String toString() {
-    return 'PackageInfo(appName: $appName, buildNumber: $buildNumber, packageName: $packageName, version: $version, buildSignature: $buildSignature, installerStore: $installerStore)';
+    return 'PackageInfo(appName: $appName, buildNumber: $buildNumber, packageName: $packageName, version: $version, buildSignature: $buildSignature, installerStore: $installerStore, installTime: $installTime)';
   }
 
   Map<String, dynamic> _toMap() {
@@ -205,6 +218,7 @@ class PackageInfo {
       'version': version,
       if (buildSignature.isNotEmpty) 'buildSignature': buildSignature,
       if (installerStore?.isNotEmpty ?? false) 'installerStore': installerStore,
+      if (installTime != null) 'installTime': installTime
     };
   }
 

--- a/packages/package_info_plus/package_info_plus/test/package_info_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_test.dart
@@ -12,6 +12,8 @@ void main() {
   const channel = MethodChannel('dev.fluttercommunity.plus/package_info');
   final log = <MethodCall>[];
 
+  final now = DateTime.now().copyWith(microsecond: 0);
+
   TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
       .setMockMethodCallHandler(
     channel,
@@ -25,6 +27,7 @@ void main() {
             'packageName': 'io.flutter.plugins.packageinfoexample',
             'version': '1.0',
             'installerStore': null,
+            'installTime': now.millisecondsSinceEpoch.toString(),
           };
         default:
           assert(false);
@@ -44,6 +47,7 @@ void main() {
     expect(info.packageName, 'io.flutter.plugins.packageinfoexample');
     expect(info.version, '1.0');
     expect(info.installerStore, null);
+    expect(info.installTime, now);
     expect(
       log,
       <Matcher>[
@@ -63,6 +67,7 @@ void main() {
       buildNumber: '2',
       buildSignature: 'deadbeef',
       installerStore: null,
+      installTime: now,
     );
     final info = await PackageInfo.fromPlatform();
     expect(info.appName, 'mock_package_info_example');
@@ -71,6 +76,7 @@ void main() {
     expect(info.version, '1.1');
     expect(info.buildSignature, 'deadbeef');
     expect(info.installerStore, null);
+    expect(info.installTime, now);
   });
 
   test('equals checks for value equality', () async {
@@ -81,6 +87,7 @@ void main() {
       version: '1.0',
       buildSignature: '',
       installerStore: null,
+      installTime: now,
     );
     final info2 = PackageInfo(
       appName: 'package_info_example',
@@ -89,19 +96,20 @@ void main() {
       version: '1.0',
       buildSignature: '',
       installerStore: null,
+      installTime: now,
     );
     expect(info1, info2);
   });
 
   test('hashCode checks for value equality', () async {
     final info1 = PackageInfo(
-      appName: 'package_info_example',
-      buildNumber: '1',
-      packageName: 'io.flutter.plugins.packageinfoexample',
-      version: '1.0',
-      buildSignature: '',
-      installerStore: null,
-    );
+        appName: 'package_info_example',
+        buildNumber: '1',
+        packageName: 'io.flutter.plugins.packageinfoexample',
+        version: '1.0',
+        buildSignature: '',
+        installerStore: null,
+        installTime: now);
     final info2 = PackageInfo(
       appName: 'package_info_example',
       buildNumber: '1',
@@ -109,6 +117,7 @@ void main() {
       version: '1.0',
       buildSignature: '',
       installerStore: null,
+      installTime: now,
     );
     expect(info1.hashCode, info2.hashCode);
   });
@@ -121,10 +130,11 @@ void main() {
       version: '1.0',
       buildSignature: '',
       installerStore: null,
+      installTime: now,
     );
     expect(
       info.toString(),
-      'PackageInfo(appName: package_info_example, buildNumber: 1, packageName: io.flutter.plugins.packageinfoexample, version: 1.0, buildSignature: , installerStore: null)',
+      'PackageInfo(appName: package_info_example, buildNumber: 1, packageName: io.flutter.plugins.packageinfoexample, version: 1.0, buildSignature: , installerStore: null, installTime: $now)',
     );
   });
 
@@ -136,6 +146,7 @@ void main() {
       buildNumber: '2',
       buildSignature: '',
       installerStore: null,
+      installTime: now,
     );
     final info1 = await PackageInfo.fromPlatform();
     expect(info1.data, {
@@ -143,7 +154,10 @@ void main() {
       'packageName': 'io.flutter.plugins.mockpackageinfoexample',
       'version': '1.1',
       'buildNumber': '2',
+      'installTime': now,
     });
+
+    final nextWeek = now.add(const Duration(days: 7));
     PackageInfo.setMockInitialValues(
       appName: 'mock_package_info_example',
       packageName: 'io.flutter.plugins.mockpackageinfoexample',
@@ -151,6 +165,7 @@ void main() {
       buildNumber: '2',
       buildSignature: 'deadbeef',
       installerStore: 'testflight',
+      installTime: nextWeek,
     );
     final info2 = await PackageInfo.fromPlatform();
     expect(info2.data, {
@@ -160,6 +175,7 @@ void main() {
       'buildNumber': '2',
       'buildSignature': 'deadbeef',
       'installerStore': 'testflight',
+      'installTime': nextWeek,
     });
   });
 }

--- a/packages/package_info_plus/package_info_plus/test/package_info_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_test.dart
@@ -103,13 +103,14 @@ void main() {
 
   test('hashCode checks for value equality', () async {
     final info1 = PackageInfo(
-        appName: 'package_info_example',
-        buildNumber: '1',
-        packageName: 'io.flutter.plugins.packageinfoexample',
-        version: '1.0',
-        buildSignature: '',
-        installerStore: null,
-        installTime: now);
+      appName: 'package_info_example',
+      buildNumber: '1',
+      packageName: 'io.flutter.plugins.packageinfoexample',
+      version: '1.0',
+      buildSignature: '',
+      installerStore: null,
+      installTime: now,
+    );
     final info2 = PackageInfo(
       appName: 'package_info_example',
       buildNumber: '1',

--- a/packages/package_info_plus/package_info_plus_platform_interface/lib/method_channel_package_info.dart
+++ b/packages/package_info_plus/package_info_plus_platform_interface/lib/method_channel_package_info.dart
@@ -11,6 +11,12 @@ class MethodChannelPackageInfo extends PackageInfoPlatform {
   @override
   Future<PackageInfoData> getAll({String? baseUrl}) async {
     final map = await _channel.invokeMapMethod<String, dynamic>('getAll');
+
+    final installTime = map?['installTime'] != null &&
+            int.tryParse(map!['installTime']!) != null
+        ? DateTime.fromMillisecondsSinceEpoch(int.parse(map['installTime']!))
+        : null;
+
     return PackageInfoData(
       appName: map!['appName'] ?? '',
       packageName: map['packageName'] ?? '',
@@ -18,6 +24,7 @@ class MethodChannelPackageInfo extends PackageInfoPlatform {
       buildNumber: map['buildNumber'] ?? '',
       buildSignature: map['buildSignature'] ?? '',
       installerStore: map['installerStore'] as String?,
+      installTime: installTime,
     );
   }
 }

--- a/packages/package_info_plus/package_info_plus_platform_interface/lib/package_info_data.dart
+++ b/packages/package_info_plus/package_info_plus_platform_interface/lib/package_info_data.dart
@@ -10,6 +10,7 @@ class PackageInfoData {
     required this.buildNumber,
     required this.buildSignature,
     this.installerStore,
+    this.installTime,
   });
 
   /// The app name. `CFBundleDisplayName` on iOS, `application/label` on Android.
@@ -29,4 +30,7 @@ class PackageInfoData {
 
   /// The installer store. Indicates through which store this application was installed.
   final String? installerStore;
+
+  /// The time when the application was installed. The creation date of documents directory on iOS, `firstInstallTime` on Android, null otherwise.
+  final DateTime? installTime;
 }


### PR DESCRIPTION
## Description

Adds package install time to iOS and Android

- On Android: uses `PackageManager.firstInstallTime`
- On iOS: gets the creation date of the app's documents directory
   - The documents directory should be created automatically when the app is installed, based on this [SO answer](https://stackoverflow.com/questions/4090512/how-to-determine-the-date-an-app-is-installed-or-used-for-the-first-time)

## Related Issues

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.