### PR TITLE
docs(all): normalize MacOS -> macOS in packages

### DIFF
--- a/packages/battery_plus/battery_plus/README.md
+++ b/packages/battery_plus/battery_plus/README.md
@@ -10,7 +10,7 @@ A Flutter plugin to access various information about the battery of the device t
 
 ## Platform Support
 
-| Android | iOS | MacOS | Web | Linux | Windows |
+| Android | iOS | macOS | Web | Linux | Windows |
 | :-----: | :-: | :---: | :-: | :---: | :----: |
 |   ✅    | ✅  |  ✅   | ✅  |  ✅   |   ✅   |
 
@@ -19,7 +19,7 @@ A Flutter plugin to access various information about the battery of the device t
 - Flutter >=3.22.0
 - Dart >=3.4.0 <4.0.0
 - iOS >=12.0
-- MacOS >=10.14
+- macOS >=10.14
 - Android `compileSDK` 34
 - Java 17
 - Android Gradle Plugin >=8.3.0
@@ -47,7 +47,7 @@ battery.onBatteryStateChanged.listen((BatteryState state) {
 });
 
 // Check if device in battery save mode
-// Currently available on Android, iOS, MacOS and Windows platforms only
+// Currently available on Android, iOS, macOS and Windows platforms only
 print(await battery.isInBatterySaveMode);
 ```
 

--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -16,7 +16,7 @@ This plugin allows Flutter apps to discover network connectivity types that can 
 
 ## Platform Support
 
-| Android | iOS | MacOS | Web | Linux | Windows |
+| Android | iOS | macOS | Web | Linux | Windows |
 | :-----: | :-: | :---: | :-: | :---: | :-----: |
 |   ✅    | ✅  |  ✅   | ✅  |  ✅   |   ✅    |
 
@@ -25,7 +25,7 @@ This plugin allows Flutter apps to discover network connectivity types that can 
 - Flutter >=3.19.0
 - Dart >=3.3.0 <4.0.0
 - iOS >=12.0
-- MacOS >=10.14
+- macOS >=10.14
 - Android `compileSDK` 34
 - Java 17
 - Android Gradle Plugin >=8.3.0
@@ -103,7 +103,7 @@ class _MyWidgetState extends State<MyWidget> {
 
 The following table shows which `ConnectivityResult` values are supported per platform.
 
-|           | Android | iOS | Web | MacOS | Windows | Linux |
+|           | Android | iOS | Web | macOS | Windows | Linux |
 |-----------|:-------:|:---:|:---:|:-----:|:-------:|:-----:|
 | wifi      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 | bluetooth | :white_check_mark: |                    |                    |                    |                    | :white_check_mark: |
@@ -118,11 +118,11 @@ _`none` is supported on all platforms by default._
 
 Connectivity changes are no longer communicated to Android apps in the background starting with Android O (8.0). You should always check for connectivity status when your app is resumed. The broadcast is only useful when your application is in the foreground.
 
-### iOS & MacOS
+### iOS & macOS
 
 On iOS simulators, the connectivity types stream might not update when Wi-Fi status changes. This is a known issue.
 
-Starting with iOS 12 and MacOS 10.14, the implementation uses `NWPathMonitor` to obtain the enabled connectivity types. We noticed that this observer can give multiple or unreliable results. For example, reporting connectivity "none" followed by connectivity "wifi" right after reconnecting.
+Starting with iOS 12 and macOS 10.14, the implementation uses `NWPathMonitor` to obtain the enabled connectivity types. We noticed that this observer can give multiple or unreliable results. For example, reporting connectivity "none" followed by connectivity "wifi" right after reconnecting.
 
 We recommend to use the `onConnectivityChanged` with this limitation in mind, as the method doesn't filter events, nor it ensures distinct values.
 

--- a/packages/device_info_plus/device_info_plus/README.md
+++ b/packages/device_info_plus/device_info_plus/README.md
@@ -10,7 +10,7 @@ Get current device information from within the Flutter application.
 
 ## Platform Support
 
-| Android | iOS | MacOS | Web | Linux | Windows |
+| Android | iOS | macOS | Web | Linux | Windows |
 | :-----: | :-: | :---: | :-: | :---: | :-----: |
 |   ✅    | ✅  |  ✅   | ✅  |  ✅   |   ✅    |
 
@@ -19,7 +19,7 @@ Get current device information from within the Flutter application.
 - Flutter >=3.29.0
 - Dart >=3.7.0 <4.0.0
 - iOS >=12.0
-- MacOS >=10.14
+- macOS >=10.14
 - Android `compileSDK` 34
 - Java 17
 - Android Gradle Plugin >=8.3.0

--- a/packages/network_info_plus/network_info_plus/README.md
+++ b/packages/network_info_plus/network_info_plus/README.md
@@ -11,7 +11,7 @@ themselves accordingly.
 
 ## Platform Support
 
-| Android | iOS | MacOS | Web | Linux | Windows |
+| Android | iOS | macOS | Web | Linux | Windows |
 | :-----: | :-: | :---: | :-: | :---: | :----: |
 |   ✅    | ✅  |  ✅   | ❌  |  ✅   |   ✅   |
 
@@ -22,7 +22,7 @@ The functionality is not supported on Web.
 - Flutter >=3.3.0
 - Dart >=2.18.0 <4.0.0
 - iOS >=12.0
-- MacOS >=10.14
+- macOS >=10.14
 - Android `compileSDK` 34
 - Java 17
 - Android Gradle Plugin >=8.3.0

--- a/packages/package_info_plus/package_info_plus/README.md
+++ b/packages/package_info_plus/package_info_plus/README.md
@@ -10,7 +10,7 @@ This Flutter plugin provides an API for querying information about an applicatio
 
 ## Platform Support
 
-| Android |  iOS  | MacOS |  Web  | Linux | Windows |
+| Android |  iOS  | macOS |  Web  | Linux | Windows |
 | :-----: | :---: | :---: | :---: | :---: | :-----: |
 |✅|✅|✅|✅|✅|✅|
 
@@ -19,7 +19,7 @@ This Flutter plugin provides an API for querying information about an applicatio
 - Flutter >=3.19.0
 - Dart >=3.3.0 <4.0.0
 - iOS >=12.0
-- MacOS >=10.14
+- macOS >=10.14
 - Android `compileSDK` 34
 - Java 17
 - Android Gradle Plugin >=8.3.0
@@ -55,7 +55,7 @@ String buildNumber = packageInfo.buildNumber;
 #### Plugin returns incorrect app version
 
 Flutter build tools allow only digits and `.` (dot) symbols to be used in `version`
-of `pubspec.yaml` on iOS/MacOS to comply with official version format from Apple.
+of `pubspec.yaml` on iOS/macOS to comply with official version format from Apple.
 
 More info available in [this comment](https://github.com/fluttercommunity/plus_plugins/issues/389#issuecomment-1106764429)
 

--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -11,7 +11,7 @@ barometer sensors.
 
 ## Platform Support
 
-| Android |  iOS  | MacOS |  Web  | Linux | Windows |
+| Android |  iOS  | macOS |  Web  | Linux | Windows |
 | :-----: | :---: | :---: | :---: | :---: | :-----: |
 |   ✅   |   ✅   |   ❌   |   ✅*  |   ❌    |    ❌   |
 
@@ -22,7 +22,7 @@ barometer sensors.
 - Flutter >=3.19.0
 - Dart >=3.3.0 <4.0.0
 - iOS >=12.0
-- MacOS >=10.14
+- macOS >=10.14
 - Android `compileSDK` 34
 - Java 17
 - Android Gradle Plugin >=8.3.0

--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -14,7 +14,7 @@ on iOS, or equivalent platform content sharing methods.
 
 ## Platform Support
 
-| Shared content | Android | iOS | MacOS | Web | Linux | Windows |
+| Shared content | Android | iOS | macOS | Web | Linux | Windows |
 | :------------: | :-----: | :-: | :---: | :-: | :---: | :-----: |
 | Text           |   ✅    | ✅  |  ✅   | ✅  |  ✅   |   ✅   |
 | URI            |   ✅    | ✅  |  ✅   | As text | As text | As text |
@@ -29,7 +29,7 @@ Sharing files is not supported on Linux.
 - Flutter >=3.22.0
 - Dart >=3.4.0 <4.0.0
 - iOS >=12.0
-- MacOS >=10.14
+- macOS >=10.14
 - Android `compileSDK` 34
 - Java 17
 - Android Gradle Plugin >=8.3.0


### PR DESCRIPTION
Normalize platform spelling from "MacOS" to "macOS" across a few package READMEs
for consistency with Apple style and with the root README.

Packages touched: battery_plus, connectivity_plus, device_info_plus, network_info_plus, package_info_plus, sensors_plus, share_plus (README files only). No code changes.