### PR TITLE
fix(connectivity_plus): Use serial queue for NWPathMonitor to prevent race condition crash

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus/Sources/connectivity_plus/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/ios/connectivity_plus/Sources/connectivity_plus/PathMonitorConnectivityProvider.swift
@@ -3,9 +3,9 @@ import Network
 
 public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
 
-  // Use .utility, as it is intended for tasks that the user does not track actively.
-  // See: https://developer.apple.com/documentation/dispatch/dispatchqos
-  private let queue = DispatchQueue.global(qos: .utility)
+  // Use a serial queue to ensure that all network updates and monitor events happen 
+  // sequentially, preventing race conditions during deallocation.
+  private let queue = DispatchQueue(label: "dev.fluttercommunity.plus.connectivity")
 
   private var pathMonitor: NWPathMonitor?
 

--- a/packages/connectivity_plus/connectivity_plus/macos/connectivity_plus/Sources/connectivity_plus/PathMonitorConnectivityProvider.swift
+++ b/packages/connectivity_plus/connectivity_plus/macos/connectivity_plus/Sources/connectivity_plus/PathMonitorConnectivityProvider.swift
@@ -3,9 +3,9 @@ import Network
 
 public class PathMonitorConnectivityProvider: NSObject, ConnectivityProvider {
 
-  // Use .utility, as it is intended for tasks that the user does not track actively.
-  // See: https://developer.apple.com/documentation/dispatch/dispatchqos
-  private let queue = DispatchQueue.global(qos: .utility)
+  // Use a serial queue to ensure that all network updates and monitor events happen 
+  // sequentially, preventing race conditions during deallocation.
+  private let queue = DispatchQueue(label: "dev.fluttercommunity.plus.connectivity")
 
   private var pathMonitor: NWPathMonitor?
 


### PR DESCRIPTION
## Description

This PR fixes a crash occurring on iOS/macOS when `NWPathMonitor` updates are processed concurrently while the monitor is being deallocated.

The crash manifests as `swift::fatalError` / `swift_deallocPartialClassInstance` / double free.

The `NWPathMonitor` was previously initialized on a global concurrent queue (`DispatchQueue.global(qos: .utility)`). This allowed race conditions where the `pathUpdateHandler` block could still be executing on one thread while `stop()` was setting `pathMonitor = nil` on another, leading to memory corruption.

**Fix:** Changed the queue to a private **serial** `DispatchQueue`. This ensures that start, stop, and update events are processed sequentially, preventing the race condition.

## Related Issues

- Fix #3753

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.