### PR TITLE
Update device_info_plus_windows.dart

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
@@ -124,8 +124,7 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
       if (result != 0) {
         return memoryInKilobytes.value ~/ 1024;
       } else {
-        final error = GetLastError();
-        throw WindowsException(HRESULT_FROM_WIN32(error));
+        return 0;
       }
     } finally {
       free(memoryInKilobytes);


### PR DESCRIPTION
Refactor: Return 0 instead of throwing exception for memory retrieval error

- Updated `getSystemMemoryInMegabytes` to return 0 when `GetPhysicallyInstalledSystemMemory` fails.

## Description

<!-- Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. -->

## Related Issues

<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

