### PR TITLE
feat(device_info_plus): Add User Device Name in Android (PR #3437)

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
@@ -24,8 +24,9 @@ class DeviceInfoPlusPlugin : FlutterPlugin {
     private fun setupMethodChannel(messenger: BinaryMessenger, context: Context) {
         methodChannel = MethodChannel(messenger, "dev.fluttercommunity.plus/device_info")
         val packageManager: PackageManager = context.packageManager
-        val activityManager: ActivityManager = context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        val handler = MethodCallHandlerImpl(packageManager, activityManager)
+        val activityManager: ActivityManager =
+            context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+        val handler = MethodCallHandlerImpl(packageManager, activityManager, context)
         methodChannel.setMethodCallHandler(handler)
     }
 }

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/DeviceInfoPlusPlugin.kt
@@ -3,7 +3,6 @@ package dev.fluttercommunity.plus.device_info
 import android.app.ActivityManager
 import android.content.Context
 import android.content.pm.PackageManager
-import android.view.WindowManager
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodChannel
@@ -26,7 +25,8 @@ class DeviceInfoPlusPlugin : FlutterPlugin {
         val packageManager: PackageManager = context.packageManager
         val activityManager: ActivityManager =
             context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
-        val handler = MethodCallHandlerImpl(packageManager, activityManager, context)
+        val contentResolver = context.contentResolver
+        val handler = MethodCallHandlerImpl(packageManager, activityManager, contentResolver)
         methodChannel.setMethodCallHandler(handler)
     }
 }

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
@@ -1,6 +1,7 @@
 package dev.fluttercommunity.plus.device_info
 
 import android.app.ActivityManager
+import android.content.Context
 import android.content.pm.FeatureInfo
 import android.content.pm.PackageManager
 import android.os.Build
