### PR TITLE
chore(device_info_plus): fix analysis issues in plugin and tests

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
@@ -1,5 +1,5 @@
 /// The Windows implementation of `device_info_plus`.
-library device_info_plus_windows;
+library;
 
 import 'dart:ffi';
 import 'dart:typed_data';

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -176,7 +176,7 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
     );
   }
 
-  /// Deserializes message as List<String>
+  /// Deserializes message as `List<String>`
   static List<String> _fromList(List<dynamic> message) {
     final list = message.takeWhile((item) => item != null).toList();
     return List<String>.from(list);

--- a/packages/device_info_plus/device_info_plus/test/device_info_plus_linux_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/device_info_plus_linux_test.dart
@@ -1,5 +1,5 @@
 @TestOn('linux')
-library device_info_plus_linux_test;
+library;
 
 import 'package:device_info_plus/src/device_info_plus_linux.dart';
 import 'package:device_info_plus_platform_interface/device_info_plus_platform_interface.dart';

--- a/packages/device_info_plus/device_info_plus/test/device_info_plus_web_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/device_info_plus_web_test.dart
@@ -1,5 +1,5 @@
 @TestOn('browser')
-library device_info_plus_web_test;
+library;
 
 import 'package:device_info_plus/src/model/web_browser_info.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/device_info_plus/device_info_plus/test/device_info_plus_windows_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/device_info_plus_windows_test.dart
@@ -1,5 +1,5 @@
 @TestOn('windows')
-library device_info_plus_windows_test;
+library;
 
 import 'dart:typed_data';
 


### PR DESCRIPTION
## Description

Fixes analysis issues in plugins and tests

## Related Issues

- Related #3513 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

