### PR TITLE
fix(package_info_plus): data serialization converts installTime to String instead of DateTime

### DIFF
--- a/packages/package_info_plus/package_info_plus/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/packages/package_info_plus/package_info_plus/example/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>11.0</string>
+  <string>12.0</string>
 </dict>
 </plist>

--- a/packages/package_info_plus/package_info_plus/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/packages/package_info_plus/package_info_plus/example/ios/Runner.xcodeproj/project.pbxproj
@@ -215,7 +215,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1300;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					331C8080294A63A400263BE5 = {

--- a/packages/package_info_plus/package_info_plus/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/package_info_plus/package_info_plus/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1300"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/packages/package_info_plus/package_info_plus/example/ios/Runner/AppDelegate.swift
+++ b/packages/package_info_plus/package_info_plus/example/ios/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import UIKit
 import Flutter
 
-@UIApplicationMain
+@main
 @objc class AppDelegate: FlutterAppDelegate {
   override func application(
     _ application: UIApplication,

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -221,7 +221,7 @@ class PackageInfo {
       'version': version,
       if (buildSignature.isNotEmpty) 'buildSignature': buildSignature,
       if (installerStore?.isNotEmpty ?? false) 'installerStore': installerStore,
-      if (installTime != null) 'installTime': installTime.toIso8601String()
+      if (installTime != null) 'installTime': (installTime?.toIso8601String() ?? "")
     };
   }
 

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -221,7 +221,7 @@ class PackageInfo {
       'version': version,
       if (buildSignature.isNotEmpty) 'buildSignature': buildSignature,
       if (installerStore?.isNotEmpty ?? false) 'installerStore': installerStore,
-      if (installTime != null) 'installTime': installTime
+      if (installTime != null) 'installTime': installTime.toString()
     };
   }
 

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -221,7 +221,7 @@ class PackageInfo {
       'version': version,
       if (buildSignature.isNotEmpty) 'buildSignature': buildSignature,
       if (installerStore?.isNotEmpty ?? false) 'installerStore': installerStore,
-      if (installTime != null) 'installTime': installTime.toString()
+      if (installTime != null) 'installTime': installTime.toIso8601String()
     };
   }
 

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -221,7 +221,8 @@ class PackageInfo {
       'version': version,
       if (buildSignature.isNotEmpty) 'buildSignature': buildSignature,
       if (installerStore?.isNotEmpty ?? false) 'installerStore': installerStore,
-      if (installTime != null) 'installTime': (installTime?.toIso8601String() ?? "")
+      if (installTime != null)
+        'installTime': (installTime?.toIso8601String() ?? "")
     };
   }
 

--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -221,8 +221,7 @@ class PackageInfo {
       'version': version,
       if (buildSignature.isNotEmpty) 'buildSignature': buildSignature,
       if (installerStore?.isNotEmpty ?? false) 'installerStore': installerStore,
-      if (installTime != null)
-        'installTime': (installTime?.toIso8601String() ?? "")
+      if (installTime != null) 'installTime': installTime!.toIso8601String(),
     };
   }
 

--- a/packages/package_info_plus/package_info_plus/test/package_info_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:package_info_plus/package_info_plus.dart';
@@ -177,6 +179,52 @@ void main() {
       'buildSignature': 'deadbeef',
       'installerStore': 'testflight',
       'installTime': nextWeek.toIso8601String(),
+    });
+  });
+
+  test('data supports null values', () async {
+    PackageInfo.setMockInitialValues(
+      appName: 'mock_package_info_example',
+      packageName: 'io.flutter.plugins.mockpackageinfoexample',
+      version: '1.1',
+      buildNumber: '2',
+      buildSignature: '',
+      installerStore: null,
+      installTime: null,
+    );
+    final info1 = await PackageInfo.fromPlatform();
+    expect(info1.data, {
+      'appName': 'mock_package_info_example',
+      'packageName': 'io.flutter.plugins.mockpackageinfoexample',
+      'version': '1.1',
+      'buildNumber': '2',
+    });
+  });
+
+  test('data can be converted to JSON and back', () async {
+    PackageInfo.setMockInitialValues(
+      appName: 'mock_package_info_example',
+      packageName: 'io.flutter.plugins.mockpackageinfoexample',
+      version: '1.1',
+      buildNumber: '2',
+      buildSignature: 'signature',
+      installerStore: 'store',
+      installTime: now,
+    );
+    final info1 = await PackageInfo.fromPlatform();
+
+    // Convert to Json and back to Map
+    final jsonData = jsonEncode(info1.data);
+    final parsedData = jsonDecode(jsonData);
+
+    expect(parsedData, {
+      'appName': 'mock_package_info_example',
+      'packageName': 'io.flutter.plugins.mockpackageinfoexample',
+      'version': '1.1',
+      'buildNumber': '2',
+      'buildSignature': 'signature',
+      'installerStore': 'store',
+      'installTime': now.toIso8601String(),
     });
   });
 }

--- a/packages/package_info_plus/package_info_plus/test/package_info_test.dart
+++ b/packages/package_info_plus/package_info_plus/test/package_info_test.dart
@@ -155,7 +155,7 @@ void main() {
       'packageName': 'io.flutter.plugins.mockpackageinfoexample',
       'version': '1.1',
       'buildNumber': '2',
-      'installTime': now,
+      'installTime': now.toIso8601String(),
     });
 
     final nextWeek = now.add(const Duration(days: 7));
@@ -176,7 +176,7 @@ void main() {
       'buildNumber': '2',
       'buildSignature': 'deadbeef',
       'installerStore': 'testflight',
-      'installTime': nextWeek,
+      'installTime': nextWeek.toIso8601String(),
     });
   });
 }


### PR DESCRIPTION
This commit addresses an issue where the `installTime` was not being properly serialized due to being a `DateTime` object. When attempting to convert the object to JSON, an error occurred as `DateTime` is not natively encodable. The `installTime` is now explicitly converted to a string before being included in the JSON, preventing the serialization failure.

## Description
This PR addresses an issue where the `installTime` (a `DateTime` object) was not being properly serialized into JSON, causing errors when trying to encode the object. The `installTime` is now explicitly converted to a string before it’s included in the JSON, ensuring compatibility with the encoding process. This change prevents the "Converting object to an encodable object failed" error and allows for correct JSON handling.

## Related Issues
- Fixes #3461

## Checklist
- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.