### PR TITLE
fix(device_info_plus): handle nullability on getString(DEVICE_NAME)

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
@@ -39,7 +39,7 @@ internal class MethodCallHandlerImpl(
             build["product"] = Build.PRODUCT
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N_MR1) {
-                build["name"] = Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME)
+                build["name"] = Settings.Global.getString(contentResolver, Settings.Global.DEVICE_NAME) ?: ""
             }
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {


### PR DESCRIPTION
## Description

`Settings.Global.getString()` can return null. And `Any` is not a subtype of nullable, so if `getString()` returns null the code will crash. Kotlin did not warn us about this.

https://developer.android.com/reference/android/provider/Settings.Global#getString(android.content.ContentResolver,%20java.lang.String)

## Related Issues

- Fix #3505 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

