### PR TITLE
chore(sensors_plus): Remove stray override annotations

### DIFF
--- a/packages/sensors_plus/sensors_plus/lib/sensors_plus.dart
+++ b/packages/sensors_plus/sensors_plus/lib/sensors_plus.dart
@@ -35,7 +35,6 @@ Stream<MagnetometerEvent> get magnetometerEvents {
 
 /// Returns a broadcast stream of events from the device accelerometer at the
 /// given sampling frequency.
-@override
 Stream<AccelerometerEvent> accelerometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
@@ -44,7 +43,6 @@ Stream<AccelerometerEvent> accelerometerEventStream({
 
 /// Returns a broadcast stream of events from the device gyroscope at the
 /// given sampling frequency.
-@override
 Stream<GyroscopeEvent> gyroscopeEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
@@ -53,7 +51,6 @@ Stream<GyroscopeEvent> gyroscopeEventStream({
 
 /// Returns a broadcast stream of events from the device accelerometer with
 /// gravity removed at the given sampling frequency.
-@override
 Stream<UserAccelerometerEvent> userAccelerometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
@@ -62,7 +59,6 @@ Stream<UserAccelerometerEvent> userAccelerometerEventStream({
 
 /// Returns a broadcast stream of events from the device magnetometer at the
 /// given sampling frequency.
-@override
 Stream<MagnetometerEvent> magnetometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {


### PR DESCRIPTION
## Description

The `@override` annotation is not applicable on top-level functions. The analyzer will begin to report misplaced `@override` annotations such as these soon.
 

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

