### PR TITLE
fix(device_info_plus): fix memory leak when calling DeviceInfoPlugin().macOsInfo

### DIFF
--- a/packages/device_info_plus/device_info_plus/macos/device_info_plus/Sources/device_info_plus/SystemUUID.swift
+++ b/packages/device_info_plus/device_info_plus/macos/device_info_plus/Sources/device_info_plus/SystemUUID.swift
@@ -1,23 +1,16 @@
 import Foundation
 
-public struct SystemUUID {
-    
+public enum SystemUUID {
     public static func getSystemUUID() -> String? {
-        let dev = IOServiceMatching("IOPlatformExpertDevice")
-        
-        var platformExpert: io_service_t
-        if #available(macOS 12, *) {
-            platformExpert = IOServiceGetMatchingService(kIOMainPortDefault, dev)
+        let mainPort: mach_port_t
+        if #available(macOS 12.0, *) {
+            mainPort = kIOMainPortDefault
         } else {
-            platformExpert = IOServiceGetMatchingService(kIOMasterPortDefault, dev)
+            mainPort = kIOMasterPortDefault
         }
-        
-        let serialNumberAsCFString = IORegistryEntryCreateCFProperty(platformExpert, kIOPlatformUUIDKey as CFString, kCFAllocatorDefault, 0)
-        IOObjectRelease(platformExpert)
-        let ser: CFTypeRef? = serialNumberAsCFString?.takeUnretainedValue()
-        if let result = ser as? String {
-            return result
-        }
-        return nil
+        let service = IOServiceGetMatchingService(mainPort, IOServiceMatching("IOPlatformExpertDevice"))
+        let uuid = IORegistryEntryCreateCFProperty(service, kIOPlatformUUIDKey as CFString, kCFAllocatorDefault, 0).takeRetainedValue() as? String
+        IOObjectRelease(service)
+        return uuid
     }
 }


### PR DESCRIPTION
## Description

Fix memory leak when call DeviceInfoPlugin().macOsInfo in macOS.

## Related Issues

[[Bug]: device_info_plus memory leak in macOS](https://github.com/fluttercommunity/plus_plugins/issues/3473)

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

