### PR TITLE
fix(connectivity_plus): prevent crash when NetworkManager is unavailable on Linux

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/lib/src/connectivity_plus_linux.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/src/connectivity_plus_linux.dart
@@ -20,11 +20,19 @@ class ConnectivityPlusLinuxPlugin extends ConnectivityPlatform {
   /// Checks the connection status of the device.
   @override
   Future<List<ConnectivityResult>> checkConnectivity() async {
-    final client = createClient();
-    await client.connect();
-    final connectivity = _getConnectivity(client);
-    await client.close();
-    return connectivity;
+    try {
+      final client = createClient();
+      await client.connect();
+      final connectivity = _getConnectivity(client);
+      await client.close();
+      return connectivity;
+    } catch (e) {
+      // NetworkManager may not be installed or running on this Linux system.
+      // Rather than crashing, we gracefully degrade by treating this as
+      // no connectivity. This ensures the plugin works on all Linux distributions
+      // regardless of their network management infrastructure.
+      return [ConnectivityResult.none];
+    }
   }
 
   NetworkManagerClient? _client;
@@ -69,14 +77,21 @@ class ConnectivityPlusLinuxPlugin extends ConnectivityPlatform {
   }
 
   Future<void> _startListenConnectivity() async {
-    _client ??= createClient();
-    await _client!.connect();
-    _addConnectivity(_client!);
-    _client!.propertiesChanged.listen((properties) {
-      if (properties.contains('Connectivity')) {
-        _addConnectivity(_client!);
-      }
-    });
+    try {
+      _client ??= createClient();
+      await _client!.connect();
+      _addConnectivity(_client!);
+      _client!.propertiesChanged.listen((properties) {
+        if (properties.contains('Connectivity')) {
+          _addConnectivity(_client!);
+        }
+      });
+    } catch (e) {
+      // NetworkManager may not be installed or running on this Linux system.
+      // We emit ConnectivityResult.none to the stream to indicate no connectivity
+      // can be determined, rather than crashing the application.
+      _controller?.add([ConnectivityResult.none]);
+    }
   }
 
   void _addConnectivity(NetworkManagerClient client) {

--- a/packages/connectivity_plus/connectivity_plus/test/connectivity_plus_linux_test.dart
+++ b/packages/connectivity_plus/connectivity_plus/test/connectivity_plus_linux_test.dart
@@ -18,8 +18,9 @@ void main() {
     final linux = ConnectivityPlusLinuxPlugin();
     linux.createClient = () {
       final client = MockNetworkManagerClient();
-      when(client.connectivity)
-          .thenReturn(NetworkManagerConnectivityState.full);
+      when(
+        client.connectivity,
+      ).thenReturn(NetworkManagerConnectivityState.full);
       when(client.primaryConnectionType).thenReturn('bluetooth');
       return client;
     };
@@ -33,8 +34,9 @@ void main() {
     final linux = ConnectivityPlusLinuxPlugin();
     linux.createClient = () {
       final client = MockNetworkManagerClient();
-      when(client.connectivity)
-          .thenReturn(NetworkManagerConnectivityState.full);
+      when(
+        client.connectivity,
+      ).thenReturn(NetworkManagerConnectivityState.full);
       when(client.primaryConnectionType).thenReturn('ethernet');
       return client;
     };
@@ -48,8 +50,9 @@ void main() {
     final linux = ConnectivityPlusLinuxPlugin();
     linux.createClient = () {
       final client = MockNetworkManagerClient();
-      when(client.connectivity)
-          .thenReturn(NetworkManagerConnectivityState.full);
+      when(
+        client.connectivity,
+      ).thenReturn(NetworkManagerConnectivityState.full);
       when(client.primaryConnectionType).thenReturn('wireless');
       return client;
     };
@@ -63,8 +66,9 @@ void main() {
     final linux = ConnectivityPlusLinuxPlugin();
     linux.createClient = () {
       final client = MockNetworkManagerClient();
-      when(client.connectivity)
-          .thenReturn(NetworkManagerConnectivityState.full);
+      when(
+        client.connectivity,
+      ).thenReturn(NetworkManagerConnectivityState.full);
       when(client.primaryConnectionType).thenReturn('vpn');
       return client;
     };
@@ -78,8 +82,9 @@ void main() {
     final linux = ConnectivityPlusLinuxPlugin();
     linux.createClient = () {
       final client = MockNetworkManagerClient();
-      when(client.connectivity)
-          .thenReturn(NetworkManagerConnectivityState.full);
+      when(
+        client.connectivity,
+      ).thenReturn(NetworkManagerConnectivityState.full);
       when(client.primaryConnectionType).thenReturn('wireless,vpn');
       return client;
     };
@@ -93,33 +98,66 @@ void main() {
     final linux = ConnectivityPlusLinuxPlugin();
     linux.createClient = () {
       final client = MockNetworkManagerClient();
-      when(client.connectivity)
-          .thenReturn(NetworkManagerConnectivityState.none);
+      when(
+        client.connectivity,
+      ).thenReturn(NetworkManagerConnectivityState.none);
       return client;
     };
-    expect(linux.checkConnectivity(),
-        completion(equals([ConnectivityResult.none])));
+    expect(
+      linux.checkConnectivity(),
+      completion(equals([ConnectivityResult.none])),
+    );
   });
 
   test('connectivity changes', () {
     final linux = ConnectivityPlusLinuxPlugin();
     linux.createClient = () {
       final client = MockNetworkManagerClient();
-      when(client.connectivity)
-          .thenReturn(NetworkManagerConnectivityState.full);
+      when(
+        client.connectivity,
+      ).thenReturn(NetworkManagerConnectivityState.full);
       when(client.primaryConnectionType).thenReturn('wireless');
       when(client.propertiesChanged).thenAnswer((_) {
-        when(client.connectivity)
-            .thenReturn(NetworkManagerConnectivityState.none);
+        when(
+          client.connectivity,
+        ).thenReturn(NetworkManagerConnectivityState.none);
         return Stream.value(['Connectivity']);
       });
       return client;
     };
     expect(
-        linux.onConnectivityChanged,
-        emitsInOrder([
-          [ConnectivityResult.wifi],
-          [ConnectivityResult.none]
-        ]));
+      linux.onConnectivityChanged,
+      emitsInOrder([
+        [ConnectivityResult.wifi],
+        [ConnectivityResult.none],
+      ]),
+    );
+  });
+
+  test('NetworkManager unavailable - checkConnectivity', () async {
+    final linux = ConnectivityPlusLinuxPlugin();
+    linux.createClient = () {
+      final client = MockNetworkManagerClient();
+      when(
+        client.connect(),
+      ).thenThrow(Exception('NetworkManager not available'));
+      return client;
+    };
+    expect(
+      linux.checkConnectivity(),
+      completion(equals([ConnectivityResult.none])),
+    );
+  });
+
+  test('NetworkManager unavailable - onConnectivityChanged', () {
+    final linux = ConnectivityPlusLinuxPlugin();
+    linux.createClient = () {
+      final client = MockNetworkManagerClient();
+      when(
+        client.connect(),
+      ).thenThrow(Exception('NetworkManager not available'));
+      return client;
+    };
+    expect(linux.onConnectivityChanged, emits([ConnectivityResult.none]));
   });
 }


### PR DESCRIPTION
## Description

On Linux systems where **NetworkManager is not installed or not running**,
`connectivity_plus` crashes with an **uncaught DBus exception** during startup.

This affects applications such as **AppFlowy** and any Flutter Linux app running on:
- NixOS without networkmanager (my case)
- Minimal or containerized distributions
- Systems using alternative network managers (e.g. systemd-networkd, ConnMan)
- Systems where NetworkManager is intentionally disabled

Instead of failing gracefully, the plugin throws an uncaught platform error from DBus
and terminates the app.

### What this PR changes

- Wrap NetworkManager / DBus calls in try-catch blocks in:
  - checkConnectivity()
  - _startListenConnectivity()
- Treat missing or unavailable NetworkManager as a non-fatal condition
- Return ConnectivityResult.none when NetworkManager cannot be accessed
- Add inline documentation explaining why graceful degradation is required on Linux
- Add unit tests covering NetworkManager-unavailable scenarios

This ensures the plugin works correctly across **all Linux distributions**,
regardless of their network management infrastructure.

---

## Expected Behavior After This Change

- Flutter Linux apps do not crash when NetworkManager is missing
- Connectivity is reported as ConnectivityResult.none instead of throwing
- Behavior matches other platforms where connectivity may be temporarily unavailable

---

## Related Issues

- Fixes #3739

---

## Checklist

- [x] I read the Contributor Guide and followed the process outlined there
- [x] The PR title follows Conventional Commits
- [x] I did not modify CHANGELOG.md or plugin versions
- [x] All existing and new tests pass
- [x] flutter analyze reports no issues

---

## Breaking Change

- [ ] Yes
- [x] No

This change only affects error handling and does not modify public APIs or
expected return types.