### PR TITLE
fix: Convert DateTime to string to resolve JSON serialization error

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -221,7 +221,7 @@ class PackageInfo {
       'version': version,
       if (buildSignature.isNotEmpty) 'buildSignature': buildSignature,
       if (installerStore?.isNotEmpty ?? false) 'installerStore': installerStore,
-      if (installTime != null) 'installTime': installTime
+      if (installTime != null) 'installTime': installTime.toString()
     };
   }
 


### PR DESCRIPTION
This commit addresses an issue where the `installTime` was not being properly serialized due to being a `DateTime` object. When attempting to convert the object to JSON, an error occurred as `DateTime` is not natively encodable. The `installTime` is now explicitly converted to a string before being included in the JSON, preventing the serialization failure.

## Description
This PR addresses an issue where the `installTime` (a `DateTime` object) was not being properly serialized into JSON, causing errors when trying to encode the object. The `installTime` is now explicitly converted to a string before it’s included in the JSON, ensuring compatibility with the encoding process. This change prevents the "Converting object to an encodable object failed" error and allows for correct JSON handling.

## Related Issues
- Fixes #3461

## Checklist
- [✅] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [✅] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [✅] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [✅] All existing and new tests are passing.
- [✅] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?

- [] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [✅] No, this is *not* a breaking change.