### PR TITLE
feat(device_info_plus): Add identifier for iPhone 16e

### DIFF
--- a/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/DeviceIdentifiers.m
+++ b/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/DeviceIdentifiers.m
@@ -95,7 +95,9 @@
     return @"iPhone 16 Pro";
   } else if ([identifier isEqualToString:@"iPhone17,2"]) {
     return @"iPhone 16 Pro Max";
-    // iPads
+  } else if ([identifier isEqualToString:@"iPhone17,5"]) {
+    return @"iPhone 16e";
+      // iPads
   } else if ([identifier isEqualToString:@"iPad4,1"] ||
              [identifier isEqualToString:@"iPad4,2"] ||
              [identifier isEqualToString:@"iPad4,3"]) {


### PR DESCRIPTION
## Description

Add missing identifier to show model name correctly

## Related Issues

Closes #3563

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

