### PR TITLE
fix(device_info_plus): Specify correct Dart and Flutter version requirements

### DIFF
--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -16,8 +16,8 @@ Get current device information from within the Flutter application.
 
 ## Requirements
 
-- Flutter >=3.22.0
-- Dart >=3.4.0 <4.0.0
+- Flutter >=3.29.0
+- Dart >=3.6.0 <4.0.0
 - iOS >=12.0
 - MacOS >=10.14
 - Android `compileSDK` 34

--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -17,7 +17,7 @@ Get current device information from within the Flutter application.
 ## Requirements
 
 - Flutter >=3.29.0
-- Dart >=3.6.0 <4.0.0
+- Dart >=3.7.0 <4.0.0
 - iOS >=12.0
 - MacOS >=10.14
 - Android `compileSDK` 34

--- a/packages/device_info_plus/device_info_plus/lib/device_info_plus.dart
+++ b/packages/device_info_plus/device_info_plus/lib/device_info_plus.dart
@@ -50,8 +50,9 @@ class DeviceInfoPlugin {
   ///
   /// See: https://developer.android.com/reference/android/os/Build.html
   Future<AndroidDeviceInfo> get androidInfo async =>
-      _cachedAndroidDeviceInfo ??=
-          AndroidDeviceInfo.fromMap((await _platform.deviceInfo()).data);
+      _cachedAndroidDeviceInfo ??= AndroidDeviceInfo.fromMap(
+        (await _platform.deviceInfo()).data,
+      );
 
   /// This information does not change from call to call. Cache it.
   IosDeviceInfo? _cachedIosDeviceInfo;
@@ -59,8 +60,10 @@ class DeviceInfoPlugin {
   /// Information derived from `UIDevice`.
   ///
   /// See: https://developer.apple.com/documentation/uikit/uidevice
-  Future<IosDeviceInfo> get iosInfo async => _cachedIosDeviceInfo ??=
-      IosDeviceInfo.fromMap((await _platform.deviceInfo()).data);
+  Future<IosDeviceInfo> get iosInfo async =>
+      _cachedIosDeviceInfo ??= IosDeviceInfo.fromMap(
+        (await _platform.deviceInfo()).data,
+      );
 
   /// This information does not change from call to call. Cache it.
   LinuxDeviceInfo? _cachedLinuxDeviceInfo;
@@ -68,8 +71,9 @@ class DeviceInfoPlugin {
   /// Information derived from `/etc/os-release`.
   ///
   /// See: https://www.freedesktop.org/software/systemd/man/os-release.html
-  Future<LinuxDeviceInfo> get linuxInfo async => _cachedLinuxDeviceInfo ??=
-      await _platform.deviceInfo() as LinuxDeviceInfo;
+  Future<LinuxDeviceInfo> get linuxInfo async =>
+      _cachedLinuxDeviceInfo ??=
+          await _platform.deviceInfo() as LinuxDeviceInfo;
 
   /// This information does not change from call to call. Cache it.
   WebBrowserInfo? _cachedWebBrowserInfo;
@@ -82,8 +86,10 @@ class DeviceInfoPlugin {
   MacOsDeviceInfo? _cachedMacosDeviceInfo;
 
   /// Returns device information for macos. Information sourced from Sysctl.
-  Future<MacOsDeviceInfo> get macOsInfo async => _cachedMacosDeviceInfo ??=
-      MacOsDeviceInfo.fromMap((await _platform.deviceInfo()).data);
+  Future<MacOsDeviceInfo> get macOsInfo async =>
+      _cachedMacosDeviceInfo ??= MacOsDeviceInfo.fromMap(
+        (await _platform.deviceInfo()).data,
+      );
 
   WindowsDeviceInfo? _cachedWindowsDeviceInfo;
 

--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_linux.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_linux.dart
@@ -18,7 +18,7 @@ class DeviceInfoPlusLinuxPlugin extends DeviceInfoPlatform {
 
   ///
   DeviceInfoPlusLinuxPlugin({@visibleForTesting FileSystem? fileSystem})
-      : _fileSystem = fileSystem ?? const LocalFileSystem();
+    : _fileSystem = fileSystem ?? const LocalFileSystem();
 
   @override
   Future<BaseDeviceInfo> deviceInfo() async {
@@ -50,8 +50,9 @@ class DeviceInfoPlusLinuxPlugin extends DeviceInfoPlatform {
   }
 
   Future<Map<String, String?>?> _getOsRelease() {
-    return _tryReadKeyValues('/etc/os-release').then((value) async =>
-        value ?? await _tryReadKeyValues('/usr/lib/os-release'));
+    return _tryReadKeyValues('/etc/os-release').then(
+      (value) async => value ?? await _tryReadKeyValues('/usr/lib/os-release'),
+    );
   }
 
   Future<Map<String, String?>?> _getLsbRelease() {
@@ -95,10 +96,12 @@ extension _Unquote on String {
 
 extension _KeyValues on List<String> {
   Map<String, String?> toKeyValues() {
-    return Map.fromEntries(map((line) {
-      final parts = line.split('=');
-      if (parts.length != 2) return MapEntry(line, null);
-      return MapEntry(parts.first, parts.last.unquote());
-    }));
+    return Map.fromEntries(
+      map((line) {
+        final parts = line.split('=');
+        if (parts.length != 2) return MapEntry(line, null);
+        return MapEntry(parts.first, parts.last.unquote());
+      }),
+    );
   }
 }

--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_web.dart
@@ -17,31 +17,30 @@ class DeviceInfoPlusWebPlugin extends DeviceInfoPlatform {
   /// Factory method that initializes the DeviceInfoPlus plugin platform
   /// with an instance of the plugin for the web.
   static void registerWith(Registrar registrar) {
-    DeviceInfoPlatform.instance =
-        DeviceInfoPlusWebPlugin(html.window.navigator);
+    DeviceInfoPlatform.instance = DeviceInfoPlusWebPlugin(
+      html.window.navigator,
+    );
   }
 
   @override
   Future<BaseDeviceInfo> deviceInfo() {
     return Future<WebBrowserInfo>.value(
-      WebBrowserInfo.fromMap(
-        {
-          'appCodeName': _navigator.appCodeName,
-          'appName': _navigator.appName,
-          'appVersion': _navigator.appVersion,
-          'deviceMemory': _navigator.safeDeviceMemory,
-          'language': _navigator.language,
-          'languages': _navigator.languages.toDart,
-          'platform': _navigator.platform,
-          'product': _navigator.product,
-          'productSub': _navigator.productSub,
-          'userAgent': _navigator.userAgent,
-          'vendor': _navigator.vendor,
-          'vendorSub': _navigator.vendorSub,
-          'hardwareConcurrency': _navigator.hardwareConcurrency,
-          'maxTouchPoints': _navigator.maxTouchPoints,
-        },
-      ),
+      WebBrowserInfo.fromMap({
+        'appCodeName': _navigator.appCodeName,
+        'appName': _navigator.appName,
+        'appVersion': _navigator.appVersion,
+        'deviceMemory': _navigator.safeDeviceMemory,
+        'language': _navigator.language,
+        'languages': _navigator.languages.toDart,
+        'platform': _navigator.platform,
+        'product': _navigator.product,
+        'productSub': _navigator.productSub,
+        'userAgent': _navigator.userAgent,
+        'vendor': _navigator.vendor,
+        'vendorSub': _navigator.vendorSub,
+        'hardwareConcurrency': _navigator.hardwareConcurrency,
+        'maxTouchPoints': _navigator.maxTouchPoints,
+      }),
     );
   }
 }

--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
@@ -30,10 +30,12 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
   // package:win32, so we have to manually define it here.
   //
   // ignore: non_constant_identifier_names
-  void Function(Pointer<OSVERSIONINFOEX>) RtlGetVersion =
-      DynamicLibrary.open('ntdll.dll').lookupFunction<
-          Void Function(Pointer<OSVERSIONINFOEX>),
-          void Function(Pointer<OSVERSIONINFOEX>)>('RtlGetVersion');
+  void Function(Pointer<OSVERSIONINFOEX>) RtlGetVersion = DynamicLibrary.open(
+    'ntdll.dll',
+  ).lookupFunction<
+    Void Function(Pointer<OSVERSIONINFOEX>),
+    void Function(Pointer<OSVERSIONINFOEX>)
+  >('RtlGetVersion');
 
   /// Returns a [WindowsDeviceInfo] with information about the device.
   @override
@@ -44,30 +46,36 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
   @visibleForTesting
   WindowsDeviceInfo getInfo() {
     final systemInfo = calloc<SYSTEM_INFO>();
-    final osVersionInfo = calloc<OSVERSIONINFOEX>()
-      ..ref.dwOSVersionInfoSize = sizeOf<OSVERSIONINFOEX>();
+    final osVersionInfo =
+        calloc<OSVERSIONINFOEX>()
+          ..ref.dwOSVersionInfoSize = sizeOf<OSVERSIONINFOEX>();
 
     try {
-      final currentVersionKey = Registry.openPath(RegistryHive.localMachine,
-          path: r'SOFTWARE\Microsoft\Windows NT\CurrentVersion');
+      final currentVersionKey = Registry.openPath(
+        RegistryHive.localMachine,
+        path: r'SOFTWARE\Microsoft\Windows NT\CurrentVersion',
+      );
       final buildLab = currentVersionKey.getStringValue('BuildLab') ?? '';
       final buildLabEx = currentVersionKey.getStringValue('BuildLabEx') ?? '';
       final digitalProductId =
           currentVersionKey.getBinaryValue('DigitalProductId') ??
-              Uint8List.fromList([]);
+          Uint8List.fromList([]);
       final displayVersion =
           currentVersionKey.getStringValue('DisplayVersion') ?? '';
       final editionId = currentVersionKey.getStringValue('EditionID') ?? '';
       final installDate = DateTime.fromMillisecondsSinceEpoch(
-          1000 * (currentVersionKey.getIntValue('InstallDate') ?? 0));
+        1000 * (currentVersionKey.getIntValue('InstallDate') ?? 0),
+      );
       final productId = currentVersionKey.getStringValue('ProductID') ?? '';
       var productName = currentVersionKey.getStringValue('ProductName') ?? '';
       final registeredOwner =
           currentVersionKey.getStringValue('RegisteredOwner') ?? '';
       final releaseId = currentVersionKey.getStringValue('ReleaseId') ?? '';
 
-      final sqmClientKey = Registry.openPath(RegistryHive.localMachine,
-          path: r'SOFTWARE\Microsoft\SQMClient');
+      final sqmClientKey = Registry.openPath(
+        RegistryHive.localMachine,
+        path: r'SOFTWARE\Microsoft\SQMClient',
+      );
       final machineId = sqmClientKey.getStringValue('MachineId') ?? '';
 
       GetSystemInfo(systemInfo);
@@ -140,8 +148,11 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
     // Now allocate memory for a native string and call this a second time.
     final lpBuffer = wsalloc(nSize.value);
     try {
-      final result =
-          GetComputerNameEx(ComputerNameDnsFullyQualified, lpBuffer, nSize);
+      final result = GetComputerNameEx(
+        ComputerNameDnsFullyQualified,
+        lpBuffer,
+        nSize,
+      );
 
       if (result != 0) {
         return lpBuffer.toDartString();

--- a/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/android_device_info.dart
@@ -38,11 +38,11 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
     required this.isLowRamDevice,
     required this.physicalRamSize,
     required this.availableRamSize,
-  })  : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
-        supported64BitAbis = List<String>.unmodifiable(supported64BitAbis),
-        supportedAbis = List<String>.unmodifiable(supportedAbis),
-        systemFeatures = List<String>.unmodifiable(systemFeatures),
-        super(data);
+  }) : supported32BitAbis = List<String>.unmodifiable(supported32BitAbis),
+       supported64BitAbis = List<String>.unmodifiable(supported64BitAbis),
+       supportedAbis = List<String>.unmodifiable(supportedAbis),
+       systemFeatures = List<String>.unmodifiable(systemFeatures),
+       super(data);
 
   /// Android operating system version values derived from `android.os.Build.VERSION`.
   final AndroidBuildVersion version;
@@ -175,7 +175,8 @@ class AndroidDeviceInfo extends BaseDeviceInfo {
     return AndroidDeviceInfo._(
       data: map,
       version: AndroidBuildVersion._fromMap(
-          map['version']?.cast<String, dynamic>() ?? {}),
+        map['version']?.cast<String, dynamic>() ?? {},
+      ),
       board: map['board'],
       bootloader: map['bootloader'],
       brand: map['brand'],

--- a/packages/device_info_plus/device_info_plus/lib/src/model/ios_device_info.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/model/ios_device_info.dart
@@ -99,8 +99,9 @@ class IosDeviceInfo extends BaseDeviceInfo {
       physicalRamSize: map['physicalRamSize'],
       availableRamSize: map['availableRamSize'],
       isiOSAppOnMac: map['isiOSAppOnMac'],
-      utsname:
-          IosUtsname._fromMap(map['utsname']?.cast<String, dynamic>() ?? {}),
+      utsname: IosUtsname._fromMap(
+        map['utsname']?.cast<String, dynamic>() ?? {},
+      ),
     );
   }
 

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -49,5 +49,5 @@ dev_dependencies:
   test: ^1.25.15
 
 environment:
-  sdk: ">=3.4.0 <4.0.0"
-  flutter: ">=3.22.0"
+  sdk: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.0"

--- a/packages/device_info_plus/device_info_plus/test/device_info_plus_web_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/device_info_plus_web_test.dart
@@ -6,25 +6,23 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('WebBrowserInfo from Map with values', () {
-    final info = WebBrowserInfo.fromMap(
-      {
-        'appCodeName': 'CODENAME',
-        'appName': 'NAME',
-        'appVersion': 'VERSION',
-        'deviceMemory': 64,
-        'language': 'en',
-        'languages': ['en', 'es'],
-        'platform': 'PLATFORM',
-        'product': 'PRODUCT',
-        'productSub': 'PRODUCTSUB',
-        'userAgent':
-            'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0',
-        'vendor': 'VENDOR',
-        'vendorSub': 'VENDORSUB',
-        'hardwareConcurrency': 1,
-        'maxTouchPoints': 2,
-      },
-    );
+    final info = WebBrowserInfo.fromMap({
+      'appCodeName': 'CODENAME',
+      'appName': 'NAME',
+      'appVersion': 'VERSION',
+      'deviceMemory': 64,
+      'language': 'en',
+      'languages': ['en', 'es'],
+      'platform': 'PLATFORM',
+      'product': 'PRODUCT',
+      'productSub': 'PRODUCTSUB',
+      'userAgent':
+          'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:61.0) Gecko/20100101 Firefox/61.0',
+      'vendor': 'VENDOR',
+      'vendorSub': 'VENDORSUB',
+      'hardwareConcurrency': 1,
+      'maxTouchPoints': 2,
+    });
 
     expect(info.appName, 'NAME');
     expect(info.browserName, BrowserName.firefox);

--- a/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus/test/model/android_device_info_test.dart
@@ -8,8 +8,9 @@ part '../model/android_device_info_fake.dart';
 void main() {
   group('$AndroidDeviceInfo fromMap | toMap', () {
     test('fromMap should return $AndroidDeviceInfo with correct values', () {
-      final androidDeviceInfo =
-          AndroidDeviceInfo.fromMap(_fakeAndroidDeviceInfo);
+      final androidDeviceInfo = AndroidDeviceInfo.fromMap(
+        _fakeAndroidDeviceInfo,
+      );
 
       expect(androidDeviceInfo.id, 'id');
       expect(androidDeviceInfo.host, 'host');
@@ -47,8 +48,9 @@ void main() {
     });
 
     test('toMap should return map with correct key and map', () {
-      final androidDeviceInfo =
-          AndroidDeviceInfo.fromMap(_fakeAndroidDeviceInfo);
+      final androidDeviceInfo = AndroidDeviceInfo.fromMap(
+        _fakeAndroidDeviceInfo,
+      );
 
       expect(androidDeviceInfo.data, _fakeAndroidDeviceInfo);
     });

--- a/packages/device_info_plus/device_info_plus_platform_interface/lib/method_channel/method_channel_device_info.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/lib/method_channel/method_channel_device_info.dart
@@ -9,13 +9,15 @@ import 'package:device_info_plus_platform_interface/device_info_plus_platform_in
 class MethodChannelDeviceInfo extends DeviceInfoPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
-  MethodChannel channel =
-      const MethodChannel('dev.fluttercommunity.plus/device_info');
+  MethodChannel channel = const MethodChannel(
+    'dev.fluttercommunity.plus/device_info',
+  );
 
   // Generic method channel for all devices
   @override
   Future<BaseDeviceInfo> deviceInfo() async {
     return BaseDeviceInfo(
-        (await channel.invokeMethod('getDeviceInfo')).cast<String, dynamic>());
+      (await channel.invokeMethod('getDeviceInfo')).cast<String, dynamic>(),
+    );
   }
 }

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -7,15 +7,15 @@ repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.8.0
-  plugin_platform_interface: ^2.1.4
+  meta: ^1.16.0
+  plugin_platform_interface: ^2.1.8
 
 dev_dependencies:
-  flutter_lints: ">=4.0.0 <6.0.0"
+  flutter_lints: ">=5.0.0 <7.0.0"
   flutter_test:
     sdk: flutter
   mockito: ^5.4.0
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.7.0 <4.0.0"
+  flutter: ">=3.29.0"

--- a/packages/device_info_plus/device_info_plus_platform_interface/test/method_channel_device_info_test.dart
+++ b/packages/device_info_plus/device_info_plus_platform_interface/test/method_channel_device_info_test.dart
@@ -16,17 +16,16 @@ void main() {
       methodChannelDeviceInfo = MethodChannelDeviceInfo();
 
       TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-        methodChannelDeviceInfo.channel,
-        (MethodCall methodCall) async {
-          switch (methodCall.method) {
-            case 'getDeviceInfo':
-              return {'device_info': 'is_fake'};
-            default:
-              return null;
-          }
-        },
-      );
+          .setMockMethodCallHandler(methodChannelDeviceInfo.channel, (
+            MethodCall methodCall,
+          ) async {
+            switch (methodCall.method) {
+              case 'getDeviceInfo':
+                return {'device_info': 'is_fake'};
+              default:
+                return null;
+            }
+          });
     });
 
     test('deviceInfo', () async {


### PR DESCRIPTION
## Description

Adjusted declared min Dart and Flutter versions to match actual requirements. Initially, I wanted to relax versions and downgrade part of dependencies, but it makes not much sense as in the end we are still limited by `win32_registry` 2.x versions that need meta `^1.16.0` which is not present in Flutter before 3.29.0. So in the end just updated versions in the pubspec file. Additionally did minor updates for platform interface to match plugin's requirements.

<img width="1621" alt="Screenshot 2025-06-11 at 19 20 37" src="https://github.com/user-attachments/assets/0e7d65e8-934a-4ef0-9fd1-bb22c4ffcb16" />

## Related Issues

Closes #3526 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

