### PR TITLE
feat(sensors_plus)!: Change Android compile SDK, update Android build config

### DIFF
--- a/packages/sensors_plus/sensors_plus/README.md
+++ b/packages/sensors_plus/sensors_plus/README.md
@@ -6,7 +6,7 @@
 
 [<img src="../../../assets/flutter-favorite-badge.png" width="100" />](https://flutter.dev/docs/development/packages-and-plugins/favorites)
 
-A Flutter plugin to access the accelerometer, gyroscope, magnetometer and 
+A Flutter plugin to access the accelerometer, gyroscope, magnetometer and
 barometer sensors.
 
 ## Platform Support
@@ -23,15 +23,15 @@ barometer sensors.
 - Dart >=3.3.0 <4.0.0
 - iOS >=12.0
 - macOS >=10.14
-- Android `compileSDK` 34
 - Java 17
-- Android Gradle Plugin >=8.3.0
-- Gradle wrapper >=8.4
+- Kotlin 2.2.0
+- Android Gradle Plugin >=8.12.1
+- Gradle wrapper >=8.13
 
 ## Usage
 
 Add `sensors_plus` as a dependency in your pubspec.yaml file.
-  
+
 On iOS you must also include a key called [`NSMotionUsageDescription`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsmotionusagedescription) in your app's `Info.plist` file. This key provides a message that tells the user why the app is requesting access to the device’s motion data. The plugin itself needs access to motion data to get barometer data.
 
 Example Info.plist entry:
@@ -67,7 +67,7 @@ The plugin exposes such classes of sensor events through a set of streams:
 - `GyroscopeEvent` describes the rotation of the device.
 - `MagnetometerEvent` describes the ambient magnetic field surrounding the
   device. A compass is an example usage of this data.
-- `BarometerEvent` describes the atmospheric pressure surrounding the device, in hPa. 
+- `BarometerEvent` describes the atmospheric pressure surrounding the device, in hPa.
   An altimeter is an example usage of this data. Not supported on web browsers.
 
 These events are exposed through a `BroadcastStream`: `accelerometerEvents`,
@@ -173,15 +173,15 @@ sensor data.
 
 ### Platform Restrictions and Considerations
 
-The following lists the restrictions for the sensors on certain platforms due to limitations of the platform. 
+The following lists the restrictions for the sensors on certain platforms due to limitations of the platform.
 
 - **Magnetometer and Barometer missing for web**
 
-  The Magnetometer API is currently not supported by any modern web browsers. Check browser compatibility matrix on [MDN docs for Magnetormeter API](https://developer.mozilla.org/en-US/docs/Web/API/Magnetometer). 
+  The Magnetometer API is currently not supported by any modern web browsers. Check browser compatibility matrix on [MDN docs for Magnetormeter API](https://developer.mozilla.org/en-US/docs/Web/API/Magnetometer).
 
-  The Barometer API does not exist for web platforms as can be seen at [MDN docs forn Sensors API](https://developer.mozilla.org/en-US/docs/Web/API/Sensor_APIs). 
+  The Barometer API does not exist for web platforms as can be seen at [MDN docs forn Sensors API](https://developer.mozilla.org/en-US/docs/Web/API/Sensor_APIs).
 
-  Developers should consider alternative methods or inform users about the limitation when their application runs on a web platform. 
+  Developers should consider alternative methods or inform users about the limitation when their application runs on a web platform.
 
 > [!NOTE]
 >
@@ -189,11 +189,11 @@ The following lists the restrictions for the sensors on certain platforms due to
 
 - **Sampling periods for web**
 
-  Currently it is not possible to set sensors sampling rate on web. Calls to event streams at specied sampling periods will have the sampling period ignored. 
+  Currently it is not possible to set sensors sampling rate on web. Calls to event streams at specied sampling periods will have the sampling period ignored.
 
 - **Barometer sampling period limitation for iOS**
 
-  On iOS devices, barometer updates are [CMAltimeter](https://developer.apple.com/documentation/coremotion/cmaltimeter) which provides updates at regular intervals that cannot be controlled by the user. Calls to `barometerEventStream` at specied sampling periods will have the sampling period ignored. 
+  On iOS devices, barometer updates are [CMAltimeter](https://developer.apple.com/documentation/coremotion/cmaltimeter) which provides updates at regular intervals that cannot be controlled by the user. Calls to `barometerEventStream` at specied sampling periods will have the sampling period ignored.
 
 ## Learn more
 

--- a/packages/sensors_plus/sensors_plus/android/build.gradle
+++ b/packages/sensors_plus/sensors_plus/android/build.gradle
@@ -2,14 +2,14 @@ group 'dev.fluttercommunity.plus.sensors'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.7.22'
+    ext.kotlin_version = '2.2.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.1'
+        classpath 'com.android.tools.build:gradle:8.12.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -25,9 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 34
-
     namespace 'dev.fluttercommunity.plus.sensors'
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/packages/sensors_plus/sensors_plus/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/sensors_plus/sensors_plus/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists

--- a/packages/sensors_plus/sensors_plus/example/android/app/build.gradle
+++ b/packages/sensors_plus/sensors_plus/example/android/app/build.gradle
@@ -22,7 +22,7 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdk 34
+    compileSdk = flutter.compileSdkVersion
 
     namespace 'io.flutter.plugins.sensorsexample'
 
@@ -41,8 +41,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.sensorsexample"
-        minSdk 21
-        targetSdk 34
+        minSdk flutter.minSdkVersion
+        targetSdk flutter.targetSdkVersion
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/packages/sensors_plus/sensors_plus/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/sensors_plus/sensors_plus/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/sensors_plus/sensors_plus/example/android/settings.gradle
+++ b/packages/sensors_plus/sensors_plus/example/android/settings.gradle
@@ -18,7 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.3.1" apply false
+    id "com.android.application" version "8.12.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Description

Same as #3665 but for `sensors_plus`

## Related Issues

- Part of #3624
- Part of #3649 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

