### PR TITLE
fix(alarm_manager_plus): removed import that broke build

### DIFF
--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -6,8 +6,8 @@ package dev.fluttercommunity.plus.androidalarmmanager;
 
 import android.content.Context;
 import android.util.Log;
-import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.FlutterEngine;
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;

--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AndroidAlarmManagerPlugin.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AndroidAlarmManagerPlugin.java
@@ -7,13 +7,13 @@ package dev.fluttercommunity.plus.androidalarmmanager;
 import android.content.Context;
 import android.util.Log;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.JSONMethodCodec;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.view.FlutterNativeView;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -28,8 +28,8 @@ import org.json.JSONObject;
  *   <li>The Dart side of this plugin sends the Android side a "AlarmService.start" message, along
  *       with a Dart callback handle for a Dart callback that should be immediately invoked by a
  *       background Dart isolate.
- *   <li>The Android side of this plugin spins up a background {@link FlutterNativeView}, which
- *       includes a background Dart isolate.
+ *   <li>The Android side of this plugin spins up a background {@link FlutterEngine} to run a
+ *       background Dart isolate.
  *   <li>The Android side of this plugin instructs the new background Dart isolate to execute the
  *       callback that was received in the "AlarmService.start" message.
  *   <li>The Dart side of this plugin, running within the new background isolate, executes the


### PR DESCRIPTION
## Description

Removes an import for the no longer existing `io.flutter.view.FlutterNativeView` class in Android.
This fixes build issues seen in Flutter starting with version `3.29.0`.

## Related Issues

Fix #3476 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [~] The analyzer (`flutter analyze`) does not report any problems on my PR.
    ^ It *does* find issues - but they are not related to my changes

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

