### PR TITLE
fix(battery_plus): Improve battery save mode check on Xiaomi devices

### DIFF
--- a/packages/battery_plus/battery_plus/android/build.gradle
+++ b/packages/battery_plus/battery_plus/android/build.gradle
@@ -38,7 +38,7 @@ android {
     }
 
     defaultConfig {
-        minSdk 19
+        minSdk 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Description

Replacement for #3537 as there were no reply and no access to allow editing by maintainers. Additionally, I have bumped the min Android version, because with having min Flutter version allowed as 3.22.0 in the [pubspec](https://github.com/fluttercommunity/plus_plugins/blob/main/packages/battery_plus/battery_plus/pubspec.yaml#L49) we have Android 5 (API 21) and newer only supported anyway as mentioned in this article: https://medium.com/flutter/whats-new-in-flutter-3-22-fbde6c164fe3

Note, I don't have recent Xiaomi devices to validate the fix, so can't guarantee the result. However, the change seems similar to other manufacturers battery save mode check.

## Related Issues

Closes #3540 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

