### PR TITLE
docs(package_info_plus): add installerStore values documentation

### DIFF
--- a/packages/package_info_plus/package_info_plus/README.md
+++ b/packages/package_info_plus/package_info_plus/README.md
@@ -48,15 +48,16 @@ String version = packageInfo.version;
 String buildNumber = packageInfo.buildNumber;
 ```
 
-## Installer Store
+### Installer Store
 
 The `installerStore` property indicates which app store installed the application. This is useful for directing users to the appropriate store page for ratings or updates.
 
 ```dart
+PackageInfo packageInfo = await PackageInfo.fromPlatform();
 String? installerStore = packageInfo.installerStore;
 ```
 
-### iOS
+#### iOS
 
 On iOS, the `installerStore` value is determined by checking the app store receipt path:
 
@@ -66,7 +67,7 @@ On iOS, the `installerStore` value is determined by checking the app store recei
 | TestFlight | `com.apple.testflight` |
 | Simulator | `com.apple.simulator` |
 
-### Android
+#### Android
 
 On Android, the value is the package name of the app store that installed the application, obtained via `PackageManager.getInstallSourceInfo()` (Android 11+) or `PackageManager.getInstallerPackageName()` (older versions).
 
@@ -83,13 +84,9 @@ On Android, the value is the package name of the app store that installed the ap
 
 **Note:** Some stores may not properly implement the installer package name API, which could result in `null` being returned even for store installations.
 
-### macOS
+#### Other Platforms
 
-On macOS, `installerStore` always returns `null` as there is no reliable way to detect the installation source.
-
-### Other Platforms
-
-On Linux, Windows, and Web, `installerStore` returns `null`.
+On MacOS, Linux, Windows, and Web, `installerStore` returns `null`.
 
 ## Known Issues
 


### PR DESCRIPTION
Closes #1468

## Description

<!-- Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. -->

## Related Issues

<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

