### PR TITLE
chore(deps): bump win32_registry from 1.1.5 to 2.0.1 in /packages/device_info_plus/device_info_plus

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
@@ -50,28 +50,25 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
     try {
       final currentVersionKey = Registry.openPath(RegistryHive.localMachine,
           path: r'SOFTWARE\Microsoft\Windows NT\CurrentVersion');
-      final buildLab = currentVersionKey.getValueAsString('BuildLab') ?? '';
-      final buildLabEx = currentVersionKey.getValueAsString('BuildLabEx') ?? '';
-      final digitalProductIdValue =
-          currentVersionKey.getValue('DigitalProductId');
-      final digitalProductId = digitalProductIdValue != null &&
-              digitalProductIdValue.data is Uint8List
-          ? digitalProductIdValue.data as Uint8List
-          : Uint8List.fromList([]);
+      final buildLab = currentVersionKey.getStringValue('BuildLab') ?? '';
+      final buildLabEx = currentVersionKey.getStringValue('BuildLabEx') ?? '';
+      final digitalProductId =
+          currentVersionKey.getBinaryValue('DigitalProductId') ??
+              Uint8List.fromList([]);
       final displayVersion =
-          currentVersionKey.getValueAsString('DisplayVersion') ?? '';
-      final editionId = currentVersionKey.getValueAsString('EditionID') ?? '';
+          currentVersionKey.getStringValue('DisplayVersion') ?? '';
+      final editionId = currentVersionKey.getStringValue('EditionID') ?? '';
       final installDate = DateTime.fromMillisecondsSinceEpoch(
-          1000 * (currentVersionKey.getValueAsInt('InstallDate') ?? 0));
-      final productId = currentVersionKey.getValueAsString('ProductID') ?? '';
-      var productName = currentVersionKey.getValueAsString('ProductName') ?? '';
+          1000 * (currentVersionKey.getIntValue('InstallDate') ?? 0));
+      final productId = currentVersionKey.getStringValue('ProductID') ?? '';
+      var productName = currentVersionKey.getStringValue('ProductName') ?? '';
       final registeredOwner =
-          currentVersionKey.getValueAsString('RegisteredOwner') ?? '';
-      final releaseId = currentVersionKey.getValueAsString('ReleaseId') ?? '';
+          currentVersionKey.getStringValue('RegisteredOwner') ?? '';
+      final releaseId = currentVersionKey.getStringValue('ReleaseId') ?? '';
 
       final sqmClientKey = Registry.openPath(RegistryHive.localMachine,
           path: r'SOFTWARE\Microsoft\SQMClient');
-      final machineId = sqmClientKey.getValueAsString('MachineId') ?? '';
+      final machineId = sqmClientKey.getStringValue('MachineId') ?? '';
 
       GetSystemInfo(systemInfo);
 
@@ -138,14 +135,13 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
     // We call this a first time to get the length of the string in characters,
     // so we can allocate sufficient memory.
     final nSize = calloc<DWORD>();
-    GetComputerNameEx(
-        COMPUTER_NAME_FORMAT.ComputerNameDnsFullyQualified, nullptr, nSize);
+    GetComputerNameEx(ComputerNameDnsFullyQualified, nullptr, nSize);
 
     // Now allocate memory for a native string and call this a second time.
     final lpBuffer = wsalloc(nSize.value);
     try {
-      final result = GetComputerNameEx(
-          COMPUTER_NAME_FORMAT.ComputerNameDnsFullyQualified, lpBuffer, nSize);
+      final result =
+          GetComputerNameEx(ComputerNameDnsFullyQualified, lpBuffer, nSize);
 
       if (result != 0) {
         return lpBuffer.toDartString();

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -39,7 +39,7 @@ dependencies:
   meta: ^1.8.0
   web: ^1.0.0
   win32: ^5.5.3
-  win32_registry: ^1.1.0
+  win32_registry: ^2.0.1
 
 dev_dependencies:
   flutter_lints: ">=4.0.0 <6.0.0"


### PR DESCRIPTION
## Description

Fixes windows code for https://github.com/fluttercommunity/plus_plugins/pull/3482

## Related Issues

n/a

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

