### PR TITLE
feat(android_intent_plus): adds error catching and forwarding

### DIFF
--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
@@ -63,7 +63,6 @@ public final class IntentSender {
     }
   }
 
-
   /** Creates an intent and launches it as a Service. */
   void sendService(Intent intent) {
     if (applicationContext == null) {

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
@@ -63,6 +63,24 @@ public final class IntentSender {
     }
   }
 
+
+  /** Creates an intent and launches it as a Service. */
+  void sendService(Intent intent) {
+    if (applicationContext == null) {
+      Log.wtf(TAG, "Trying to send an intent before the applicationContext was initialized.");
+      return;
+    }
+
+    Log.v(TAG, "Sending service intent " + intent);
+
+    if (activity != null) {
+      activity.startService(intent);
+    } else {
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      applicationContext.startService(intent);
+    }
+  }
+
   /**
    * Like with {@code send}, creates and launches an intent with the given params, but wraps the
    * {@code Intent} with {@code Intent.createChooser}.

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
@@ -73,59 +73,63 @@ public final class MethodCallHandlerImpl implements MethodCallHandler {
    */
   @Override
   public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {
-    String action = convertAction((String) call.argument("action"));
-    Integer flags = call.argument("flags");
-    String category = call.argument("category");
-    Uri data = call.argument("data") != null ? Uri.parse((String) call.argument("data")) : null;
-    Bundle arguments = convertArguments((Map<String, ?>) call.argument("arguments"));
-    Bundle arrayArguments = convertArrayArguments((Map<String, ?>) call.argument("arrayArguments"));
-    arguments.putAll(arrayArguments);
-    String packageName = call.argument("package");
-    ComponentName componentName =
-        (!TextUtils.isEmpty(packageName)
-                && !TextUtils.isEmpty((String) call.argument("componentName")))
-            ? new ComponentName(packageName, (String) call.argument("componentName"))
-            : null;
-    String type = call.argument("type");
+    try {
+      String action = convertAction((String) call.argument("action"));
+      Integer flags = call.argument("flags");
+      String category = call.argument("category");
+      Uri data = call.argument("data") != null ? Uri.parse((String) call.argument("data")) : null;
+      Bundle arguments = convertArguments((Map<String, ?>) call.argument("arguments"));
+      Bundle arrayArguments = convertArrayArguments((Map<String, ?>) call.argument("arrayArguments"));
+      arguments.putAll(arrayArguments);
+      String packageName = call.argument("package");
+      ComponentName componentName =
+          (!TextUtils.isEmpty(packageName)
+                  && !TextUtils.isEmpty((String) call.argument("componentName")))
+              ? new ComponentName(packageName, (String) call.argument("componentName"))
+              : null;
+      String type = call.argument("type");
 
-    Intent intent =
-        sender.buildIntent(
-            action, flags, category, data, arguments, packageName, componentName, type);
+      Intent intent =
+          sender.buildIntent(
+              action, flags, category, data, arguments, packageName, componentName, type);
 
-    if ("parseAndLaunch".equalsIgnoreCase(call.method)) {
-      try {
-        intent = sender.parse(call.argument("uri"));
+      if ("parseAndLaunch".equalsIgnoreCase(call.method)) {
+        try {
+          intent = sender.parse(call.argument("uri"));
+          sender.send(intent);
+          result.success(null);
+        } catch (URISyntaxException e) {
+          result.error("parse_error", "Failed to parse URI", e.getMessage());
+        }
+      } else if ("launch".equalsIgnoreCase(call.method)) {
+
+        if (intent != null && !sender.canResolveActivity(intent)) {
+          Log.i(TAG, "Cannot resolve explicit intent, falling back to implicit");
+          intent.setPackage(null);
+        }
+
         sender.send(intent);
         result.success(null);
-      } catch (URISyntaxException e) {
-        result.error("parse_error", "Failed to parse URI", e.getMessage());
+      } else if ("launchChooser".equalsIgnoreCase(call.method)) {
+        String title = call.argument("chooserTitle");
+
+        sender.launchChooser(intent, title);
+        result.success(null);
+      } else if ("sendService".equalsIgnoreCase(call.method)) {
+        sender.sendService(intent);
+        result.success(null);
+      } else if ("sendBroadcast".equalsIgnoreCase(call.method)) {
+        sender.sendBroadcast(intent);
+        result.success(null);
+      } else if ("canResolveActivity".equalsIgnoreCase(call.method)) {
+        result.success(sender.canResolveActivity(intent));
+      } else if ("getResolvedActivity".equalsIgnoreCase(call.method)) {
+        result.success(sender.getResolvedActivity(intent));
+      } else {
+        result.notImplemented();
       }
-    } else if ("launch".equalsIgnoreCase(call.method)) {
-
-      if (intent != null && !sender.canResolveActivity(intent)) {
-        Log.i(TAG, "Cannot resolve explicit intent, falling back to implicit");
-        intent.setPackage(null);
-      }
-
-      sender.send(intent);
-      result.success(null);
-    } else if ("launchChooser".equalsIgnoreCase(call.method)) {
-      String title = call.argument("chooserTitle");
-
-      sender.launchChooser(intent, title);
-      result.success(null);
-    } else if ("sendService".equalsIgnoreCase(call.method)) {
-      sender.sendService(intent);
-      result.success(null);
-    } else if ("sendBroadcast".equalsIgnoreCase(call.method)) {
-      sender.sendBroadcast(intent);
-      result.success(null);
-    } else if ("canResolveActivity".equalsIgnoreCase(call.method)) {
-      result.success(sender.canResolveActivity(intent));
-    } else if ("getResolvedActivity".equalsIgnoreCase(call.method)) {
-      result.success(sender.getResolvedActivity(intent));
-    } else {
-      result.notImplemented();
+    } catch (Throwable e) {
+      result.error("error", e.getMessage(), null);
     }
   }
 

--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/MethodCallHandlerImpl.java
@@ -114,6 +114,9 @@ public final class MethodCallHandlerImpl implements MethodCallHandler {
 
       sender.launchChooser(intent, title);
       result.success(null);
+    } else if ("sendService".equalsIgnoreCase(call.method)) {
+      sender.sendService(intent);
+      result.success(null);
     } else if ("sendBroadcast".equalsIgnoreCase(call.method)) {
       sender.sendBroadcast(intent);
       result.success(null);

--- a/packages/android_intent_plus/example/integration_test/android_intent_plus_test.dart
+++ b/packages/android_intent_plus/example/integration_test/android_intent_plus_test.dart
@@ -85,6 +85,13 @@ void main() {
     await intent.launchChooser('title');
   }, skip: !Platform.isAndroid);
 
+  testWidgets('sendService should not throw', (WidgetTester tester) async {
+    const intent = AndroidIntent(
+      action: 'com.example.service',
+    );
+    await intent.sendService();
+  }, skip: !Platform.isAndroid);
+
   testWidgets('SendBroadcast should not throw', (WidgetTester tester) async {
     const intent = AndroidIntent(
       action: 'com.example.broadcast',

--- a/packages/android_intent_plus/lib/android_intent.dart
+++ b/packages/android_intent_plus/lib/android_intent.dart
@@ -182,6 +182,20 @@ class AndroidIntent {
   /// Sends intent as broadcast.
   ///
   /// This works only on Android platforms.
+  Future<void> sendService() async {
+    if (!_platform.isAndroid) {
+      return;
+    }
+
+    await _channel.invokeMethod<void>(
+      'sendService',
+      _buildArguments(),
+    );
+  }
+
+  /// Sends intent as broadcast.
+  ///
+  /// This works only on Android platforms.
   Future<void> sendBroadcast() async {
     if (!_platform.isAndroid) {
       return;

--- a/packages/android_intent_plus/lib/android_intent.dart
+++ b/packages/android_intent_plus/lib/android_intent.dart
@@ -179,7 +179,7 @@ class AndroidIntent {
     );
   }
 
-  /// Sends intent as broadcast.
+  /// Starts intent as service.
   ///
   /// This works only on Android platforms.
   Future<void> sendService() async {

--- a/packages/android_intent_plus/test/android_intent_test.dart
+++ b/packages/android_intent_plus/test/android_intent_test.dart
@@ -236,6 +236,20 @@ void main() {
       });
     });
 
+    group('sendService', () {
+      test('send a broadcast', () async {
+        androidIntent = AndroidIntent.private(
+          action: 'com.example.service',
+          channel: mockChannel,
+          platform: FakePlatform(operatingSystem: 'android'),
+        );
+        await androidIntent.sendService();
+        verify(mockChannel.invokeMethod<void>('sendService', <String, Object>{
+          'action': 'com.example.service',
+        }));
+      });
+    });
+
     group('sendBroadcast', () {
       test('send a broadcast', () async {
         androidIntent = AndroidIntent.private(

--- a/packages/android_intent_plus/test/android_intent_test.dart
+++ b/packages/android_intent_plus/test/android_intent_test.dart
@@ -237,7 +237,7 @@ void main() {
     });
 
     group('sendService', () {
-      test('send a broadcast', () async {
+      test('start a service', () async {
         androidIntent = AndroidIntent.private(
           action: 'com.example.service',
           channel: mockChannel,


### PR DESCRIPTION
## Description
Currently, when sending an intent, any native errors occur silently without any notification to the flutter side of code.
This adds error forwarding back to flutter through the MethodCaller.

This can be tested by trying to send an intent to an Activity that doesn't exist.
Previous behaviour, it would show a native error in the log but this is not catchable in flutter code
New behaviour forwards the error and allows it to be caught
<!-- Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. -->

## Related Issues
No related issues exist for this
<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

