### PR TITLE
fix(battery_plus): Do not call hidden flag on Samsung with Android versions >= 12

### DIFF
--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -124,10 +124,16 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
     }
 
     private fun isSamsungPowerSaveModeActive(): Boolean {
-        val mode = Settings.System.getString(
-            applicationContext!!.contentResolver,
-            POWER_SAVE_MODE_SAMSUNG_NAME
-        )
+        // psm_switch check is only available before Android 12 (S)
+        val mode = if (VERSION.SDK_INT < VERSION_CODES.S) {
+            Settings.System.getString(
+                applicationContext!!.contentResolver,
+                POWER_SAVE_MODE_SAMSUNG_NAME
+            )
+        } else {
+            null
+        }
+
         return if (mode == null) {
             checkPowerServiceSaveMode()
         } else {


### PR DESCRIPTION
## Description

Avoid security exceptions as there were changes in Android 12 that restrict reading of `psm_switch` flag to system apps.

## Related Issues

Fixes #3626 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

