### PR TITLE
docs(device_info_plus): Update the documentation URL for property descriptions.

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -109,7 +109,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
   final String tags;
 
   /// The type of build, like "user" or "eng".
-  /// https://developer.android.com/reference/android/os/Build#TIME
+  /// https://developer.android.com/reference/android/os/Build#TYPE
   final String type;
 
   /// `false` if the application is running in an emulator, `true` otherwise.


### PR DESCRIPTION
## Description

I found that the documentation for the type property seemed to point to time when reading the code. I have corrected it.

## Related Issues

<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

