### PR TITLE
chore(device_info_plus): Fix typo in CHANGELOG

### DIFF
--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ## 11.3.1
 
-- Retracted release due to [#3496](https://sgithub.com/fluttercommunity/plus_plugins/issues/3496)
+- Retracted release due to [#3496](https://github.com/fluttercommunity/plus_plugins/issues/3496)
 
 ## 11.3.0
 


### PR DESCRIPTION
## Description

This is a super small typo but since changelog is displayed in https://pub.dev/packages/device_info_plus/changelog would be a good improvement for developers


## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

