### PR TITLE
feat(android_intent_plus)!: Change Android compile SDK, update Android build config

### DIFF
--- a/packages/android_intent_plus/README.md
+++ b/packages/android_intent_plus/README.md
@@ -18,10 +18,10 @@ This plugin allows Flutter apps to launch arbitrary intents when the platform is
 
 - Flutter >=3.12.0
 - Dart >=3.1.0 <4.0.0
-- Android `compileSDK` 34
 - Java 17
-- Android Gradle Plugin >=8.3.0
-- Gradle wrapper >=8.4
+- Kotlin 2.2.0
+- Android Gradle Plugin >=8.12.1
+- Gradle wrapper >=8.13
 
 ## Usage
 

--- a/packages/android_intent_plus/android/build.gradle
+++ b/packages/android_intent_plus/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.1'
+        classpath 'com.android.tools.build:gradle:8.12.1'
     }
 }
 
@@ -22,9 +22,8 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdk 34
-
     namespace 'dev.fluttercommunity.plus.androidintent'
+    compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
         minSdk 19
@@ -46,7 +45,7 @@ android {
 }
 
 dependencies {
-    implementation 'androidx.annotation:annotation:1.8.2'
+    implementation 'androidx.annotation:annotation:1.9.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.13.0'
     testImplementation 'androidx.test:core:1.6.1'

--- a/packages/android_intent_plus/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_intent_plus/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists

--- a/packages/android_intent_plus/example/android/app/build.gradle
+++ b/packages/android_intent_plus/example/android/app/build.gradle
@@ -23,9 +23,8 @@ if (flutterVersionName == null) {
 }
 
 android {
-    compileSdk 34
-
     namespace 'io.flutter.plugins.androidintentexample'
+    compileSdk = flutter.compileSdkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
@@ -38,9 +37,8 @@ android {
 
     defaultConfig {
         applicationId "io.flutter.plugins.androidintentexample"
-        minSdk 21
-        targetSdk 34
-        multiDexEnabled true
+        minSdk flutter.minSdkVersion
+        targetSdk flutter.targetSdkVersion
 
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
@@ -61,15 +59,6 @@ flutter {
 }
 
 dependencies {
-    constraints {
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22") {
-            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
-        }
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22") {
-            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
-        }
-    }
-    implementation 'androidx.multidex:multidex:2.0.1'
     implementation 'androidx.core:core-ktx:1.13.1'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test:runner:1.6.1'

--- a/packages/android_intent_plus/example/android/app/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_intent_plus/example/android/app/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists

--- a/packages/android_intent_plus/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_intent_plus/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 02 17:46:54 EEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/android_intent_plus/example/android/settings.gradle
+++ b/packages/android_intent_plus/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.3.1" apply false
-    id "org.jetbrains.kotlin.android" version "1.7.22" apply false
+    id "com.android.application" version "8.12.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
 }
 
 include ":app"

--- a/packages/android_intent_plus/example/pubspec.yaml
+++ b/packages/android_intent_plus/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: android_intent_plus_example
 description: Demonstrates how to use the android_intent plugin.
 
 environment:
-  sdk: ">=2.18.0 <4.0.0"
-  flutter: ">=3.3.0"
+  sdk: ">=3.1.0 <4.0.0"
+  flutter: ">=3.12.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Same as #3665 but for `android_intent_plus`

## Related Issues

- Part of #3624
- Part of #3649 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

