### PR TITLE
fix(android): Prevent potential crash in checkPowerServiceSaveMode

### DIFF
--- a/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
+++ b/packages/battery_plus/battery_plus/android/src/main/kotlin/dev/fluttercommunity/plus/battery/BatteryPlusPlugin.kt
@@ -170,9 +170,10 @@ class BatteryPlusPlugin : MethodCallHandler, EventChannel.StreamHandler, Flutter
     }
 
     private fun checkPowerServiceSaveMode(): Boolean {
-        val powerManager =
-            applicationContext!!.getSystemService(Context.POWER_SERVICE) as PowerManager
-        return powerManager.isPowerSaveMode
+        return applicationContext?.let {
+            val powerManager = it.getSystemService(Context.POWER_SERVICE) as PowerManager
+            powerManager.isPowerSaveMode
+        } ?: false
     }
 
     private fun getBatteryProperty(property: Int): Int {


### PR DESCRIPTION
### Description

This PR improves the null safety of the `checkPowerServiceSaveMode` method on the Android platform to prevent a potential crash.

### The Problem

Currently, the `checkPowerServiceSaveMode` method uses a non-null assertion (`!!`) on `applicationContext`. While the context is very unlikely to be null in normal operation, a library should be as resilient as possible against rare edge cases (e.g., race conditions during plugin detachment). A `NullPointerException` here would crash the entire host application.

### The Solution

I have replaced the `!!` operator with a safe-call (`?.let`) block. If `applicationContext` happens to be null, the method will now safely return a default value of `false` instead of crashing.

This is a small, targeted change that increases the stability of the plugin without altering its core logic.