### PR TITLE
fix(workflows): update min android API level to 24

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [22, 26, 31, 34]
+        android-api-level: [24, 26, 31, 34]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 21, 26, 31, 34]
+        android-api-level: [ 24, 26, 31, 34]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -63,7 +63,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 26, 31, 34 ]
 
     steps:
       - name: "Checkout repository"


### PR DESCRIPTION
## Description

Starting Flutter 3.35, the min Android API level is 24. Hence, workflows using API level < 24, consistently fails.

## Related Issues

<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

