### PR TITLE
feat(device_info_plus): Add identifiers for iPad Pro 11-Inch (M5) models

### DIFF
--- a/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/DeviceIdentifiers.m
+++ b/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/DeviceIdentifiers.m
@@ -217,6 +217,9 @@
   } else if ([identifier isEqualToString:@"iPad16,5"] ||
              [identifier isEqualToString:@"iPad16,6"]) {
     return @"iPad Pro 13-Inch (M4)";
+  } else if ([identifier isEqualToString:@"iPad17,1"] ||
+             [identifier isEqualToString:@"iPad17,2"]) {
+    return @"iPad Pro 11-Inch (M5)";
   } else if ([identifier isEqualToString:@"iPad17,3"] ||
              [identifier isEqualToString:@"iPad17,4"]) {
     return @"iPad Pro 13-Inch (M5)";


### PR DESCRIPTION
## Description

<!-- Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. -->

Adding iPad Pro 11-Inch (M5) models missing on #3698

## Related Issues

<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

