### PR TITLE
fix: fix-xiaomi-battery-safe-mode

### DIFF
--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -123,21 +123,22 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
     private fun isInPowerSaveMode(): Boolean? {
         val deviceManufacturer = Build.MANUFACTURER.lowercase(Locale.getDefault())
 
-        return if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
-            when (deviceManufacturer) {
-                "xiaomi" -> isXiaomiPowerSaveModeActive()
-                "huawei" -> isHuaweiPowerSaveModeActive()
-                "samsung" -> isSamsungPowerSaveModeActive()
-                else -> checkPowerServiceSaveMode()
-            }
-        } else {
-            null
+        if (VERSION.SDK_INT < VERSION_CODES.LOLLIPOP) {
+            return null
+        }
+
+        return when (deviceManufacturer) {
+            "xiaomi" -> isXiaomiPowerSaveModeActive()
+            "huawei" -> isHuaweiPowerSaveModeActive()
+            "samsung" -> isSamsungPowerSaveModeActive()
+            else -> checkPowerServiceSaveMode()
         }
     }
 
+    @RequiresApi(VERSION_CODES.LOLLIPOP)
     private fun isSamsungPowerSaveModeActive(): Boolean {
         val mode = Settings.System.getString(applicationContext!!.contentResolver, POWER_SAVE_MODE_SAMSUNG_NAME)
-        return if (mode == null && VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+        return if (mode == null) {
             checkPowerServiceSaveMode()
         } else {
             mode == POWER_SAVE_MODE_SAMSUNG_VALUE
@@ -156,12 +157,13 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
         }
     }
 
-    private fun isXiaomiPowerSaveModeActive(): Boolean? {
+    @RequiresApi(VERSION_CODES.LOLLIPOP)
+    private fun isXiaomiPowerSaveModeActive(): Boolean {
         val mode = Settings.System.getInt(applicationContext!!.contentResolver, POWER_SAVE_MODE_XIAOMI_NAME, -1)
         return if (mode != -1) {
             mode == POWER_SAVE_MODE_XIAOMI_VALUE
         } else {
-            null
+            checkPowerServiceSaveMode()
         }
     }
 

--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -20,7 +20,6 @@ import android.os.Build
 import java.util.Locale
 import android.os.PowerManager
 import android.provider.Settings
-import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.content.ContextCompat
 import androidx.core.content.ContextCompat.RECEIVER_NOT_EXPORTED

--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -173,9 +173,6 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
 
     @RequiresApi(VERSION_CODES.LOLLIPOP)
     private fun isXiaomiPowerSaveModeActive(): Boolean {
-        val allSettings = dumpSystemSettings(applicationContext!!)
-        Log.e("JB", allSettings.toString())
-        Log.e("JB", "------------")
         val mode = Settings.System.getInt(
             applicationContext!!.contentResolver,
             POWER_SAVE_MODE_XIAOMI_NAME,
@@ -186,30 +183,6 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
         } else {
             checkPowerServiceSaveMode()
         }
-    }
-
-    private fun dumpSystemSettings(context: Context): Map<String, String> {
-        val settingsMap = mutableMapOf<String, String>()
-
-        try {
-            val contentResolver = context.contentResolver
-            val uri = Settings.System.CONTENT_URI
-
-            contentResolver.query(uri, null, null, null, null)?.use { cursor ->
-                val nameIndex = cursor.getColumnIndex("name")
-                val valueIndex = cursor.getColumnIndex("value")
-
-                while (cursor.moveToNext()) {
-                    val name = cursor.getString(nameIndex)
-                    val value = cursor.getString(valueIndex)
-                    settingsMap[name] = value
-                }
-            }
-        } catch (e: Exception) {
-            e.printStackTrace()
-        }
-
-        return settingsMap
     }
 
     @RequiresApi(api = VERSION_CODES.LOLLIPOP)

--- a/packages/battery_plus/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/example/pubspec.yaml
@@ -8,10 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  battery_plus_platform_interface:
-    path: ../../battery_plus_platform_interface
-  battery_plus:
-    path: ../
+  battery_plus: ^6.2.1
 
 dev_dependencies:
   flutter_driver:
@@ -21,12 +18,6 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   flutter_lints: ">=4.0.0 <6.0.0"
-
-dependency_overrides:
-  battery_plus_platform_interface:
-    path: ../../battery_plus_platform_interface
-  battery_plus:
-    path: ../
 
 flutter:
   uses-material-design: true

--- a/packages/battery_plus/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/example/pubspec.yaml
@@ -8,7 +8,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  battery_plus: ^6.2.1
+  battery_plus_platform_interface:
+    path: ../../battery_plus_platform_interface
+  battery_plus:
+    path: ../
 
 dev_dependencies:
   flutter_driver:
@@ -18,6 +21,12 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   flutter_lints: ">=4.0.0 <6.0.0"
+
+dependency_overrides:
+  battery_plus_platform_interface:
+    path: ../../battery_plus_platform_interface
+  battery_plus:
+    path: ../
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Description

This PR fixes a bug where the battery safe mode or power safe mode was not correctly fetched on Xiaomi devices. I added a comment in the PR at the important code that resolved the issue.

## Related Issues

This resolves #3540 


## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

