### PR TITLE
fix(device_info_plus): tighten dependency constraints

### DIFF
--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -30,23 +30,23 @@ flutter:
 
 dependencies:
   device_info_plus_platform_interface: ^7.0.2
-  ffi: ^2.0.1
-  file: ">=6.1.4 <8.0.0"
+  ffi: ^2.1.4
+  file: ^7.0.1
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  meta: ^1.8.0
-  web: ^1.0.0
-  win32: ^5.5.3
-  win32_registry: ^2.0.1
+  meta: ^1.16.0
+  web: ^1.1.0
+  win32: ^5.11.0
+  win32_registry: ^2.1.0
 
 dev_dependencies:
-  flutter_lints: ">=4.0.0 <6.0.0"
+  flutter_lints: ^5.0.0
   flutter_test:
     sdk: flutter
-  mockito: ^5.4.0
-  test: ^1.22.0
+  mockito: ^5.4.5
+  test: ^1.25.15
 
 environment:
   sdk: ">=3.4.0 <4.0.0"


### PR DESCRIPTION
## Description

Run `flutter pub upgrade --tighten` to avoid compilation issues with some dependency constraints.

## Related Issues

- fix #3496 


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