@@ -20,6 +21,7 @@ import android.provider.Settings
 internal class MethodCallHandlerImpl(
     private val packageManager: PackageManager,
     private val activityManager: ActivityManager,
+    private val context: Context,
 ) : MethodCallHandler {
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
@@ -38,7 +40,7 @@ internal class MethodCallHandlerImpl(
             build["manufacturer"] = Build.MANUFACTURER
             build["model"] = Build.MODEL
             build["product"] = Build.PRODUCT
-            build["name"] = Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME)
+            build["name"] = Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 build["supported32BitAbis"] = listOf(*Build.SUPPORTED_32_BIT_ABIS)

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
@@ -1,13 +1,10 @@
 package dev.fluttercommunity.plus.device_info
 
 import android.app.ActivityManager
-import android.content.Context
+import android.content.ContentResolver
 import android.content.pm.FeatureInfo
 import android.content.pm.PackageManager
 import android.os.Build
-import android.util.DisplayMetrics
-import android.view.Display
-import android.view.WindowManager
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -21,7 +18,7 @@ import android.provider.Settings
 internal class MethodCallHandlerImpl(
     private val packageManager: PackageManager,
     private val activityManager: ActivityManager,
-    private val context: Context,
+    private val contentResolver: ContentResolver,
 ) : MethodCallHandler {
 
     override fun onMethodCall(call: MethodCall, result: MethodChannel.Result) {
@@ -40,7 +37,10 @@ internal class MethodCallHandlerImpl(
             build["manufacturer"] = Build.MANUFACTURER
             build["model"] = Build.MODEL
             build["product"] = Build.PRODUCT
-            build["name"] = Settings.Global.getString(context.contentResolver, Settings.Global.DEVICE_NAME)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
+                build["name"] = Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME)
+            }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 build["supported32BitAbis"] = listOf(*Build.SUPPORTED_32_BIT_ABIS)

--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
@@ -11,6 +11,7 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import kotlin.collections.HashMap
+import android.provider.Settings
 
 /**
  * The implementation of [MethodChannel.MethodCallHandler] for the plugin. Responsible for
@@ -37,6 +38,7 @@ internal class MethodCallHandlerImpl(
             build["manufacturer"] = Build.MANUFACTURER
             build["model"] = Build.MODEL
             build["product"] = Build.PRODUCT
+            build["name"] = Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME)
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 build["supported32BitAbis"] = listOf(*Build.SUPPORTED_32_BIT_ABIS)

--- a/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
+++ b/packages/device_info_plus/device_info_plus/example/integration_test/device_info_plus_test.dart
@@ -99,6 +99,7 @@ void main() {
     expect(androidInfo.manufacturer, isNotNull);
     expect(androidInfo.model, isNotNull);
     expect(androidInfo.product, isNotNull);
+    expect(androidInfo.name, isNotNull);
 
     expect(androidInfo.supported32BitAbis, isNotNull);
     expect(androidInfo.supported64BitAbis, isNotNull);

--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -94,6 +94,7 @@ class _MyAppState extends State<MyApp> {
       'manufacturer': build.manufacturer,
       'model': build.model,
       'product': build.product,
+      'name': build.name,
       'supported32BitAbis': build.supported32BitAbis,
       'supported64BitAbis': build.supported64BitAbis,
       'supportedAbis': build.supportedAbis,

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -91,7 +91,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
   final String product;
 
   /// The name of the device.
-  /// https://developer.android.com/reference/android/os/Build#NAME
+  /// https://developer.android.com/reference/android/provider/Settings.Global#DEVICE_NAME
   final String name;
 
   /// An ordered list of 32 bit ABIs supported by this device.

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -23,6 +23,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
     required this.manufacturer,
     required this.model,
     required this.product,
+    required this.name,
     required List<String> supported32BitAbis,
     required List<String> supported64BitAbis,
     required List<String> supportedAbis,
@@ -88,6 +89,10 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
   /// The name of the overall product.
   /// https://developer.android.com/reference/android/os/Build#PRODUCT
   final String product;
+
+  /// The name of the device.
+  /// https://developer.android.com/reference/android/os/Build#NAME
+  final String name;
 
   /// An ordered list of 32 bit ABIs supported by this device.
   /// Available only on Android L (API 21) and newer
@@ -158,6 +163,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
       manufacturer: map['manufacturer'],
       model: map['model'],
       product: map['product'],
+      name: map['name'] ?? '',
       supported32BitAbis: _fromList(map['supported32BitAbis'] ?? <String>[]),
       supported64BitAbis: _fromList(map['supported64BitAbis'] ?? <String>[]),
       supportedAbis: _fromList(map['supportedAbis'] ?? []),

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
@@ -25,6 +25,7 @@ const _fakeAndroidDeviceInfo = <String, dynamic>{
   'brand': 'Google',
   'device': 'device',
   'product': 'product',
+  "name": "Custom Device Name",
   'display': 'display',
   'hardware': 'hardware',
   'isPhysicalDevice': true,

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
@@ -20,7 +20,7 @@ void main() {
       expect(androidDeviceInfo.brand, 'Google');
       expect(androidDeviceInfo.device, 'device');
       expect(androidDeviceInfo.product, 'product');
-      expect(androidDeviceInfo.product, "Custom Device Name");
+      expect(androidDeviceInfo.name, "Custom Device Name");
       expect(androidDeviceInfo.display, 'display');
       expect(androidDeviceInfo.hardware, 'hardware');
       expect(androidDeviceInfo.bootloader, 'bootloader');

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
@@ -20,6 +20,7 @@ void main() {
       expect(androidDeviceInfo.brand, 'Google');
       expect(androidDeviceInfo.device, 'device');
       expect(androidDeviceInfo.product, 'product');
+      expect(androidDeviceInfo.product, "Custom Device Name");
       expect(androidDeviceInfo.display, 'display');
       expect(androidDeviceInfo.hardware, 'hardware');
       expect(androidDeviceInfo.bootloader, 'bootloader');


### PR DESCRIPTION
## Description

This PR updates the functionality of the NAME property to now include and send the customer's device name. This enhancement ensures that the application can capture and utilize the user device name for better identification, personalization, and debugging. Prior to this change, the NAME property did not include device-specific details. This update significantly improves logging, user tracking, and system behavior analysis. 

## Related Issues

In the current package, the user is unable to obtain the Android user's custom device name

e.g.
- Fix #3437 
- Related #3437 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

