### PR TITLE
fix(share_plus): on ios use top view controller instead of root

### DIFF
--- a/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
@@ -418,14 +418,14 @@ activityTypesForStrings(NSArray<NSString *> *activityTypeStrings) {
                       withSubject:shareTitle
                          withText:shareText
             excludedActivityTypes:excludedActivityTypes
-                   withController:rootViewController
+                   withController:topViewController
                          atSource:originRect
                          toResult:result];
       } else if (shareText) {
         [self shareText:shareText
                           subject:shareTitle
             excludedActivityTypes:excludedActivityTypes
-                   withController:rootViewController
+                   withController:topViewController
                          atSource:originRect
                          toResult:result];
       } else {


### PR DESCRIPTION
## Description

There was an error in iOS implementation of share_plus plugin. 
In case of sharing texts or files, instead of top view controller, root view controller was passed.
Sharing of Uri uses correct view controller.

Error appears only in scenario where existing iOS app uses Flutter module, which in turn uses share_plus.

## Related Issues

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

