### PR TITLE
chore(network_info_plus): Fix imports on wasm

### DIFF
--- a/packages/network_info_plus/network_info_plus/lib/network_info_plus.dart
+++ b/packages/network_info_plus/network_info_plus/lib/network_info_plus.dart
@@ -12,7 +12,7 @@ export 'package:network_info_plus_platform_interface/network_info_plus_platform_
 
 export 'src/network_info_plus_linux.dart';
 export 'src/network_info_plus_windows.dart'
-    if (dart.library.html) 'src/network_info_plus_web.dart';
+    if (dart.library.js_interop) 'src/network_info_plus_web.dart';
 
 /// Discover network info: check WI-FI details and more.
 class NetworkInfo {


### PR DESCRIPTION
## Description

<!-- Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. -->
dart.library.html isn't supported when exporting with flutter build web --wasm and result in an compilation error

## Related Issues

<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

