### PR TITLE
feat(device_info_plus): add ram information

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
+++ b/packages/device_info_plus/device_info_plus/android/src/main/kotlin/dev/fluttercommunity/plus/device_info/MethodCallHandlerImpl.kt
@@ -5,11 +5,10 @@ import android.content.ContentResolver
 import android.content.pm.FeatureInfo
 import android.content.pm.PackageManager
 import android.os.Build
+import android.provider.Settings
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
-import kotlin.collections.HashMap
-import android.provider.Settings
 
 /**
  * The implementation of [MethodChannel.MethodCallHandler] for the plugin. Responsible for
@@ -68,7 +67,13 @@ internal class MethodCallHandlerImpl(
             version["release"] = Build.VERSION.RELEASE
             version["sdkInt"] = Build.VERSION.SDK_INT
             build["version"] = version
-            build["isLowRamDevice"] = activityManager.isLowRamDevice
+
+            val memoryInfo: ActivityManager.MemoryInfo = ActivityManager.MemoryInfo()
+            activityManager.getMemoryInfo(memoryInfo)
+            build["isLowRamDevice"] = memoryInfo.lowMemory
+            build["physicalRamSize"] = memoryInfo.totalMem / 1048576L // Mb
+            build["availableRamSize"] = memoryInfo.availMem / 1048576L // Mb
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
                 build["serialNumber"] = try {
                     Build.getSerial()

--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -120,6 +120,8 @@ class _MyAppState extends State<MyApp> {
       'identifierForVendor': data.identifierForVendor,
       'isPhysicalDevice': data.isPhysicalDevice,
       'isiOSAppOnMac': data.isiOSAppOnMac,
+      'physicalRamSize': data.physicalRamSize,
+      'availableRamSize': data.availableRamSize,
       'utsname.sysname:': data.utsname.sysname,
       'utsname.nodename:': data.utsname.nodename,
       'utsname.release:': data.utsname.release,

--- a/packages/device_info_plus/device_info_plus/example/lib/main.dart
+++ b/packages/device_info_plus/device_info_plus/example/lib/main.dart
@@ -104,6 +104,8 @@ class _MyAppState extends State<MyApp> {
       'systemFeatures': build.systemFeatures,
       'serialNumber': build.serialNumber,
       'isLowRamDevice': build.isLowRamDevice,
+      'physicalRamSize': build.physicalRamSize,
+      'availableRamSize': build.availableRamSize,
     };
   }
 

--- a/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/FPPDeviceInfoPlusPlugin.m
+++ b/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/FPPDeviceInfoPlusPlugin.m
@@ -4,6 +4,7 @@
 
 #import "./include/device_info_plus/FPPDeviceInfoPlusPlugin.h"
 #import "./include/device_info_plus/DeviceIdentifiers.h"
+#import <mach/mach.h>
 #import <sys/utsname.h>
 
 @implementation FPPDeviceInfoPlusPlugin
@@ -38,6 +39,9 @@
     }
     deviceName = [DeviceIdentifiers userKnownDeviceModel:machine];
 
+    NSNumber *physicalRamSize = @([NSProcessInfo processInfo].physicalMemory / 1048576); // Mb
+    NSNumber *availableRamSize = @([self availableMemoryInbMB]);
+
     result(@{
       @"name" : [device name],
       @"systemName" : [device systemName],
@@ -49,6 +53,8 @@
           ?: [NSNull null],
       @"isPhysicalDevice" : isPhysicalNumber,
       @"isiOSAppOnMac" : isiOSAppOnMac,
+      @"physicalRamSize": physicalRamSize,
+      @"availableRamSize": availableRamSize,
       @"utsname" : @{
         @"sysname" : @(un.sysname),
         @"nodename" : @(un.nodename),
@@ -62,7 +68,25 @@
   }
 }
 
-// return value is false if code is run on a simulator
+// Return available memory in megabytes
+- (int)availableMemoryInbMB {
+    mach_port_t host_port = mach_host_self();
+    mach_msg_type_number_t host_size = sizeof(vm_statistics_data_t) / sizeof(integer_t);
+
+    vm_size_t page_size;
+    host_page_size(host_port, &page_size);
+
+    vm_statistics_data_t vm_stat;
+    if (host_statistics(host_port, HOST_VM_INFO, (host_info_t)&vm_stat, &host_size) != KERN_SUCCESS) {
+        // Failed to fetch vm statistics
+        return -1;
+    }
+
+    natural_t mem_free = vm_stat.free_count * page_size;
+    return mem_free / 1048576;
+}
+
+// Return value is false if code is run on a simulator
 - (BOOL)isDevicePhysical {
   BOOL isPhysicalDevice = NO;
 #if TARGET_OS_SIMULATOR

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -34,6 +34,8 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
     required List<String> systemFeatures,
     required this.serialNumber,
     required this.isLowRamDevice,
+    required this.physicalRamSize,
+    required this.availableRamSize,
   })  : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
         supported64BitAbis = List<String>.unmodifiable(supported64BitAbis),
         supportedAbis = List<String>.unmodifiable(supportedAbis),
@@ -146,6 +148,16 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
   /// `true` if the application is running on a low-RAM device, `false` otherwise.
   final bool isLowRamDevice;
 
+  /// Total physical RAM size of the device in megabytes
+  ///
+  /// https://developer.android.com/reference/android/app/ActivityManager.MemoryInfo#totalMem
+  final int physicalRamSize;
+
+  /// Current unallocated RAM size of the device in megabytes
+  ///
+  /// https://developer.android.com/reference/android/app/ActivityManager.MemoryInfo#availMem
+  final int availableRamSize;
+
   /// Deserializes from the message received from [_kChannel].
   static AndroidDeviceInfo fromMap(Map<String, dynamic> map) {
     return AndroidDeviceInfo._(
@@ -174,6 +186,8 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
       systemFeatures: _fromList(map['systemFeatures'] ?? []),
       serialNumber: map['serialNumber'],
       isLowRamDevice: map['isLowRamDevice'],
+      physicalRamSize: map['physicalRamSize'],
+      availableRamSize: map['availableRamSize'],
     );
   }
 
@@ -203,6 +217,8 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
     required List<String> systemFeatures,
     required String serialNumber,
     required bool isLowRamDevice,
+    required int physicalRamSize,
+    required int availableRamSize,
   }) {
     final Map<String, dynamic> data = {
       'version': {
@@ -236,6 +252,8 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
       'systemFeatures': systemFeatures,
       'serialNumber': serialNumber,
       'isLowRamDevice': isLowRamDevice,
+      'physicalRamSize': physicalRamSize,
+      'availableRamSize': availableRamSize,
     };
 
     return AndroidDeviceInfo._(
@@ -263,6 +281,8 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
       systemFeatures: _fromList(systemFeatures),
       serialNumber: serialNumber,
       isLowRamDevice: isLowRamDevice,
+      physicalRamSize: physicalRamSize,
+      availableRamSize: availableRamSize,
     );
   }
 

--- a/packages/device_info_plus/device_info_plus/lib/src/model/ios_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/ios_device_info.dart
@@ -20,6 +20,8 @@ class IosDeviceInfo extends BaseDeviceInfo {
     required this.localizedModel,
     this.identifierForVendor,
     required this.isPhysicalDevice,
+    required this.physicalRamSize,
+    required this.availableRamSize,
     required this.isiOSAppOnMac,
     required this.utsname,
   }) : super(data);
@@ -59,6 +61,12 @@ class IosDeviceInfo extends BaseDeviceInfo {
   /// `false` if the application is running in a simulator, `true` otherwise.
   final bool isPhysicalDevice;
 
+  /// Total physical RAM size of the device in megabytes
+  final int physicalRamSize;
+
+  /// Current unallocated RAM size of the device in megabytes
+  final int availableRamSize;
+
   /// that indicates whether the process is an iPhone or iPad app running on a Mac.
   /// https://developer.apple.com/documentation/foundation/nsprocessinfo/3608556-iosapponmac
   final bool isiOSAppOnMac;
@@ -78,6 +86,8 @@ class IosDeviceInfo extends BaseDeviceInfo {
       localizedModel: map['localizedModel'],
       identifierForVendor: map['identifierForVendor'],
       isPhysicalDevice: map['isPhysicalDevice'],
+      physicalRamSize: map['physicalRamSize'],
+      availableRamSize: map['availableRamSize'],
       isiOSAppOnMac: map['isiOSAppOnMac'],
       utsname:
           IosUtsname._fromMap(map['utsname']?.cast<String, dynamic>() ?? {}),
@@ -96,6 +106,8 @@ class IosDeviceInfo extends BaseDeviceInfo {
     String? identifierForVendor,
     required bool isPhysicalDevice,
     required bool isiOSAppOnMac,
+    required int physicalRamSize,
+    required int availableRamSize,
     required IosUtsname utsname,
   }) {
     final Map<String, dynamic> data = {
@@ -108,6 +120,8 @@ class IosDeviceInfo extends BaseDeviceInfo {
       'identifierForVendor': identifierForVendor,
       'isPhysicalDevice': isPhysicalDevice,
       'isiOSAppOnMac': isiOSAppOnMac,
+      'physicalRamSize': physicalRamSize,
+      'availableRamSize': availableRamSize,
       'utsname': {
         'sysname': utsname.sysname,
         'nodename': utsname.nodename,
@@ -127,6 +141,8 @@ class IosDeviceInfo extends BaseDeviceInfo {
       identifierForVendor: identifierForVendor,
       isPhysicalDevice: isPhysicalDevice,
       isiOSAppOnMac: isiOSAppOnMac,
+      physicalRamSize: physicalRamSize,
+      availableRamSize: availableRamSize,
       utsname: utsname,
     );
   }

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_fake.dart
@@ -39,4 +39,6 @@ const _fakeAndroidDeviceInfo = <String, dynamic>{
   'supported32BitAbis': _fakeSupported32BitAbis,
   'serialNumber': 'SERIAL',
   'isLowRamDevice': false,
+  'physicalRamSize': 8192,
+  'availableRamSize': 4096,
 };

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
@@ -40,6 +40,8 @@ void main() {
       expect(androidDeviceInfo.version.securityPatch, 'securityPatch');
       expect(androidDeviceInfo.serialNumber, 'SERIAL');
       expect(androidDeviceInfo.isLowRamDevice, false);
+      expect(androidDeviceInfo.physicalRamSize, 8192);
+      expect(androidDeviceInfo.availableRamSize, 4096);
     });
 
     test('toMap should return map with correct key and map', () {

--- a/packages/device_info_plus/device_info_plus/test/model/ios_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/ios_device_info_test.dart
@@ -22,6 +22,8 @@ void main() {
         'systemName': 'systemName',
         'isPhysicalDevice': true,
         'isiOSAppOnMac': true,
+        'physicalRamSize': 8192,
+        'availableRamSize': 4096,
         'systemVersion': 'systemVersion',
         'localizedModel': 'localizedModel',
         'identifierForVendor': 'identifierForVendor',
@@ -36,6 +38,8 @@ void main() {
       expect(iosDeviceInfo.modelName, 'modelName');
       expect(iosDeviceInfo.isPhysicalDevice, isTrue);
       expect(iosDeviceInfo.isiOSAppOnMac, isTrue);
+      expect(iosDeviceInfo.physicalRamSize, 8192);
+      expect(iosDeviceInfo.availableRamSize, 4096);
       expect(iosDeviceInfo.systemName, 'systemName');
       expect(iosDeviceInfo.systemVersion, 'systemVersion');
       expect(iosDeviceInfo.localizedModel, 'localizedModel');


### PR DESCRIPTION
## Description

I added RAM information for both Android and iOS because I need it in my own application and thought it would fit the best here

## Related Issues

None

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

No

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

