### PR TITLE
ci: run analyze on all plugins

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -106,3 +106,21 @@ jobs:
       - name: "Flutter Test - Web"
         run: melos run test:web --no-select
 
+  analyze:
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: flutter-actions/setup-flutter@v4
+
+      - name: "Install Tools"
+        run: ./.github/workflows/scripts/install-tools.sh
+
+      - name: "Bootstrap Workspace"
+        run: melos bootstrap
+
+      - name: "Flutter Analyze"
+        run: melos run analyze
+


### PR DESCRIPTION
## Description

This PR adds a CI jobs that runs the analyzer on all plugins. Similar to the CI job that runs tests. This job is not marked as mandatory (yet).

I will fix the individual projects one by one in separated PRs

## Related Issues

- None

## Checklist

- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

