### PR TITLE
docs: Add note regarding large PRs to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,8 @@ _See also: [Flutter's code of conduct](https://flutter.dev/design-principles/#co
 We welcome all contributions to the project, however some contributions will need extra work in
 order to be accepted.
 
-**New:** Before submitting a large PR, create a ticket with a proposal and wait for the maintainers to give you feedback.
+> [!IMPORTANT]  
+> Before submitting a large PR, create a ticket with a proposal and wait for the maintainers to give you feedback.
 
 Here's some examples:
 
@@ -180,7 +181,8 @@ Please follow the
 working on anything non-trivial. These guidelines are intended to
 keep the code consistent and avoid common pitfalls.
 
-**Important:** When modifying multiple packages, **create a different branch and pull request per package.**
+> [!IMPORTANT]  
+> When modifying multiple packages, **create a different branch and pull request per package.**
 This facilitates maintenance, the review process, and generating changelogs.
 
 ### 5.1 Getting started
@@ -232,6 +234,9 @@ guide, and include the package name in parenthesis. For example, for a fix to th
 
 Please also enable **“Allow edits by maintainers”**, this will help to speed-up the review
 process as well.
+
+> [!TIP]
+> Ensure the PR description is filled correctly and the markdown looks correctly.
 
 ### 5.6 Now be patient :)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,7 @@ The bootstrap command locally links all dependencies within the project without 
 provide manual [`dependency_overrides`](https://dart.dev/tools/pub/pubspec). This allows all
 plugins, examples and tests to build from the local clone project.
 
+> [!TIP]
 > You do not need to run `flutter pub get` once bootstrap has been completed.
 
 ## 4. Running an example
@@ -183,7 +184,7 @@ keep the code consistent and avoid common pitfalls.
 
 > [!IMPORTANT]  
 > When modifying multiple packages, **create a different branch and pull request per package.**
-This facilitates maintenance, the review process, and generating changelogs.
+> This facilitates maintenance, the review process, and generating changelogs.
 
 ### 5.1 Getting started
 
@@ -206,9 +207,10 @@ melos run analyze
 melos run format
 ```
 
-### 5.3 (Do not) Update version and changelog
+### 5.3 Do not update version and changelog
 
-**NEW: Do not modify the CHANGELOG.md or the version in the pubspec.yaml, this is handled by the maintainers from now on**
+> [!CAUTION]
+> Do not modify the `CHANGELOG.md` or the version in the `pubspec.yaml`, this is handled by the maintainers from now on
 
 ### 5.4 Commit and push your changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@ _See also: [Flutter's code of conduct](https://flutter.dev/design-principles/#co
 We welcome all contributions to the project, however some contributions will need extra work in
 order to be accepted.
 
+**New:** Before submitting a large PR, create a ticket with a proposal and wait for the maintainers to give you feedback.
+
 Here's some examples:
 
 ### 🟢 Easily accepted contributions
@@ -172,7 +174,7 @@ file.
 
 We gladly accept contributions via GitHub pull requests.
 
-Please peruse the
+Please follow the
 [Flutter style guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo) and
 [design principles](https://flutter.dev/design-principles/) before
 working on anything non-trivial. These guidelines are intended to


### PR DESCRIPTION
## Description

I want to add some notes to the Contributing guidelines regarding large PRs (usually are for new features but always applies), as they should be discussed beforehand.

I may add some other notes to the Contributing file before merging.

## Related Issues

- None

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

