### PR TITLE
chore(release): prepare for release

### DIFF
--- a/packages/android_alarm_manager_plus/CHANGELOG.md
+++ b/packages/android_alarm_manager_plus/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 5.0.0
+
+> Note: This release has breaking changes.
+>
+> On Android plugin now requires the following:
+> - Android Gradle Plugin >=8.12.1
+> - Gradle wrapper >=8.13
+> - Kotlin 2.2.0
+
+ - **BREAKING** **FEAT**(android_alarm_manager_plus): Change Android compile SDK, update Android build config ([#3665](https://github.com/fluttercommunity/plus_plugins/issues/3665)). ([bb49385b](https://github.com/fluttercommunity/plus_plugins/commit/bb49385bdbdc8c8ba0bdb5c97fe229f7487d9f00))
+
 ## 4.0.8
 
  - **DOCS**(all): improve documentation across multiple README files ([#3630](https://github.com/fluttercommunity/plus_plugins/issues/3630)). ([643e12df](https://github.com/fluttercommunity/plus_plugins/commit/643e12dfe0389dc21b49bd31ec03e7f38844d339))

--- a/packages/android_alarm_manager_plus/example/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  android_alarm_manager_plus: ^4.0.8
+  android_alarm_manager_plus: ^5.0.0
   permission_handler: ^12.0.1
   shared_preferences: ^2.5.3
 

--- a/packages/android_alarm_manager_plus/pubspec.yaml
+++ b/packages/android_alarm_manager_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: android_alarm_manager_plus
 description: Flutter plugin for accessing the Android AlarmManager service, and
   running Dart code in the background when alarms fire.
-version: 4.0.8
+version: 5.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/android_alarm_manager_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/android_alarm_manager_plus

--- a/packages/android_intent_plus/CHANGELOG.md
+++ b/packages/android_intent_plus/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 6.0.0
+
+> Note: This release has breaking changes.
+>
+> On Android plugin now requires the following:
+> - Android Gradle Plugin >=8.12.1
+> - Gradle wrapper >=8.13
+> - Kotlin 2.2.0
+
+ - **BREAKING** **FEAT**(android_intent_plus): Change Android compile SDK, update Android build config ([#3673](https://github.com/fluttercommunity/plus_plugins/issues/3673)). ([7a228c3e](https://github.com/fluttercommunity/plus_plugins/commit/7a228c3e29e92ffba068422709136b55a05a0e33))
+
 ## 5.3.1
 
  - **DOCS**(all): improve documentation across multiple README files ([#3630](https://github.com/fluttercommunity/plus_plugins/issues/3630)). ([643e12df](https://github.com/fluttercommunity/plus_plugins/commit/643e12dfe0389dc21b49bd31ec03e7f38844d339))

--- a/packages/android_intent_plus/example/pubspec.yaml
+++ b/packages/android_intent_plus/example/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   flutter:
     sdk: flutter
   platform: ^3.1.0
-  android_intent_plus: ^5.3.1
+  android_intent_plus: ^6.0.0
 
 dev_dependencies:
   flutter_driver:

--- a/packages/android_intent_plus/pubspec.yaml
+++ b/packages/android_intent_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: android_intent_plus
 description: Flutter plugin for launching Android Intents. Not supported on iOS.
-version: 5.3.1
+version: 6.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/android_intent_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/android_intent_plus

--- a/packages/battery_plus/battery_plus/CHANGELOG.md
+++ b/packages/battery_plus/battery_plus/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 7.0.0
+
+> Note: This release has breaking changes.
+>
+> On Android plugin now requires the following:
+> - Android Gradle Plugin >=8.12.1
+> - Gradle wrapper >=8.13
+> - Kotlin 2.2.0
+
+ - **DOCS**(all): replace MacOS by macOS in package READMEs ([#3658](https://github.com/fluttercommunity/plus_plugins/issues/3658)). ([72b6234c](https://github.com/fluttercommunity/plus_plugins/commit/72b6234c25315c30d8efc9f15a9258b0bb7273a8))
+ - **BREAKING** **FEAT**(battery_plus): Change Android compile SDK, update Android build config ([#3666](https://github.com/fluttercommunity/plus_plugins/issues/3666)). ([c2fe29ab](https://github.com/fluttercommunity/plus_plugins/commit/c2fe29ab224d1fca33905fe57110aee106da55e4))
+
 ## 6.2.3
 
  - **FIX**(battery_plus): Do not call hidden flag on Samsung with Android versions >= 12 ([#3641](https://github.com/fluttercommunity/plus_plugins/issues/3641)). ([a8764705](https://github.com/fluttercommunity/plus_plugins/commit/a87647056529ef88d319d9a27c75744c9db9ff53))

--- a/packages/battery_plus/battery_plus/example/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/example/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  battery_plus: ^6.2.3
+  battery_plus: ^7.0.0
 
 dev_dependencies:
   flutter_driver:

--- a/packages/battery_plus/battery_plus/pubspec.yaml
+++ b/packages/battery_plus/battery_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: battery_plus
 description: Flutter plugin for accessing information about the battery state(full, charging, discharging).
-version: 6.2.3
+version: 7.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/battery_plus/battery_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/battery_plus

--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 7.0.0
+
+> Note: This release has breaking changes.
+>
+> On Android plugin now requires the following:
+> - Android Gradle Plugin >=8.12.1
+> - Gradle wrapper >=8.13
+> - Kotlin 2.2.0
+
+ - **DOCS**(all): replace MacOS by macOS in package READMEs ([#3658](https://github.com/fluttercommunity/plus_plugins/issues/3658)). ([72b6234c](https://github.com/fluttercommunity/plus_plugins/commit/72b6234c25315c30d8efc9f15a9258b0bb7273a8))
+ - **BREAKING** **FEAT**(connectivity_plus): Change Android compile SDK, update Android build config ([#3667](https://github.com/fluttercommunity/plus_plugins/issues/3667)). ([01b596a0](https://github.com/fluttercommunity/plus_plugins/commit/01b596a05204286903451a8d65a9186e4956f065))
+
 ## 6.1.5
 
  - **DOCS**(all): improve documentation across multiple README files ([#3630](https://github.com/fluttercommunity/plus_plugins/issues/3630)). ([643e12df](https://github.com/fluttercommunity/plus_plugins/commit/643e12dfe0389dc21b49bd31ec03e7f38844d339))

--- a/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  connectivity_plus: ^6.1.5
+  connectivity_plus: ^7.0.0
 
 dev_dependencies:
   flutter_driver:

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 6.1.5
+version: 7.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/connectivity_plus/connectivity_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/connectivity_plus

--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 12.0.0
+
+> Note: This release has breaking changes.
+>
+> Plugin now requires the following:
+> - Android Gradle Plugin >=8.12.1
+> - Gradle wrapper >=8.13
+> - Kotlin 2.2.0
+
+ - **DOCS**(all): replace MacOS by macOS in package READMEs ([#3658](https://github.com/fluttercommunity/plus_plugins/issues/3658)). ([72b6234c](https://github.com/fluttercommunity/plus_plugins/commit/72b6234c25315c30d8efc9f15a9258b0bb7273a8))
+ - **BREAKING** **REFACTOR**(device_info_plus): remove `serialNumber` property from AndroidDeviceInfo ([#3663](https://github.com/fluttercommunity/plus_plugins/issues/3663)). ([d0fdc582](https://github.com/fluttercommunity/plus_plugins/commit/d0fdc582e8187f71522678e19b6329221b5f535d))
+ - **BREAKING** **FEAT**(device_info_plus): Change Android compile SDK, update Android build config ([#3668](https://github.com/fluttercommunity/plus_plugins/issues/3668)). ([32528e7f](https://github.com/fluttercommunity/plus_plugins/commit/32528e7f852893dd4448c448096e459e1950c7e4))
+
 ## 11.5.0
 
  - **FIX**(device_info_plus): Specify correct Dart and Flutter version requirements ([#3597](https://github.com/fluttercommunity/plus_plugins/issues/3597)). ([6ebc0ead](https://github.com/fluttercommunity/plus_plugins/commit/6ebc0ead68df477f06c6d4738a69a9e56223cf47))

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the device_info_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus: ^11.5.0
+  device_info_plus: ^12.0.0
 
 dev_dependencies:
   flutter_driver:

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 11.5.0
+version: 12.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/device_info_plus/device_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus

--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 7.0.0
+
+> Note: This release has breaking changes.
+>
+> On Android plugin now requires the following:
+> - Android Gradle Plugin >=8.12.1
+> - Gradle wrapper >=8.13
+> - Kotlin 2.2.0
+
+ - **DOCS**(all): replace MacOS by macOS in package READMEs ([#3658](https://github.com/fluttercommunity/plus_plugins/issues/3658)). ([72b6234c](https://github.com/fluttercommunity/plus_plugins/commit/72b6234c25315c30d8efc9f15a9258b0bb7273a8))
+ - **BREAKING** **FEAT**(network_info_plus): Change Android compile SDK, update Android build config ([#3669](https://github.com/fluttercommunity/plus_plugins/issues/3669)). ([bcb42027](https://github.com/fluttercommunity/plus_plugins/commit/bcb420277b5907fa9aac3977c20fbac65284a4a8))
+
 ## 6.1.4
 
  - **FIX**(network_info_plus): fix deprecated member use in Windows implementation ([#3519](https://github.com/fluttercommunity/plus_plugins/issues/3519)). ([f723fad9](https://github.com/fluttercommunity/plus_plugins/commit/f723fad94e2a834cd0dbac861c6dc086b8dd71f2))

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus: ^6.1.4
+  network_info_plus: ^7.0.0
   permission_handler: ^12.0.0+1
 
 dev_dependencies:

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 6.1.4
+version: 7.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/network_info_plus/network_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/network_info_plus

--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 9.0.0
+
+> Note: This release has breaking changes.
+>
+> On Android plugin now requires the following:
+> - Android Gradle Plugin >=8.12.1
+> - Gradle wrapper >=8.13
+> - Kotlin 2.2.0
+
+ - **DOCS**(all): replace MacOS by macOS in package READMEs ([#3658](https://github.com/fluttercommunity/plus_plugins/issues/3658)). ([72b6234c](https://github.com/fluttercommunity/plus_plugins/commit/72b6234c25315c30d8efc9f15a9258b0bb7273a8))
+ - **BREAKING** **FEAT**(package_info_plus): Change Android compile SDK, update Android build config ([#3674](https://github.com/fluttercommunity/plus_plugins/issues/3674)). ([78c2b742](https://github.com/fluttercommunity/plus_plugins/commit/78c2b7420bcc943b5f46a22285e750a0dc58e5bb))
+
 ## 8.3.1
 
  - **FIX**(package_info_plus): incorrect install time on macOS when app sandbox disabled ([#3638](https://github.com/fluttercommunity/plus_plugins/issues/3638)). ([2cf9297b](https://github.com/fluttercommunity/plus_plugins/commit/2cf9297b4e3ce5cc71d22539ca7d0dfc82ac819b))

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -11,11 +11,11 @@ dependencies:
   flutter:
     sdk: flutter
   http: ">=0.13.5 <2.0.0"
-  package_info_plus: ^8.3.1
+  package_info_plus: ^9.0.0
 
 dev_dependencies:
   build_runner: ^2.3.3
-  device_info_plus: ^11.5.0
+  device_info_plus: ^12.0.0
   integration_test:
     sdk: flutter
   flutter_driver:

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 8.3.1
+version: 9.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/package_info_plus/package_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/package_info_plus

--- a/packages/sensors_plus/sensors_plus/CHANGELOG.md
+++ b/packages/sensors_plus/sensors_plus/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 7.0.0
+
+> Note: This release has breaking changes.
+>
+> On Android plugin now requires the following:
+> - Android Gradle Plugin >=8.12.1
+> - Gradle wrapper >=8.13
+> - Kotlin 2.2.0
+
+ - **DOCS**(all): replace MacOS by macOS in package READMEs ([#3658](https://github.com/fluttercommunity/plus_plugins/issues/3658)). ([72b6234c](https://github.com/fluttercommunity/plus_plugins/commit/72b6234c25315c30d8efc9f15a9258b0bb7273a8))
+ - **BREAKING** **FEAT**(sensors_plus): Change Android compile SDK, update Android build config ([#3670](https://github.com/fluttercommunity/plus_plugins/issues/3670)). ([ad32fae5](https://github.com/fluttercommunity/plus_plugins/commit/ad32fae515a61a7d251b574b96b3a707f7cfacaf))
+
 ## 6.1.2
 
  - **DOCS**(all): improve documentation across multiple README files ([#3630](https://github.com/fluttercommunity/plus_plugins/issues/3630)). ([643e12df](https://github.com/fluttercommunity/plus_plugins/commit/643e12dfe0389dc21b49bd31ec03e7f38844d339))

--- a/packages/sensors_plus/sensors_plus/example/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the sensors plugin.
 dependencies:
   flutter:
     sdk: flutter
-  sensors_plus: ^6.1.2
+  sensors_plus: ^7.0.0
 
 dev_dependencies:
   flutter_driver:

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: sensors_plus
 description: Flutter plugin for accessing accelerometer, gyroscope, and
   magnetometer sensors.
-version: 6.1.2
+version: 7.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/sensors_plus/sensors_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/sensors_plus

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 12.0.0
+
+> Note: This release has breaking changes.
+>
+> On Android plugin now requires the following:
+> - Android Gradle Plugin >=8.12.1
+> - Gradle wrapper >=8.13
+> - Kotlin 2.2.0
+
+ - **FIX**(share_plus): unable to get the correct result on iOS ([#3660](https://github.com/fluttercommunity/plus_plugins/issues/3660)). ([3bd253b0](https://github.com/fluttercommunity/plus_plugins/commit/3bd253b04021a932fa79412a5da2318c22cfdbe2))
+ - **DOCS**(all): replace MacOS by macOS in package READMEs ([#3658](https://github.com/fluttercommunity/plus_plugins/issues/3658)). ([72b6234c](https://github.com/fluttercommunity/plus_plugins/commit/72b6234c25315c30d8efc9f15a9258b0bb7273a8))
+ - **BREAKING** **FEAT**(share_plus): Change Android compile SDK, update Android build config ([#3671](https://github.com/fluttercommunity/plus_plugins/issues/3671)). ([24363e27](https://github.com/fluttercommunity/plus_plugins/commit/24363e270d3c8219b9516fe57474a448f6c5fd48))
+
 ## 11.1.0
 
  - **FEAT**(share_plus): Added `excludedCupertinoActivities` share parameter ([#3376](https://github.com/fluttercommunity/plus_plugins/issues/3376)). ([f9fdadb4](https://github.com/fluttercommunity/plus_plugins/commit/f9fdadb41242ad2e36ddbf1ade82be6c5bb78ec4))

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the share_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  share_plus: ^11.1.0
+  share_plus: ^12.0.0
   image_picker: ^1.1.2
   file_selector: ^1.0.3
 

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 11.1.0
+version: 12.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/share_plus/share_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus


### PR DESCRIPTION
## Description

New release for all plugins. Added updated Android requirements on top on purpose in hope that at least someone reads them and adjusts their project accordingly before updating.

## Related Issues

Closes #3624 
Closes #3649 

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

