### PR TITLE
fix(device_info_plus): #2957 replaces throwing exception with returning default values

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
@@ -3,6 +3,7 @@ library device_info_plus_windows;
 
 import 'dart:ffi';
 import 'dart:typed_data';
+import 'dart:developer' as developer;
 
 import 'package:device_info_plus_platform_interface/device_info_plus_platform_interface.dart';
 import 'package:ffi/ffi.dart';
@@ -124,8 +125,8 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
       if (result != 0) {
         return memoryInKilobytes.value ~/ 1024;
       } else {
-        final error = GetLastError();
-        throw WindowsException(HRESULT_FROM_WIN32(error));
+        developer.log('Failed to get system memory', error: GetLastError());
+        return 0;
       }
     } finally {
       free(memoryInKilobytes);
@@ -149,7 +150,8 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
       if (result != 0) {
         return lpBuffer.toDartString();
       } else {
-        throw WindowsException(HRESULT_FROM_WIN32(GetLastError()));
+        developer.log('Failed to get computer name', error: GetLastError());
+        return "";
       }
     } finally {
       free(lpBuffer);
@@ -167,7 +169,8 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
       if (result != 0) {
         return lpBuffer.toDartString();
       } else {
-        throw WindowsException(HRESULT_FROM_WIN32(GetLastError()));
+        developer.log('Failed to get user name', error: GetLastError());
+        return "";
       }
     } finally {
       free(pcbBuffer);


### PR DESCRIPTION
## Description

As discussed in #2957 seems that some Windows VMs will return 0 when asked for physical device memory, which causes the plugin to throw an exception.

The main issue is that 3rd party devs using this plugin in their packages may not properly catch exceptions.

This PR replaces these types of exception errors with returning default values, to avoid uncaught exceptions.

## Related Issues

- Closes #2957 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

