### PR TITLE
docs: Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,10 @@ To start working on a patch:
 2. `git checkout upstream/main -b <name_of_your_branch>`
 3. Hack away!
 
+> [!CAUTION]  
+> Do not create PRs directly from the `main` branch of your repository, as it causes problems when pushing changes by reviewers.
+> Always create a new branch for your pull requests.
+
 ### 5.2 Check the code
 
 Once you have made your changes, ensure that it passes the internal analyzer & formatting checks. The following


### PR DESCRIPTION
## Description

Request contributors to create PRs from branches instead of `main`, otherwise it will cause problems when pushing changes by PR reviewers.

