### PR TITLE
fix(package_info_plus): incorrect install time returned on macOS when app sandbox disabled

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
+++ b/packages/package_info_plus/package_info_plus/lib/package_info_plus.dart
@@ -154,7 +154,9 @@ class PackageInfo {
   /// The time when the application was installed.
   ///
   /// - On Android, returns `PackageManager.firstInstallTime`
-  /// - On iOS and macOS, return the creation date of the app default `NSDocumentDirectory`
+  /// - On iOS, return the creation date of the app default `NSDocumentDirectory`
+  /// - On macOS, if the app is running in sandbox, return the creation date of the app default `NSDocumentDirectory`;
+  ///   If the app is not running in sandbox, return the last modified date of the app main bundle
   /// - On Windows and Linux, returns the creation date of the app executable.
   ///   If the creation date is not available, returns the last modified date of the app executable.
   ///   If the last modified date is not available, returns `null`.

--- a/packages/package_info_plus/package_info_plus_platform_interface/lib/package_info_data.dart
+++ b/packages/package_info_plus/package_info_plus_platform_interface/lib/package_info_data.dart
@@ -35,7 +35,9 @@ class PackageInfoData {
   /// The time when the application was installed.
   ///
   /// - On Android, returns `PackageManager.firstInstallTime`
-  /// - On iOS and macOS, return the creation date of the app default `NSDocumentDirectory`
+  /// - On iOS, return the creation date of the app default `NSDocumentDirectory`
+  /// - On macOS, if the app is running in sandbox, return the creation date of the app default `NSDocumentDirectory`;
+  ///   If the app is not running in sandbox, return the last modified date of the app main bundle
   /// - On Windows and Linux, returns the creation date of the app executable.
   ///   If the creation date is not available, returns the last modified date of the app executable.
   ///   If the last modified date is not available, returns `null`.


### PR DESCRIPTION
## Description

Currently, this plugin get the `installTime` by retrieving the creation date of `NSDocumentDirectory` on macOS. However, the path of `NSDocumentDirectory` varies on whether the app has the app sandbox enabled.

`NSDocumentDirectory` path return value when App Sandbox:
 - Enabled: `~/Library/Containers/<BundleId>/Data/Documents`
 - Disabled: `~/Documents`

This is leading to 2 problems when App Sandbox Disabled:
 1. The creation date of `~/Documents` can't be used as app first installation time.
 2. Triggering a confirmation dialog that informs the user the app wants to access files in the User Documents folder — even though the app may not have intended to do so. See:
    <img width="281" height="245" alt="image" src="https://github.com/user-attachments/assets/999e4b99-3db6-4349-b02f-ae11e148c764" />

This PR fixes the issue by returning the main bundle's last modified date as the `installTime` when the app is not sandboxed. Since currently there's no reliable way to get the first install time when sandbox disabled, the modified date is used as an approximate fallback.

## Related Issues

Fixes https://github.com/fluttercommunity/plus_plugins/issues/3636, https://github.com/fluttercommunity/plus_plugins/pull/3434#issuecomment-2673982542

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

