### PR TITLE
ConnectivityPlus: moved the register network callback code to backgruund to avoid possible ANRs

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
+++ b/packages/connectivity_plus/connectivity_plus/android/src/main/java/dev/fluttercommunity/plus/connectivity/ConnectivityBroadcastReceiver.java
@@ -14,6 +14,7 @@ import android.net.NetworkCapabilities;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.HandlerThread;
 import io.flutter.plugin.common.EventChannel;
 import java.util.List;
 
@@ -26,96 +27,107 @@ import java.util.List;
  * to set up the receiver.
  */
 public class ConnectivityBroadcastReceiver extends BroadcastReceiver
-    implements EventChannel.StreamHandler {
-  private final Context context;
-  private final Connectivity connectivity;
-  private EventChannel.EventSink events;
-  private final Handler mainHandler = new Handler(Looper.getMainLooper());
-  private ConnectivityManager.NetworkCallback networkCallback;
-  public static final String CONNECTIVITY_ACTION = "android.net.conn.CONNECTIVITY_CHANGE";
+        implements EventChannel.StreamHandler {
+    private final Context context;
+    private final Connectivity connectivity;
+    private EventChannel.EventSink events;
+    private final Handler mainHandler = new Handler(Looper.getMainLooper());
+    private ConnectivityManager.NetworkCallback networkCallback;
+    private HandlerThread backgroundThread;
+    private Handler backgroundHandler;
+    public static final String CONNECTIVITY_ACTION = "android.net.conn.CONNECTIVITY_CHANGE";
 
-  public ConnectivityBroadcastReceiver(Context context, Connectivity connectivity) {
-    this.context = context;
-    this.connectivity = connectivity;
-  }
+    public ConnectivityBroadcastReceiver(Context context, Connectivity connectivity) {
+        this.context = context;
+        this.connectivity = connectivity;
+        backgroundThread = new HandlerThread("ConnectivityBackground");
+        backgroundThread.start();
+        backgroundHandler = new Handler(backgroundThread.getLooper());
+    }
 
-  @Override
-  public void onListen(Object arguments, EventChannel.EventSink events) {
-    this.events = events;
-    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      networkCallback =
-          new ConnectivityManager.NetworkCallback() {
-            @Override
-            public void onAvailable(Network network) {
-              // onAvailable is called when the phone switches to a new network
-              // e.g. the phone was offline and gets wifi connection
-              // or the phone was on wifi and now switches to mobile.
-              // The plugin sends the current capability connection to the users.
-              sendEvent(connectivity.getCapabilitiesFromNetwork(network));
+    @Override
+    public void onListen(Object arguments, EventChannel.EventSink events) {
+        this.events = events;
+
+        // Post the network registration work to background thread
+        backgroundHandler.post(() -> {
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                networkCallback =
+                        new ConnectivityManager.NetworkCallback() {
+                            @Override
+                            public void onAvailable(Network network) {
+                                // onAvailable is called when the phone switches to a new network
+                                // e.g. the phone was offline and gets wifi connection
+                                // or the phone was on wifi and now switches to mobile.
+                                // The plugin sends the current capability connection to the users.
+                                sendEvent(connectivity.getCapabilitiesFromNetwork(network));
+                            }
+
+                            @Override
+                            public void onCapabilitiesChanged(
+                                    Network network, NetworkCapabilities networkCapabilities) {
+                                // This callback is called multiple times after a call to onAvailable
+                                // this also causes multiple callbacks to the Flutter layer.
+                                sendEvent(connectivity.getCapabilitiesList(networkCapabilities));
+                            }
+
+                            @Override
+                            public void onLost(Network network) {
+                                // This callback is called when a capability is lost.
+                                //
+                                // The provided Network object contains information about the
+                                // network capability that has been lost, so we cannot use it.
+                                //
+                                // Instead, post the current network but with a delay long enough
+                                // that we avoid a race condition.
+                                sendCurrentStatusWithDelay();
+                            }
+                        };
+                connectivity.getConnectivityManager().registerDefaultNetworkCallback(networkCallback);
+            } else {
+                context.registerReceiver(this, new IntentFilter(CONNECTIVITY_ACTION));
             }
 
-            @Override
-            public void onCapabilitiesChanged(
-                Network network, NetworkCapabilities networkCapabilities) {
-              // This callback is called multiple times after a call to onAvailable
-              // this also causes multiple callbacks to the Flutter layer.
-              sendEvent(connectivity.getCapabilitiesList(networkCapabilities));
+            // Send initial event on main thread
+            mainHandler.post(() -> sendEvent(connectivity.getNetworkTypes()));
+        });
+    }
+
+    @Override
+    public void onCancel(Object arguments) {
+        backgroundHandler.post(() -> {
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                if (networkCallback != null) {
+                    connectivity.getConnectivityManager().unregisterNetworkCallback(networkCallback);
+                    networkCallback = null;
+                }
+            } else {
+                try {
+                    context.unregisterReceiver(this);
+                } catch (Exception e) {
+                    // listen never called, ignore the error
+                }
             }
-
-            @Override
-            public void onLost(Network network) {
-              // This callback is called when a capability is lost.
-              //
-              // The provided Network object contains information about the
-              // network capability that has been lost, so we cannot use it.
-              //
-              // Instead, post the current network but with a delay long enough
-              // that we avoid a race condition.
-              sendCurrentStatusWithDelay();
-            }
-          };
-      connectivity.getConnectivityManager().registerDefaultNetworkCallback(networkCallback);
-    } else {
-      context.registerReceiver(this, new IntentFilter(CONNECTIVITY_ACTION));
+        });
     }
-    // Need to emit first event with connectivity types without waiting for first change in system
-    // that might happen much later
-    sendEvent(connectivity.getNetworkTypes());
-  }
 
-  @Override
-  public void onCancel(Object arguments) {
-    if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-      if (networkCallback != null) {
-        connectivity.getConnectivityManager().unregisterNetworkCallback(networkCallback);
-        networkCallback = null;
-      }
-    } else {
-      try {
-        context.unregisterReceiver(this);
-      } catch (Exception e) {
-        // listen never called, ignore the error
-      }
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        if (events != null) {
+            events.success(connectivity.getNetworkTypes());
+        }
     }
-  }
 
-  @Override
-  public void onReceive(Context context, Intent intent) {
-    if (events != null) {
-      events.success(connectivity.getNetworkTypes());
+    private void sendEvent(List<String> networkTypes) {
+        Runnable runnable = () -> events.success(networkTypes);
+        // Emit events on main thread
+        mainHandler.post(runnable);
     }
-  }
 
-  private void sendEvent(List<String> networkTypes) {
-    Runnable runnable = () -> events.success(networkTypes);
-    // Emit events on main thread
-    mainHandler.post(runnable);
-  }
-
-  private void sendCurrentStatusWithDelay() {
-    Runnable runnable = () -> events.success(connectivity.getNetworkTypes());
-    // Emit events on main thread
-    // 500 milliseconds to avoid race conditions
-    mainHandler.postDelayed(runnable, 500);
-  }
+    private void sendCurrentStatusWithDelay() {
+        Runnable runnable = () -> events.success(connectivity.getNetworkTypes());
+        // Emit events on main thread
+        // 500 milliseconds to avoid race conditions
+        mainHandler.postDelayed(runnable, 500);
+    }
 }


### PR DESCRIPTION
## Description

<!-- Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. -->

## Related Issues

moved the register network callback code to backgruund to avoid possible ANRs