### PR TITLE
fix(network_info_plus): fix deprecated member use in Windows implementation

### DIFF
--- a/packages/network_info_plus/network_info_plus/lib/src/network_info_plus_windows.dart
+++ b/packages/network_info_plus/network_info_plus/lib/src/network_info_plus_windows.dart
@@ -36,7 +36,7 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
         pdwNegotiatedVersion,
         phClientHandle,
       );
-      if (hr == WIN32_ERROR.ERROR_SERVICE_NOT_ACTIVE) return;
+      if (hr == ERROR_SERVICE_NOT_ACTIVE) return;
       clientHandle = phClientHandle.value;
     } finally {
       free(pdwNegotiatedVersion);
@@ -58,7 +58,7 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
 
     try {
       var hr = WlanEnumInterfaces(clientHandle, nullptr, ppInterfaceList);
-      if (hr != WIN32_ERROR.ERROR_SUCCESS) {
+      if (hr != ERROR_SUCCESS) {
         return null; // no wifi interface available
       }
 
@@ -81,7 +81,7 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
             ppAttributes.cast(),
             nullptr,
           );
-          if (hr != WIN32_ERROR.ERROR_SUCCESS) break;
+          if (hr != ERROR_SUCCESS) break;
           if (ppAttributes.value.ref.isState != 0) {
             return query(pInterfaceGuid, ppAttributes.value);
           }
@@ -107,19 +107,19 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
   String formatIPAddress(Pointer<SOCKADDR> addr) {
     final buffer = calloc<BYTE>(64).cast<Utf8>();
     try {
-      if (addr.ref.sa_family == ADDRESS_FAMILY.AF_INET) {
+      if (addr.ref.sa_family == AF_INET) {
         final sinAddr = addr.cast<SOCKADDR_IN>().ref.sin_addr;
         final sinAddrPtr = calloc<Int32>();
         sinAddrPtr.value = sinAddr;
-        inet_ntop(ADDRESS_FAMILY.AF_INET, sinAddrPtr, buffer, 64);
+        inet_ntop(AF_INET, sinAddrPtr, buffer, 64);
         free(sinAddrPtr);
-      } else if (addr.ref.sa_family == ADDRESS_FAMILY.AF_INET6) {
+      } else if (addr.ref.sa_family == AF_INET6) {
         final sinAddr = addr.cast<SOCKADDR_IN6>().ref.sin6_addr;
         final sinAddrPtr = calloc<Uint8>(16);
         for (var i = 0; i < 16; i++) {
           sinAddrPtr[i] = sinAddr[i];
         }
-        inet_ntop(ADDRESS_FAMILY.AF_INET6, sinAddrPtr, buffer, 64);
+        inet_ntop(AF_INET6, sinAddrPtr, buffer, 64);
         free(sinAddrPtr);
       }
       return buffer.cast<Utf8>().toDartString();
@@ -201,13 +201,13 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
   /// Obtains the IP v4 address of the connected wifi network
   @override
   Future<String?> getWifiIP() {
-    return getIPAddr(ADDRESS_FAMILY.AF_INET);
+    return getIPAddr(AF_INET);
   }
 
   /// Obtains the IP v6 address of the connected wifi network
   @override
   Future<String?> getWifiIPv6() {
-    return getIPAddr(ADDRESS_FAMILY.AF_INET6);
+    return getIPAddr(AF_INET6);
   }
 
   /// Obtains the subnet mask of the connected wifi network
@@ -218,7 +218,7 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
       Pointer<IP_ADAPTER_ADDRESSES_LH> pIpAdapterAddress = nullptr;
       try {
         GetAdaptersAddresses(
-          ADDRESS_FAMILY.AF_INET,
+          AF_INET,
           0,
           nullptr,
           nullptr,
@@ -226,7 +226,7 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
         );
         pIpAdapterAddress = HeapAlloc(GetProcessHeap(), 0, ulSize.value).cast();
         GetAdaptersAddresses(
-          ADDRESS_FAMILY.AF_INET,
+          AF_INET,
           0,
           nullptr,
           pIpAdapterAddress,
@@ -290,7 +290,7 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
       Pointer<IP_ADAPTER_ADDRESSES_LH> pIpAdapterAddress = nullptr;
       try {
         GetAdaptersAddresses(
-          ADDRESS_FAMILY.AF_INET,
+          AF_INET,
           0x80,
           nullptr,
           nullptr,
@@ -298,7 +298,7 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
         );
         pIpAdapterAddress = HeapAlloc(GetProcessHeap(), 0, ulSize.value).cast();
         GetAdaptersAddresses(
-          ADDRESS_FAMILY.AF_INET,
+          AF_INET,
           0x80,
           nullptr,
           pIpAdapterAddress,


### PR DESCRIPTION
## Description

Fixes analyzer warnings in the windows implementation

## Related Issues

- related #3513 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

