### PR TITLE
fix(android_intent_plus): startForegroundService on SDK higher than 26 

### DIFF
--- a/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
+++ b/packages/android_intent_plus/android/src/main/java/dev/fluttercommunity/plus/androidintent/IntentSender.java
@@ -14,6 +14,7 @@ import androidx.annotation.Nullable;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import android.os.Build;
 
 /** Forms and launches intents. */
 public final class IntentSender {
@@ -72,10 +73,9 @@ public final class IntentSender {
 
     Log.v(TAG, "Sending service intent " + intent);
 
-    if (activity != null) {
-      activity.startService(intent);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      applicationContext.startForegroundService(intent);
     } else {
-      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       applicationContext.startService(intent);
     }
   }


### PR DESCRIPTION
## Description
Currently, when starting a foreground service or a non-foreground service while the application is in the background, the application fails with 

`not allowed to start service intent app is in background`

This can be tested by trying to start a service where the application isn't in the foreground

- Previous behaviour, it would give the error above
- New behaviour sends the intent as expected and starts the service

<!-- Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. -->

## Related Issues
No related issues exist for this
<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

