### PR TITLE
feat(android_alarm_manager_plus)!: Change Android compile SDK, update Android build config

### DIFF
--- a/packages/android_alarm_manager_plus/README.md
+++ b/packages/android_alarm_manager_plus/README.md
@@ -20,8 +20,9 @@ Dart code in the background when alarms fire.
 - Flutter >=3.12.0
 - Dart >=3.1.0 <4.0.0
 - Java 17
+- Kotlin 2.2.0
 - Android Gradle Plugin >=8.12.1
-- Gradle wrapper >=8.11.1
+- Gradle wrapper >=8.13
 
 ## Getting Started
 

--- a/packages/android_alarm_manager_plus/README.md
+++ b/packages/android_alarm_manager_plus/README.md
@@ -19,10 +19,9 @@ Dart code in the background when alarms fire.
 
 - Flutter >=3.12.0
 - Dart >=3.1.0 <4.0.0
-- Android `compileSDK` 34
 - Java 17
-- Android Gradle Plugin >=8.3.0
-- Gradle wrapper >=8.4
+- Android Gradle Plugin >=8.9.1
+- Gradle wrapper >=8.11.1
 
 ## Getting Started
 

--- a/packages/android_alarm_manager_plus/README.md
+++ b/packages/android_alarm_manager_plus/README.md
@@ -20,7 +20,7 @@ Dart code in the background when alarms fire.
 - Flutter >=3.12.0
 - Dart >=3.1.0 <4.0.0
 - Java 17
-- Android Gradle Plugin >=8.9.1
+- Android Gradle Plugin >=8.12.1
 - Gradle wrapper >=8.11.1
 
 ## Getting Started

--- a/packages/android_alarm_manager_plus/android/build.gradle
+++ b/packages/android_alarm_manager_plus/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.9.1'
+        classpath 'com.android.tools.build:gradle:8.12.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/android_alarm_manager_plus/android/build.gradle
+++ b/packages/android_alarm_manager_plus/android/build.gradle
@@ -2,14 +2,14 @@ group 'dev.fluttercommunity.plus.androidalarmmanager'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.9.23'
+    ext.kotlin_version = '2.2.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.1'
+        classpath 'com.android.tools.build:gradle:8.9.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,9 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 34
-
     namespace 'dev.fluttercommunity.plus.androidalarmmanager'
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
@@ -39,7 +38,7 @@ android {
     }
 
     defaultConfig {
-        minSdk 19
+        minSdk 21
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -50,6 +49,6 @@ android {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    api 'androidx.core:core-ktx:1.13.1'
+    api 'androidx.core:core-ktx:1.16.0'
     implementation 'androidx.appcompat:appcompat:1.7.0'
 }

--- a/packages/android_alarm_manager_plus/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_alarm_manager_plus/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,0 @@
-#Tue Oct 05 10:00:26 EEST 2021
-distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
-distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME

--- a/packages/android_alarm_manager_plus/example/android/app/build.gradle
+++ b/packages/android_alarm_manager_plus/example/android/app/build.gradle
@@ -1,3 +1,16 @@
+buildscript {
+    ext.kotlin_version = '2.2.0'
+    repositories {
+        google()
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.9.1'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
 plugins {
     id "com.android.application"
     id "kotlin-android"
@@ -23,9 +36,8 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdk 34
-
     namespace 'com.example.example'
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
@@ -45,13 +57,13 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.example.example"
-        minSdk 21
-        targetSdk 34
+
+        minSdk flutter.minSdkVersion
+        targetSdk flutter.targetSdkVersion
+
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        multiDexEnabled true
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
@@ -71,7 +83,7 @@ flutter {
 dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "com.google.truth:truth:1.4.4"
-    androidTestImplementation 'androidx.test:runner:1.6.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    api 'androidx.test:core:1.6.1'
+    androidTestImplementation 'androidx.test:runner:1.7.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+    api 'androidx.test:core:1.7.0'
 }

--- a/packages/android_alarm_manager_plus/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_alarm_manager_plus/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 05 12:15:50 EEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/android_alarm_manager_plus/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_alarm_manager_plus/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 05 12:15:50 EEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/android_alarm_manager_plus/example/android/settings.gradle
+++ b/packages/android_alarm_manager_plus/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.3.1" apply false
-    id "org.jetbrains.kotlin.android" version "1.9.23" apply false
+    id "com.android.application" version "8.9.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 
 include ":app"

--- a/packages/android_alarm_manager_plus/example/android/settings.gradle
+++ b/packages/android_alarm_manager_plus/example/android/settings.gradle
@@ -18,7 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.9.1" apply false
+    id "com.android.application" version "8.12.1" apply false
     id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 

--- a/packages/android_alarm_manager_plus/example/lib/main.dart
+++ b/packages/android_alarm_manager_plus/example/lib/main.dart
@@ -82,6 +82,7 @@ class _AlarmHomePageState extends State<_AlarmHomePage> {
 
   void _checkExactAlarmPermission() async {
     final currentStatus = await Permission.scheduleExactAlarm.status;
+    if (!mounted) return;
     setState(() {
       _exactAlarmPermissionStatus = currentStatus;
     });

--- a/packages/android_alarm_manager_plus/example/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/example/pubspec.yaml
@@ -2,18 +2,18 @@ name: android_alarm_manager_plus_example
 description: Demonstrates how to use the android_alarm_manager_plus plugin.
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.12.0"
 
 dependencies:
   flutter:
     sdk: flutter
   android_alarm_manager_plus: ^4.0.8
-  permission_handler: ^11.3.0
-  shared_preferences: ^2.2.2
+  permission_handler: ^12.0.1
+  shared_preferences: ^2.5.3
 
 dev_dependencies:
-  espresso: ^0.3.0+7
+  espresso: ^0.4.0+11
   flutter_test:
     sdk: flutter
   integration_test:


### PR DESCRIPTION
## Description

The initial idea was to just do a bump to compile SDK 36, but decided to not do it and use `flutter.compileSdkVersion`. It should make us worry less about skipping Android version, like it happened with SDK 35.
At the same time I didn't want us to be strict with minSDK, so left it 21 as Flutter supported before 3.35.x release.

As to rest of changes in dependencies - it is an alignment with dependencies versions used by official Flutter packages (e.g. https://github.com/flutter/packages/blob/main/packages/shared_preferences/shared_preferences/example/android/settings.gradle ). I believe that such change should help with better compatibility across the pub ecosystem.

Additionally, thanks for Android Gradle Plugin bump we are preparing plugins to be compatible with apps moving to Android 16KB memory pages: https://developer.android.com/guide/practices/page-sizes

Marking this PR as breaking, because I am sure there will be lots of users, who will struggle with checking the requirements and adjusting Android part of their projects accordingly. 

Next up I will create similar PRs for the rest of plugins in the repo.

## Related Issues

- Part of #3624 
- Part of #3649 
- Supersedes #3617 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

