### PR TITLE
docs: add a note about MissingPluginException after installing without a fresh restart

### DIFF
--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -45,6 +45,13 @@ Import the library.
 import 'package:share_plus/share_plus.dart';
 ```
 
+**Note**: If your app is already running/debugging, please perform a fresh restart it (kill the app and relaunch it).
+Since this plugin uses Platform code, if you just hot-restart or hot-reload after installing the package, you will encounter the following exception when triggering a share action: 
+
+```plaintext
+Unhandled Exception: MissingPluginException(No implementation found for method share on channel dev.fluttercommunity.plus/share)
+```
+
 ### Share Text
 
 Invoke the static `share()` method anywhere in your Dart code.


### PR DESCRIPTION
## Description

add a note about MissingPluginException after installing without a fresh restart. 
This exception has been reported in the issues several times, and I think it's because most of the devs add the package and don't fully restart the app to embed the platform code needed [see issues](https://github.com/fluttercommunity/plus_plugins/issues?q=is%3Aissue%20state%3Aclosed%20MissingPluginException)

Adding it to the documentation may save time for devs and prevent creating other related issues.

## Related Issues
[see issues](https://github.com/fluttercommunity/plus_plugins/issues?q=is%3Aissue%20state%3Aclosed%20MissingPluginException)


## Checklist

- [X] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.

