### PR TITLE
feat(divice_info_plus): add time for android

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
@@ -49,6 +49,7 @@ internal class MethodCallHandlerImpl(
             }
 
             build["tags"] = Build.TAGS
+            build["time"] = Build.TIME
             build["type"] = Build.TYPE
             build["isPhysicalDevice"] = !isEmulator
             build["systemFeatures"] = getSystemFeatures()

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -105,6 +105,7 @@ void main() {
     expect(androidInfo.supportedAbis, isNotNull);
 
     expect(androidInfo.tags, isNotNull);
+    expect(androidInfo.time, isNonNegative);
     expect(androidInfo.type, isNotNull);
     expect(androidInfo.isPhysicalDevice, isNotNull);
     expect(androidInfo.systemFeatures, isNotNull);

--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -98,6 +98,7 @@ class _MyAppState extends State<MyApp> {
       'supported64BitAbis': build.supported64BitAbis,
       'supportedAbis': build.supportedAbis,
       'tags': build.tags,
+      'time': build.time,
       'type': build.type,
       'isPhysicalDevice': build.isPhysicalDevice,
       'systemFeatures': build.systemFeatures,

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -167,7 +167,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
       supported64BitAbis: _fromList(map['supported64BitAbis'] ?? <String>[]),
       supportedAbis: _fromList(map['supportedAbis'] ?? []),
       tags: map['tags'],
-      time: int.tryParse(map['time']) ?? 0,
+      time: map['time'] ?? 0,
       type: map['type'],
       isPhysicalDevice: map['isPhysicalDevice'],
       systemFeatures: _fromList(map['systemFeatures'] ?? []),

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -27,6 +27,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
     required List<String> supported64BitAbis,
     required List<String> supportedAbis,
     required this.tags,
+    required this.time,
     required this.type,
     required this.isPhysicalDevice,
     required List<String> systemFeatures,
@@ -108,6 +109,10 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
   /// https://developer.android.com/reference/android/os/Build#TAGS
   final String tags;
 
+  /// The time at which the build was produced, given in milliseconds since the UNIX epoch.
+  /// https://developer.android.com/reference/android/os/Build#TIME
+  final int time;
+
   /// The type of build, like "user" or "eng".
   /// https://developer.android.com/reference/android/os/Build#TIME
   final String type;
@@ -162,6 +167,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
       supported64BitAbis: _fromList(map['supported64BitAbis'] ?? <String>[]),
       supportedAbis: _fromList(map['supportedAbis'] ?? []),
       tags: map['tags'],
+      time: int.tryParse(map['time']) ?? 0,
       type: map['type'],
       isPhysicalDevice: map['isPhysicalDevice'],
       systemFeatures: _fromList(map['systemFeatures'] ?? []),

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
@@ -20,7 +20,7 @@ const _fakeAndroidDeviceInfo = <String, dynamic>{
   'host': 'host',
   'tags': 'tags',
   'type': 'type',
-  'time': '1735689600',
+  'time': 1735689600,
   'model': 'model',
   'board': 'board',
   'brand': 'Google',

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
@@ -20,6 +20,7 @@ const _fakeAndroidDeviceInfo = <String, dynamic>{
   'host': 'host',
   'tags': 'tags',
   'type': 'type',
+  'time': '1735689600',
   'model': 'model',
   'board': 'board',
   'brand': 'Google',

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
@@ -14,6 +14,7 @@ void main() {
       expect(androidDeviceInfo.id, 'id');
       expect(androidDeviceInfo.host, 'host');
       expect(androidDeviceInfo.tags, 'tags');
+      expect(androidDeviceInfo.time, 1735689600);
       expect(androidDeviceInfo.type, 'type');
       expect(androidDeviceInfo.model, 'model');
       expect(androidDeviceInfo.board, 'board');


### PR DESCRIPTION
## Description

I noticed that all other properties are provided, but time was somehow forgotten. Although this value can also be obtained in Flutter, I think it would be even better if it were included. It could also make comparisons more convenient.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

