### PR TITLE
fix(share_plus): fix file access for sandboxed MSIX packaging

### DIFF
--- a/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/FPPDeviceInfoPlusPlugin.m
+++ b/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/FPPDeviceInfoPlusPlugin.m
@@ -31,12 +31,14 @@
       isiOSAppOnMac = [NSNumber numberWithBool:[info isiOSAppOnMac]];
     }
     NSError *error = nil;
-    NSDictionary *fsAttributes = [[NSFileManager defaultManager] attributesOfFileSystemForPath:NSHomeDirectory() error:&error];
+    NSDictionary *fsAttributes = [[NSFileManager defaultManager]
+        attributesOfFileSystemForPath:NSHomeDirectory()
+                                error:&error];
     NSNumber *freeSize = [NSNumber numberWithInt:-1];
     NSNumber *totalSize = [NSNumber numberWithInt:-1];
-    if(fsAttributes) {
-        freeSize = fsAttributes[NSFileSystemFreeSize];
-        totalSize = fsAttributes[NSFileSystemSize];
+    if (fsAttributes) {
+      freeSize = fsAttributes[NSFileSystemFreeSize];
+      totalSize = fsAttributes[NSFileSystemSize];
     }
 
     NSString *machine;
@@ -48,7 +50,8 @@
     }
     deviceName = [DeviceIdentifiers userKnownDeviceModel:machine];
 
-    NSNumber *physicalRamSize = @([NSProcessInfo processInfo].physicalMemory / 1048576); // Mb
+    NSNumber *physicalRamSize =
+        @([NSProcessInfo processInfo].physicalMemory / 1048576); // Mb
     NSNumber *availableRamSize = @([self availableMemoryInbMB]);
 
     result(@{
@@ -81,20 +84,22 @@
 
 // Return available memory in megabytes
 - (int)availableMemoryInbMB {
-    mach_port_t host_port = mach_host_self();
-    mach_msg_type_number_t host_size = sizeof(vm_statistics_data_t) / sizeof(integer_t);
+  mach_port_t host_port = mach_host_self();
+  mach_msg_type_number_t host_size =
+      sizeof(vm_statistics_data_t) / sizeof(integer_t);
 
-    vm_size_t page_size;
-    host_page_size(host_port, &page_size);
+  vm_size_t page_size;
+  host_page_size(host_port, &page_size);
 
-    vm_statistics_data_t vm_stat;
-    if (host_statistics(host_port, HOST_VM_INFO, (host_info_t)&vm_stat, &host_size) != KERN_SUCCESS) {
-        // Failed to fetch vm statistics
-        return -1;
-    }
+  vm_statistics_data_t vm_stat;
+  if (host_statistics(host_port, HOST_VM_INFO, (host_info_t)&vm_stat,
+                      &host_size) != KERN_SUCCESS) {
+    // Failed to fetch vm statistics
+    return -1;
+  }
 
-    natural_t mem_free = vm_stat.free_count * page_size;
-    return mem_free / 1048576;
+  natural_t mem_free = vm_stat.free_count * page_size;
+  return mem_free / 1048576;
 }
 
 // Return value is false if code is run on a simulator

--- a/packages/network_info_plus/network_info_plus/ios/network_info_plus/Sources/network_info_plus/FPPNetworkInfoPlusPlugin.m
+++ b/packages/network_info_plus/network_info_plus/ios/network_info_plus/Sources/network_info_plus/FPPNetworkInfoPlusPlugin.m
@@ -8,8 +8,8 @@
 #import "./include/network_info_plus/FPPHotspotNetworkInfoProvider.h"
 #import "./include/network_info_plus/FPPNetworkInfo.h"
 #import "./include/network_info_plus/FPPNetworkInfoProvider.h"
-#import "SystemConfiguration/CaptiveNetwork.h"
 #import "./include/network_info_plus/getgateway.h"
+#import "SystemConfiguration/CaptiveNetwork.h"
 #import <CoreLocation/CoreLocation.h>
 
 #include <ifaddrs.h>
@@ -69,7 +69,8 @@
   __block NSString *addr = nil;
   [self enumerateWifiAddresses:AF_INET
                     usingBlock:^(struct ifaddrs *ifaddr) {
-                      if (addr) return;
+                      if (addr)
+                        return;
                       addr = [self descriptionForAddress:ifaddr->ifa_addr];
                     }];
   return addr;
@@ -79,7 +80,8 @@
   __block NSString *addr = nil;
   [self enumerateWifiAddresses:AF_INET6
                     usingBlock:^(struct ifaddrs *ifaddr) {
-                      if (addr) return;
+                      if (addr)
+                        return;
                       addr = [self descriptionForAddress:ifaddr->ifa_addr];
                     }];
   return addr;
@@ -89,7 +91,8 @@
   __block NSString *addr = nil;
   [self enumerateWifiAddresses:AF_INET
                     usingBlock:^(struct ifaddrs *ifaddr) {
-                      if (addr) return;
+                      if (addr)
+                        return;
                       addr = [self descriptionForAddress:ifaddr->ifa_netmask];
                     }];
   return addr;
@@ -99,7 +102,8 @@
   __block NSString *addr = nil;
   [self enumerateWifiAddresses:AF_INET
                     usingBlock:^(struct ifaddrs *ifaddr) {
-                      if (addr) return;
+                      if (addr)
+                        return;
                       addr = [self descriptionForAddress:ifaddr->ifa_dstaddr];
                     }];
   return addr;
@@ -143,21 +147,21 @@
   // retrieve the current interfaces - returns 0 on success
   success = getifaddrs(&interfaces);
   if (success != 0) {
-      NSLog(@"Error: getifaddrs() failed with error code: %d", success);
-      return;
+    NSLog(@"Error: getifaddrs() failed with error code: %d", success);
+    return;
   }
 
   // Loop through linked list of interfaces
   temp_addr = interfaces;
   while (temp_addr != NULL) {
-      if (temp_addr->ifa_addr->sa_family == family) {
-          // One of `en` interfaces should be WiFi interface
-          if (strncmp(temp_addr->ifa_name, "en", 2) == 0) {
-              block(temp_addr);
-          }
+    if (temp_addr->ifa_addr->sa_family == family) {
+      // One of `en` interfaces should be WiFi interface
+      if (strncmp(temp_addr->ifa_name, "en", 2) == 0) {
+        block(temp_addr);
       }
+    }
 
-      temp_addr = temp_addr->ifa_next;
+    temp_addr = temp_addr->ifa_next;
   }
 
   // Free memory

--- a/packages/package_info_plus/package_info_plus/ios/package_info_plus/Sources/package_info_plus/FPPPackageInfoPlusPlugin.m
+++ b/packages/package_info_plus/package_info_plus/ios/package_info_plus/Sources/package_info_plus/FPPPackageInfoPlusPlugin.m
@@ -53,36 +53,42 @@
 }
 
 - (NSDate *)getInstallDate {
-    NSURL* urlToDocumentsFolder = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
-    __autoreleasing NSError *error;
-    NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:urlToDocumentsFolder.path error:&error];
+  NSURL *urlToDocumentsFolder = [[[NSFileManager defaultManager]
+      URLsForDirectory:NSDocumentDirectory
+             inDomains:NSUserDomainMask] lastObject];
+  __autoreleasing NSError *error;
+  NSDictionary *attributes = [[NSFileManager defaultManager]
+      attributesOfItemAtPath:urlToDocumentsFolder.path
+                       error:&error];
 
-    if (error) {
-        return nil;
-    }
+  if (error) {
+    return nil;
+  }
 
-    return [attributes objectForKey:NSFileCreationDate];
+  return [attributes objectForKey:NSFileCreationDate];
 }
 
 - (NSDate *)getUpdateDate {
-    __autoreleasing NSError *error;
-    NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[[NSBundle mainBundle] bundlePath] error:&error];
-    NSDate *updateDate = [attributes fileModificationDate];
+  __autoreleasing NSError *error;
+  NSDictionary *attributes = [[NSFileManager defaultManager]
+      attributesOfItemAtPath:[[NSBundle mainBundle] bundlePath]
+                       error:&error];
+  NSDate *updateDate = [attributes fileModificationDate];
 
-    if (error) {
-        return nil;
-    }
+  if (error) {
+    return nil;
+  }
 
-    return updateDate;
+  return updateDate;
 }
 
 - (NSString *)getTimeMillisStringFromDate:(NSDate *)date {
-    if (!date) {
-        return nil;
-    }
+  if (!date) {
+    return nil;
+  }
 
-    NSNumber *timeMillis = @((long long)([date timeIntervalSince1970] * 1000));
-    return [timeMillis stringValue];
+  NSNumber *timeMillis = @((long long)([date timeIntervalSince1970] * 1000));
+  return [timeMillis stringValue];
 }
 
 @end

--- a/packages/package_info_plus/package_info_plus/macos/package_info_plus/Sources/package_info_plus/FPPPackageInfoPlusPlugin.m
+++ b/packages/package_info_plus/package_info_plus/macos/package_info_plus/Sources/package_info_plus/FPPPackageInfoPlusPlugin.m
@@ -16,9 +16,11 @@
 - (void)handleMethodCall:(FlutterMethodCall *)call
                   result:(FlutterResult)result {
   if ([call.method isEqualToString:@"getAll"]) {
-    NSString *installDateStr = [self getTimeMillisStringFromDate:[self getInstallDate]];
-    NSString *updateDateStr = [self getTimeMillisStringFromDate:[self getUpdateDate]];
-    
+    NSString *installDateStr =
+        [self getTimeMillisStringFromDate:[self getInstallDate]];
+    NSString *updateDateStr =
+        [self getTimeMillisStringFromDate:[self getUpdateDate]];
+
     result(@{
       @"appName" : [[NSBundle mainBundle]
           objectForInfoDictionaryKey:@"CFBundleDisplayName"]
@@ -42,45 +44,52 @@
 }
 
 - (NSDate *)getInstallDate {
-    if (![self isRunningInSandbox]) {
-        return nil;
-    }
+  if (![self isRunningInSandbox]) {
+    return nil;
+  }
 
-    NSURL* urlToDocumentsFolder = [[[NSFileManager defaultManager] URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] lastObject];
-    __autoreleasing NSError *error;
-    NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:urlToDocumentsFolder.path error:&error];
+  NSURL *urlToDocumentsFolder = [[[NSFileManager defaultManager]
+      URLsForDirectory:NSDocumentDirectory
+             inDomains:NSUserDomainMask] lastObject];
+  __autoreleasing NSError *error;
+  NSDictionary *attributes = [[NSFileManager defaultManager]
+      attributesOfItemAtPath:urlToDocumentsFolder.path
+                       error:&error];
 
-    if (error) {
-        return nil;
-    }
+  if (error) {
+    return nil;
+  }
 
-    return [attributes objectForKey:NSFileCreationDate];
+  return [attributes objectForKey:NSFileCreationDate];
 }
 
 - (NSDate *)getUpdateDate {
-    __autoreleasing NSError *error;
-    NSDictionary *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:[[NSBundle mainBundle] bundlePath] error:&error];
-    NSDate *updateDate = [attributes fileModificationDate];
+  __autoreleasing NSError *error;
+  NSDictionary *attributes = [[NSFileManager defaultManager]
+      attributesOfItemAtPath:[[NSBundle mainBundle] bundlePath]
+                       error:&error];
+  NSDate *updateDate = [attributes fileModificationDate];
 
-    if (error) {
-        return nil;
-    }
+  if (error) {
+    return nil;
+  }
 
-    return updateDate;
+  return updateDate;
 }
 
 - (NSString *)getTimeMillisStringFromDate:(NSDate *)date {
-    if (!date) {
-        return nil;
-    }
+  if (!date) {
+    return nil;
+  }
 
-    NSNumber *timeMillis = @((long long)([date timeIntervalSince1970] * 1000));
-    return [timeMillis stringValue];
+  NSNumber *timeMillis = @((long long)([date timeIntervalSince1970] * 1000));
+  return [timeMillis stringValue];
 }
 
 - (BOOL)isRunningInSandbox {
-    NSString *sandboxContainerId = [[[NSProcessInfo processInfo] environment] objectForKey:@"APP_SANDBOX_CONTAINER_ID"];
-    return sandboxContainerId != nil;
+  NSString *sandboxContainerId = [[[NSProcessInfo processInfo] environment]
+      objectForKey:@"APP_SANDBOX_CONTAINER_ID"];
+  return sandboxContainerId != nil;
 }
 
 @end

--- a/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
@@ -421,10 +421,12 @@ activityTypesForStrings(NSArray<NSString *> *activityTypeStrings) {
       CGRectContainsRect(controller.view.frame, origin);
 
   // Check if this is actually an iPad
-  BOOL isIpad = ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad);
+  BOOL isIpad =
+      ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad);
 
-  // Before Xcode 26 hasPopoverPresentationController is true for iPads and false for iPhones.
-  // Since Xcode 26 is true both for iPads and iPhones, so additional check was added above.
+  // Before Xcode 26 hasPopoverPresentationController is true for iPads and
+  // false for iPhones. Since Xcode 26 is true both for iPads and iPhones, so
+  // additional check was added above.
   BOOL hasPopoverPresentationController =
       [activityViewController popoverPresentationController] != NULL;
   if (isIpad && hasPopoverPresentationController &&

--- a/packages/share_plus/share_plus/windows/share_plus_plugin.cpp
+++ b/packages/share_plus/share_plus/windows/share_plus_plugin.cpp
@@ -8,459 +8,392 @@
 
 #include "vector.h"
 
-namespace share_plus_windows
-{
+namespace share_plus_windows {
 
-  void SharePlusWindowsPlugin::RegisterWithRegistrar(
-      flutter::PluginRegistrarWindows *registrar)
-  {
-    auto channel =
-        std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
-            registrar->messenger(), kSharePlusChannelName,
-            &flutter::StandardMethodCodec::GetInstance());
-    auto plugin = std::make_unique<SharePlusWindowsPlugin>(registrar);
-    channel->SetMethodCallHandler(
-        [plugin_pointer = plugin.get()](const auto &call, auto result)
-        {
-          plugin_pointer->HandleMethodCall(call, std::move(result));
+void SharePlusWindowsPlugin::RegisterWithRegistrar(
+    flutter::PluginRegistrarWindows *registrar) {
+  auto channel =
+      std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+          registrar->messenger(), kSharePlusChannelName,
+          &flutter::StandardMethodCodec::GetInstance());
+  auto plugin = std::make_unique<SharePlusWindowsPlugin>(registrar);
+  channel->SetMethodCallHandler(
+      [plugin_pointer = plugin.get()](const auto &call, auto result) {
+        plugin_pointer->HandleMethodCall(call, std::move(result));
+      });
+
+  registrar->AddPlugin(std::move(plugin));
+}
+
+SharePlusWindowsPlugin::SharePlusWindowsPlugin(
+    flutter::PluginRegistrarWindows *registrar)
+    : registrar_(registrar) {}
+
+SharePlusWindowsPlugin::~SharePlusWindowsPlugin() {
+  if (data_transfer_manager_ != nullptr) {
+    data_transfer_manager_->remove_DataRequested(data_transfer_manager_token_);
+    data_transfer_manager_.Reset();
+  }
+  if (data_transfer_manager_interop_ != nullptr) {
+    data_transfer_manager_interop_.Reset();
+  }
+}
+
+HWND SharePlusWindowsPlugin::GetWindow() {
+  return ::GetAncestor(registrar_->GetView()->GetNativeWindow(), GA_ROOT);
+}
+
+WRL::ComPtr<DataTransfer::IDataTransferManager>
+SharePlusWindowsPlugin::GetDataTransferManager() {
+  using Microsoft::WRL::Wrappers::HStringReference;
+  HRESULT hr = ::RoGetActivationFactory(
+      HStringReference(
+          RuntimeClass_Windows_ApplicationModel_DataTransfer_DataTransferManager)
+          .Get(),
+      IID_PPV_ARGS(&data_transfer_manager_interop_));
+
+  if (SUCCEEDED(hr) && data_transfer_manager_interop_) {
+    hr = data_transfer_manager_interop_->GetForWindow(
+        GetWindow(), IID_PPV_ARGS(&data_transfer_manager_));
+  }
+
+  return data_transfer_manager_;
+}
+
+bool SharePlusWindowsPlugin::IsApplicationDataPath(const std::wstring &path,
+                                                   std::wstring &relative_path,
+                                                   int &folder_type) {
+
+  std::wstring lower_path = path;
+  std::transform(lower_path.begin(), lower_path.end(), lower_path.begin(),
+                 ::towlower);
+
+  const std::wstring packages_marker = L"\\appdata\\local\\packages\\";
+  const std::wstring local_marker = L"\\local\\";
+  const std::wstring localcache_marker = L"\\localcache\\";
+  const std::wstring temp_marker = L"\\temp\\";
+  const std::wstring roamingstate_marker = L"\\roamingstate\\";
+
+  size_t pos = lower_path.find(packages_marker);
+  if (pos != std::wstring::npos) {
+
+    size_t after_packages = pos + packages_marker.length();
+
+    size_t package_end = lower_path.find(L'\\', after_packages);
+    if (package_end != std::wstring::npos) {
+      std::wstring remainder = lower_path.substr(package_end);
+
+      if (remainder.find(localcache_marker) != std::wstring::npos) {
+        size_t temp_pos = remainder.find(temp_marker);
+        if (temp_pos != std::wstring::npos) {
+          folder_type = 2;
+          relative_path =
+              path.substr(package_end + temp_pos + temp_marker.length());
+          return true;
+        }
+
+        folder_type = 1;
+        size_t localcache_pos = remainder.find(localcache_marker);
+        relative_path = path.substr(package_end + localcache_pos +
+                                    localcache_marker.length());
+        return true;
+      }
+
+      if (remainder.find(roamingstate_marker) != std::wstring::npos) {
+        folder_type = 3;
+        size_t roaming_pos = remainder.find(roamingstate_marker);
+        relative_path = path.substr(package_end + roaming_pos +
+                                    roamingstate_marker.length());
+        return true;
+      }
+
+      if (remainder.find(local_marker) != std::wstring::npos) {
+        size_t local_pos = remainder.find(local_marker);
+
+        if (remainder.substr(local_pos, localcache_marker.length()) !=
+            localcache_marker) {
+          folder_type = 0;
+          relative_path =
+              path.substr(package_end + local_pos + local_marker.length());
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
+HRESULT SharePlusWindowsPlugin::GetStorageFileFromApplicationData(
+    const std::wstring &path, WindowsStorage::IStorageFile **file) {
+  using Microsoft::WRL::Wrappers::HStringReference;
+
+  std::wstring relative_path;
+  int folder_type;
+
+  if (!IsApplicationDataPath(path, relative_path, folder_type)) {
+    return E_INVALIDARG;
+  }
+
+  HRESULT hr = S_OK;
+  *file = nullptr;
+
+  WRL::ComPtr<WindowsStorage::IApplicationDataStatics> app_data_statics;
+  hr = WindowsFoundation::GetActivationFactory(
+      HStringReference(RuntimeClass_Windows_Storage_ApplicationData).Get(),
+      &app_data_statics);
+
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  WRL::ComPtr<WindowsStorage::IApplicationData> app_data;
+  hr = app_data_statics->get_Current(&app_data);
+
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  WRL::ComPtr<WindowsStorage::IStorageFolder> folder;
+  switch (folder_type) {
+  case 0:
+    hr = app_data->get_LocalFolder(&folder);
+    break;
+  case 1: {
+    WRL::ComPtr<WindowsStorage::IApplicationData2> app_data2;
+    hr = app_data.As(&app_data2);
+    if (SUCCEEDED(hr)) {
+      hr = app_data2->get_LocalCacheFolder(&folder);
+    }
+  } break;
+  case 2:
+    hr = app_data->get_TemporaryFolder(&folder);
+    break;
+  case 3:
+    hr = app_data->get_RoamingFolder(&folder);
+    break;
+  default:
+    return E_INVALIDARG;
+  }
+
+  if (FAILED(hr) || !folder) {
+    return hr;
+  }
+
+  WRL::ComPtr<WindowsFoundation::IAsyncOperation<WindowsStorage::StorageFile *>>
+      async_operation;
+  hr = folder->GetFileAsync(HStringReference(relative_path.c_str()).Get(),
+                            &async_operation);
+
+  if (SUCCEEDED(hr)) {
+    WRL::ComPtr<IAsyncInfo> info;
+    hr = async_operation.As(&info);
+    if (SUCCEEDED(hr)) {
+      AsyncStatus status;
+      while (SUCCEEDED(hr = info->get_Status(&status)) &&
+             status == AsyncStatus::Started)
+        SleepEx(0, TRUE);
+      if (FAILED(hr) || status != AsyncStatus::Completed) {
+        info->get_ErrorCode(&hr);
+      } else {
+        hr = async_operation->GetResults(file);
+      }
+    }
+  }
+
+  return hr;
+}
+
+HRESULT SharePlusWindowsPlugin::GetStorageFileFromPath(
+    wchar_t *path, WindowsStorage::IStorageFile **file) {
+  using Microsoft::WRL::Wrappers::HStringReference;
+
+  if (path == nullptr || file == nullptr) {
+    return E_POINTER;
+  }
+
+  *file = nullptr;
+  std::wstring path_wstr(path);
+
+  // Normalize path (Convert forward slashes to backslashes for Windows)
+  std::replace(path_wstr.begin(), path_wstr.end(), L'/', L'\\');
+
+  std::wstring relative_path;
+  int folder_type;
+  if (IsApplicationDataPath(path_wstr, relative_path, folder_type)) {
+    HRESULT hr = GetStorageFileFromApplicationData(path_wstr, file);
+    if (SUCCEEDED(hr) && *file != nullptr) {
+      return hr;
+    }
+  }
+
+  WRL::ComPtr<WindowsStorage::IStorageFileStatics> factory = nullptr;
+  HRESULT hr = WindowsFoundation::GetActivationFactory(
+      HStringReference(RuntimeClass_Windows_Storage_StorageFile).Get(),
+      &factory);
+
+  if (FAILED(hr)) {
+    return hr;
+  }
+
+  WRL::ComPtr<WindowsFoundation::IAsyncOperation<WindowsStorage::StorageFile *>>
+      async_operation;
+  hr = factory->GetFileFromPathAsync(HStringReference(path_wstr.c_str()).Get(),
+                                     &async_operation);
+  if (SUCCEEDED(hr)) {
+    WRL::ComPtr<IAsyncInfo> info;
+    hr = async_operation.As(&info);
+    if (SUCCEEDED(hr)) {
+      AsyncStatus status;
+      while (SUCCEEDED(hr = info->get_Status(&status)) &&
+             status == AsyncStatus::Started)
+        SleepEx(0, TRUE);
+      if (FAILED(hr) || status != AsyncStatus::Completed) {
+        info->get_ErrorCode(&hr);
+      } else {
+        hr = async_operation->GetResults(file);
+      }
+    }
+  }
+  return hr;
+}
+
+void SharePlusWindowsPlugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue> &method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+
+  if (method_call.method_name().compare(kShare) == 0) {
+    auto data_transfer_manager = GetDataTransferManager();
+
+    if (!data_transfer_manager) {
+      result->Error("UNAVAILABLE", "Data transfer manager not available");
+      return;
+    }
+
+    auto args = std::get<flutter::EncodableMap>(*method_call.arguments());
+
+    if (auto text_value =
+            std::get_if<std::string>(&args[flutter::EncodableValue("text")])) {
+      share_text_ = *text_value;
+    }
+    if (auto subject_value = std::get_if<std::string>(
+            &args[flutter::EncodableValue("subject")])) {
+      share_subject_ = *subject_value;
+    }
+    if (auto uri_value =
+            std::get_if<std::string>(&args[flutter::EncodableValue("uri")])) {
+      share_uri_ = *uri_value;
+    }
+    if (auto title_value =
+            std::get_if<std::string>(&args[flutter::EncodableValue("title")])) {
+      share_title_ = *title_value;
+    }
+    if (auto paths = std::get_if<flutter::EncodableList>(
+            &args[flutter::EncodableValue("paths")])) {
+      paths_.clear();
+      for (auto &path : *paths) {
+        paths_.emplace_back(std::get<std::string>(path));
+      }
+    }
+    if (auto mime_types = std::get_if<flutter::EncodableList>(
+            &args[flutter::EncodableValue("mimeTypes")])) {
+      mime_types_.clear();
+      for (auto &mime_type : *mime_types) {
+        mime_types_.emplace_back(std::get<std::string>(mime_type));
+      }
+    }
+
+    // Create the share callback
+    auto callback = WRL::Callback<WindowsFoundation::ITypedEventHandler<
+        DataTransfer::DataTransferManager *,
+        DataTransfer::DataRequestedEventArgs *>>(
+        [&](auto &&, DataTransfer::IDataRequestedEventArgs *e) {
+          using Microsoft::WRL::Wrappers::HStringReference;
+          WRL::ComPtr<DataTransfer::IDataRequest> request;
+          e->get_Request(&request);
+          WRL::ComPtr<DataTransfer::IDataPackage> data;
+          request->get_Data(&data);
+          WRL::ComPtr<DataTransfer::IDataPackagePropertySet> properties;
+          data->get_Properties(&properties);
+
+          // Set the title of the share dialog
+          // Prefer the title, then the subject, then the text
+          // Setting a title is mandatory for Windows
+          if (share_title_ && !share_title_.value_or("").empty()) {
+            auto title = Utf16FromUtf8(share_title_.value_or(""));
+            properties->put_Title(HStringReference(title.c_str()).Get());
+          } else if (share_subject_ && !share_subject_.value_or("").empty()) {
+            auto title = Utf16FromUtf8(share_subject_.value_or(""));
+            properties->put_Title(HStringReference(title.c_str()).Get());
+          } else {
+            auto title = Utf16FromUtf8(share_text_.value_or(""));
+            properties->put_Title(HStringReference(title.c_str()).Get());
+          }
+
+          // Set the text of the share dialog
+          if (share_text_ && !share_text_.value_or("").empty()) {
+            auto text = Utf16FromUtf8(share_text_.value_or(""));
+            properties->put_Description(HStringReference(text.c_str()).Get());
+            data->SetText(HStringReference(text.c_str()).Get());
+          }
+
+          // If URI provided, set the URI to share
+          if (share_uri_ && !share_uri_.value_or("").empty()) {
+            auto uri = Utf16FromUtf8(share_uri_.value_or(""));
+            properties->put_Description(HStringReference(uri.c_str()).Get());
+            data->SetText(HStringReference(uri.c_str()).Get());
+          }
+
+          // Add files to the data.
+          Vector<WindowsStorage::IStorageItem *> storage_items;
+          for (const std::string &path : paths_) {
+            auto str = Utf16FromUtf8(path);
+            wchar_t *ptr = const_cast<wchar_t *>(str.c_str());
+            WindowsStorage::IStorageFile *file = nullptr;
+            if (SUCCEEDED(GetStorageFileFromPath(ptr, &file)) &&
+                file != nullptr) {
+              storage_items.Append(
+                  reinterpret_cast<WindowsStorage::IStorageItem *>(file));
+            }
+          }
+          data->SetStorageItemsReadOnly(&storage_items);
+
+          return S_OK;
         });
 
-    registrar->AddPlugin(std::move(plugin));
+    // Add the callback to the data transfer manager
+    data_transfer_manager->add_DataRequested(callback.Get(),
+                                             &data_transfer_manager_token_);
+    if (data_transfer_manager_interop_ != nullptr) {
+      data_transfer_manager_interop_->ShowShareUIForWindow(GetWindow());
+    }
+    result->Success(flutter::EncodableValue(kShareResultUnavailable));
+  } else {
+    result->NotImplemented();
+  }
+}
+
+// Converts string encoded in UTF-8 to wstring.
+// Returns an empty |std::wstring| on failure.
+// Present as static helper method.
+std::wstring SharePlusWindowsPlugin::Utf16FromUtf8(std::string string) {
+  if (string.empty()) {
+    return std::wstring();
   }
 
-  SharePlusWindowsPlugin::SharePlusWindowsPlugin(
-      flutter::PluginRegistrarWindows *registrar)
-      : registrar_(registrar) {}
-
-  SharePlusWindowsPlugin::~SharePlusWindowsPlugin()
-  {
-    if (data_transfer_manager_ != nullptr)
-    {
-      data_transfer_manager_->remove_DataRequested(data_transfer_manager_token_);
-      data_transfer_manager_.Reset();
-    }
-    if (data_transfer_manager_interop_ != nullptr)
-    {
-      data_transfer_manager_interop_.Reset();
-    }
+  int size_needed =
+      MultiByteToWideChar(CP_UTF8, 0, string.c_str(), -1, NULL, 0);
+  if (size_needed <= 0) {
+    return std::wstring();
   }
 
-  HWND SharePlusWindowsPlugin::GetWindow()
-  {
-    return ::GetAncestor(registrar_->GetView()->GetNativeWindow(), GA_ROOT);
+  std::wstring result(size_needed - 1, 0);
+  int converted_length = MultiByteToWideChar(CP_UTF8, 0, string.c_str(), -1,
+                                             &result[0], size_needed);
+  if (converted_length == 0) {
+    return std::wstring();
   }
-
-  WRL::ComPtr<DataTransfer::IDataTransferManager>
-  SharePlusWindowsPlugin::GetDataTransferManager()
-  {
-    using Microsoft::WRL::Wrappers::HStringReference;
-    HRESULT hr = ::RoGetActivationFactory(
-        HStringReference(
-            RuntimeClass_Windows_ApplicationModel_DataTransfer_DataTransferManager)
-            .Get(),
-        IID_PPV_ARGS(&data_transfer_manager_interop_));
-
-    if (SUCCEEDED(hr) && data_transfer_manager_interop_)
-    {
-      hr = data_transfer_manager_interop_->GetForWindow(
-          GetWindow(), IID_PPV_ARGS(&data_transfer_manager_));
-    }
-
-    return data_transfer_manager_;
-  }
-
-  bool SharePlusWindowsPlugin::IsApplicationDataPath(const std::wstring &path,
-                                                     std::wstring &relative_path,
-                                                     int &folder_type)
-  {
-
-    std::wstring lower_path = path;
-    std::transform(lower_path.begin(), lower_path.end(), lower_path.begin(),
-                   ::towlower);
-
-    const std::wstring packages_marker = L"\\appdata\\local\\packages\\";
-    const std::wstring local_marker = L"\\local\\";
-    const std::wstring localcache_marker = L"\\localcache\\";
-    const std::wstring temp_marker = L"\\temp\\";
-    const std::wstring roamingstate_marker = L"\\roamingstate\\";
-
-    size_t pos = lower_path.find(packages_marker);
-    if (pos != std::wstring::npos)
-    {
-
-      size_t after_packages = pos + packages_marker.length();
-
-      size_t package_end = lower_path.find(L'\\', after_packages);
-      if (package_end != std::wstring::npos)
-      {
-        std::wstring remainder = lower_path.substr(package_end);
-
-        if (remainder.find(localcache_marker) != std::wstring::npos)
-        {
-          size_t temp_pos = remainder.find(temp_marker);
-          if (temp_pos != std::wstring::npos)
-          {
-            folder_type = 2;
-            relative_path = path.substr(package_end + temp_pos + temp_marker.length());
-            return true;
-          }
-
-          folder_type = 1;
-          size_t localcache_pos = remainder.find(localcache_marker);
-          relative_path = path.substr(package_end + localcache_pos + localcache_marker.length());
-          return true;
-        }
-
-        if (remainder.find(roamingstate_marker) != std::wstring::npos)
-        {
-          folder_type = 3;
-          size_t roaming_pos = remainder.find(roamingstate_marker);
-          relative_path = path.substr(package_end + roaming_pos + roamingstate_marker.length());
-          return true;
-        }
-
-        if (remainder.find(local_marker) != std::wstring::npos)
-        {
-          size_t local_pos = remainder.find(local_marker);
-
-          if (remainder.substr(local_pos, localcache_marker.length()) != localcache_marker)
-          {
-            folder_type = 0;
-            relative_path = path.substr(package_end + local_pos + local_marker.length());
-            return true;
-          }
-        }
-      }
-    }
-
-    return false;
-  }
-
-  HRESULT SharePlusWindowsPlugin::GetStorageFileFromApplicationData(
-      const std::wstring &path, WindowsStorage::IStorageFile **file)
-  {
-    using Microsoft::WRL::Wrappers::HStringReference;
-
-    std::wstring relative_path;
-    int folder_type;
-
-    if (!IsApplicationDataPath(path, relative_path, folder_type))
-    {
-      return E_INVALIDARG;
-    }
-
-    HRESULT hr = S_OK;
-    *file = nullptr;
-
-    WRL::ComPtr<WindowsStorage::IApplicationDataStatics> app_data_statics;
-    hr = WindowsFoundation::GetActivationFactory(
-        HStringReference(RuntimeClass_Windows_Storage_ApplicationData).Get(),
-        &app_data_statics);
-
-    if (FAILED(hr))
-    {
-      return hr;
-    }
-
-    WRL::ComPtr<WindowsStorage::IApplicationData> app_data;
-    hr = app_data_statics->get_Current(&app_data);
-
-    if (FAILED(hr))
-    {
-      return hr;
-    }
-
-    WRL::ComPtr<WindowsStorage::IStorageFolder> folder;
-    switch (folder_type)
-    {
-    case 0:
-      hr = app_data->get_LocalFolder(&folder);
-      break;
-    case 1:
-    {
-      WRL::ComPtr<WindowsStorage::IApplicationData2> app_data2;
-      hr = app_data.As(&app_data2);
-      if (SUCCEEDED(hr))
-      {
-        hr = app_data2->get_LocalCacheFolder(&folder);
-      }
-    }
-    break;
-    case 2:
-      hr = app_data->get_TemporaryFolder(&folder);
-      break;
-    case 3:
-      hr = app_data->get_RoamingFolder(&folder);
-      break;
-    default:
-      return E_INVALIDARG;
-    }
-
-    if (FAILED(hr) || !folder)
-    {
-      return hr;
-    }
-
-    WRL::ComPtr<WindowsFoundation::IAsyncOperation<WindowsStorage::StorageFile *>>
-        async_operation;
-    hr = folder->GetFileAsync(HStringReference(relative_path.c_str()).Get(),
-                              &async_operation);
-
-    if (SUCCEEDED(hr))
-    {
-      WRL::ComPtr<IAsyncInfo> info;
-      hr = async_operation.As(&info);
-      if (SUCCEEDED(hr))
-      {
-        AsyncStatus status;
-        while (SUCCEEDED(hr = info->get_Status(&status)) &&
-               status == AsyncStatus::Started)
-          SleepEx(0, TRUE);
-        if (FAILED(hr) || status != AsyncStatus::Completed)
-        {
-          info->get_ErrorCode(&hr);
-        }
-        else
-        {
-          hr = async_operation->GetResults(file);
-        }
-      }
-    }
-
-    return hr;
-  }
-
-  HRESULT SharePlusWindowsPlugin::GetStorageFileFromPath(
-      wchar_t *path, WindowsStorage::IStorageFile **file)
-  {
-    using Microsoft::WRL::Wrappers::HStringReference;
-
-    if (path == nullptr || file == nullptr)
-    {
-      return E_POINTER;
-    }
-
-    *file = nullptr;
-    std::wstring path_wstr(path);
-
-    // Normalize path (Convert forward slashes to backslashes for Windows)
-    std::replace(path_wstr.begin(), path_wstr.end(), L'/', L'\\');
-
-    std::wstring relative_path;
-    int folder_type;
-    if (IsApplicationDataPath(path_wstr, relative_path, folder_type))
-    {
-      HRESULT hr = GetStorageFileFromApplicationData(path_wstr, file);
-      if (SUCCEEDED(hr) && *file != nullptr)
-      {
-        return hr;
-      }
-    }
-
-    WRL::ComPtr<WindowsStorage::IStorageFileStatics> factory = nullptr;
-    HRESULT hr = WindowsFoundation::GetActivationFactory(
-        HStringReference(RuntimeClass_Windows_Storage_StorageFile).Get(),
-        &factory);
-
-    if (FAILED(hr))
-    {
-      return hr;
-    }
-
-    WRL::ComPtr<
-        WindowsFoundation::IAsyncOperation<WindowsStorage::StorageFile *>>
-        async_operation;
-    hr = factory->GetFileFromPathAsync(HStringReference(path_wstr.c_str()).Get(),
-                                       &async_operation);
-    if (SUCCEEDED(hr))
-    {
-      WRL::ComPtr<IAsyncInfo> info;
-      hr = async_operation.As(&info);
-      if (SUCCEEDED(hr))
-      {
-        AsyncStatus status;
-        while (SUCCEEDED(hr = info->get_Status(&status)) &&
-               status == AsyncStatus::Started)
-          SleepEx(0, TRUE);
-        if (FAILED(hr) || status != AsyncStatus::Completed)
-        {
-          info->get_ErrorCode(&hr);
-        }
-        else
-        {
-          hr = async_operation->GetResults(file);
-        }
-      }
-    }
-    return hr;
-  }
-
-  void SharePlusWindowsPlugin::HandleMethodCall(
-      const flutter::MethodCall<flutter::EncodableValue> &method_call,
-      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result)
-  {
-
-    if (method_call.method_name().compare(kShare) == 0)
-    {
-      auto data_transfer_manager = GetDataTransferManager();
-
-      if (!data_transfer_manager)
-      {
-        result->Error("UNAVAILABLE", "Data transfer manager not available");
-        return;
-      }
-
-      auto args = std::get<flutter::EncodableMap>(*method_call.arguments());
-
-      if (auto text_value = std::get_if<std::string>(
-              &args[flutter::EncodableValue("text")]))
-      {
-        share_text_ = *text_value;
-      }
-      if (auto subject_value = std::get_if<std::string>(
-              &args[flutter::EncodableValue("subject")]))
-      {
-        share_subject_ = *subject_value;
-      }
-      if (auto uri_value = std::get_if<std::string>(
-              &args[flutter::EncodableValue("uri")]))
-      {
-        share_uri_ = *uri_value;
-      }
-      if (auto title_value = std::get_if<std::string>(
-              &args[flutter::EncodableValue("title")]))
-      {
-        share_title_ = *title_value;
-      }
-      if (auto paths = std::get_if<flutter::EncodableList>(
-              &args[flutter::EncodableValue("paths")]))
-      {
-        paths_.clear();
-        for (auto &path : *paths)
-        {
-          paths_.emplace_back(std::get<std::string>(path));
-        }
-      }
-      if (auto mime_types = std::get_if<flutter::EncodableList>(
-              &args[flutter::EncodableValue("mimeTypes")]))
-      {
-        mime_types_.clear();
-        for (auto &mime_type : *mime_types)
-        {
-          mime_types_.emplace_back(std::get<std::string>(mime_type));
-        }
-      }
-
-      // Create the share callback
-      auto callback = WRL::Callback<WindowsFoundation::ITypedEventHandler<
-          DataTransfer::DataTransferManager *,
-          DataTransfer::DataRequestedEventArgs *>>(
-          [&](auto &&, DataTransfer::IDataRequestedEventArgs *e)
-          {
-            using Microsoft::WRL::Wrappers::HStringReference;
-            WRL::ComPtr<DataTransfer::IDataRequest> request;
-            e->get_Request(&request);
-            WRL::ComPtr<DataTransfer::IDataPackage> data;
-            request->get_Data(&data);
-            WRL::ComPtr<DataTransfer::IDataPackagePropertySet> properties;
-            data->get_Properties(&properties);
-
-            // Set the title of the share dialog
-            // Prefer the title, then the subject, then the text
-            // Setting a title is mandatory for Windows
-            if (share_title_ && !share_title_.value_or("").empty())
-            {
-              auto title = Utf16FromUtf8(share_title_.value_or(""));
-              properties->put_Title(HStringReference(title.c_str()).Get());
-            }
-            else if (share_subject_ && !share_subject_.value_or("").empty())
-            {
-              auto title = Utf16FromUtf8(share_subject_.value_or(""));
-              properties->put_Title(HStringReference(title.c_str()).Get());
-            }
-            else
-            {
-              auto title = Utf16FromUtf8(share_text_.value_or(""));
-              properties->put_Title(HStringReference(title.c_str()).Get());
-            }
-
-            // Set the text of the share dialog
-            if (share_text_ && !share_text_.value_or("").empty())
-            {
-              auto text = Utf16FromUtf8(share_text_.value_or(""));
-              properties->put_Description(
-                  HStringReference(text.c_str()).Get());
-              data->SetText(HStringReference(text.c_str()).Get());
-            }
-
-            // If URI provided, set the URI to share
-            if (share_uri_ && !share_uri_.value_or("").empty())
-            {
-              auto uri = Utf16FromUtf8(share_uri_.value_or(""));
-              properties->put_Description(
-                  HStringReference(uri.c_str()).Get());
-              data->SetText(HStringReference(uri.c_str()).Get());
-            }
-
-            // Add files to the data.
-            Vector<WindowsStorage::IStorageItem *> storage_items;
-            for (const std::string &path : paths_)
-            {
-              auto str = Utf16FromUtf8(path);
-              wchar_t *ptr = const_cast<wchar_t *>(str.c_str());
-              WindowsStorage::IStorageFile *file = nullptr;
-              if (SUCCEEDED(GetStorageFileFromPath(ptr, &file)) &&
-                  file != nullptr)
-              {
-                storage_items.Append(
-                    reinterpret_cast<WindowsStorage::IStorageItem *>(file));
-              }
-            }
-            data->SetStorageItemsReadOnly(&storage_items);
-
-            return S_OK;
-          });
-
-      // Add the callback to the data transfer manager
-      data_transfer_manager->add_DataRequested(callback.Get(),
-                                               &data_transfer_manager_token_);
-      if (data_transfer_manager_interop_ != nullptr)
-      {
-        data_transfer_manager_interop_->ShowShareUIForWindow(GetWindow());
-      }
-      result->Success(flutter::EncodableValue(kShareResultUnavailable));
-    }
-    else
-    {
-      result->NotImplemented();
-    }
-  }
-
-  // Converts string encoded in UTF-8 to wstring.
-  // Returns an empty |std::wstring| on failure.
-  // Present as static helper method.
-  std::wstring SharePlusWindowsPlugin::Utf16FromUtf8(std::string string)
-  {
-    if (string.empty())
-    {
-      return std::wstring();
-    }
-
-    int size_needed =
-        MultiByteToWideChar(CP_UTF8, 0, string.c_str(), -1, NULL, 0);
-    if (size_needed <= 0)
-    {
-      return std::wstring();
-    }
-
-    std::wstring result(size_needed - 1, 0);
-    int converted_length = MultiByteToWideChar(CP_UTF8, 0, string.c_str(), -1,
-                                               &result[0], size_needed);
-    if (converted_length == 0)
-    {
-      return std::wstring();
-    }
-    return result;
-  }
+  return result;
+}
 
 } // namespace share_plus_windows

--- a/packages/share_plus/share_plus/windows/share_plus_windows_plugin.h
+++ b/packages/share_plus/share_plus/windows/share_plus_windows_plugin.h
@@ -24,68 +24,67 @@ namespace WindowsFoundation = ABI::Windows::Foundation;
 namespace WindowsStorage = ABI::Windows::Storage;
 namespace DataTransfer = ABI::Windows::ApplicationModel::DataTransfer;
 
-namespace share_plus_windows
-{
+namespace share_plus_windows {
 
-    class SharePlusWindowsPlugin : public flutter::Plugin
-    {
-    public:
-        static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
+class SharePlusWindowsPlugin : public flutter::Plugin {
+public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
 
-        SharePlusWindowsPlugin(flutter::PluginRegistrarWindows *registrar);
+  SharePlusWindowsPlugin(flutter::PluginRegistrarWindows *registrar);
 
-        virtual ~SharePlusWindowsPlugin();
+  virtual ~SharePlusWindowsPlugin();
 
-        SharePlusWindowsPlugin(const SharePlusWindowsPlugin &) = delete;
-        SharePlusWindowsPlugin &operator=(const SharePlusWindowsPlugin &) = delete;
+  SharePlusWindowsPlugin(const SharePlusWindowsPlugin &) = delete;
+  SharePlusWindowsPlugin &operator=(const SharePlusWindowsPlugin &) = delete;
 
-    private:
-        static constexpr auto kSharePlusChannelName =
-            "dev.fluttercommunity.plus/share";
+private:
+  static constexpr auto kSharePlusChannelName =
+      "dev.fluttercommunity.plus/share";
 
-        static constexpr auto kShareResultUnavailable =
-            "dev.fluttercommunity.plus/share/unavailable";
+  static constexpr auto kShareResultUnavailable =
+      "dev.fluttercommunity.plus/share/unavailable";
 
-        static constexpr auto kShare = "share";
-        // static constexpr auto kShareFiles = "shareFiles";
+  static constexpr auto kShare = "share";
+  // static constexpr auto kShareFiles = "shareFiles";
 
-        HWND GetWindow();
+  HWND GetWindow();
 
-        WRL::ComPtr<DataTransfer::IDataTransferManager> GetDataTransferManager();
+  WRL::ComPtr<DataTransfer::IDataTransferManager> GetDataTransferManager();
 
-        void HandleMethodCall(
-            const flutter::MethodCall<flutter::EncodableValue> &method_call,
-            std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+  void HandleMethodCall(
+      const flutter::MethodCall<flutter::EncodableValue> &method_call,
+      std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
-        static HRESULT GetStorageFileFromPath(wchar_t *path,
-                                              WindowsStorage::IStorageFile **file);
+  static HRESULT GetStorageFileFromPath(wchar_t *path,
+                                        WindowsStorage::IStorageFile **file);
 
-        static HRESULT GetStorageFileFromApplicationData(
-            const std::wstring &path, WindowsStorage::IStorageFile **file);
+  static HRESULT
+  GetStorageFileFromApplicationData(const std::wstring &path,
+                                    WindowsStorage::IStorageFile **file);
 
-        static bool IsApplicationDataPath(const std::wstring &path,
-                                          std::wstring &relative_path,
-                                          int &folder_type);
+  static bool IsApplicationDataPath(const std::wstring &path,
+                                    std::wstring &relative_path,
+                                    int &folder_type);
 
-        static std::wstring SharePlusWindowsPlugin::Utf16FromUtf8(std::string string);
+  static std::wstring SharePlusWindowsPlugin::Utf16FromUtf8(std::string string);
 
-        flutter::PluginRegistrarWindows *registrar_ = nullptr;
-        WRL::ComPtr<IDataTransferManagerInterop> data_transfer_manager_interop_ =
-            nullptr;
-        WRL::ComPtr<DataTransfer::IDataTransferManager> data_transfer_manager_ =
-            nullptr;
-        EventRegistrationToken data_transfer_manager_token_;
+  flutter::PluginRegistrarWindows *registrar_ = nullptr;
+  WRL::ComPtr<IDataTransferManagerInterop> data_transfer_manager_interop_ =
+      nullptr;
+  WRL::ComPtr<DataTransfer::IDataTransferManager> data_transfer_manager_ =
+      nullptr;
+  EventRegistrationToken data_transfer_manager_token_;
 
-        // Present here to keep |std::string| in memory until data request callback
-        // from |IDataTransferManager| takes place.
-        // Subsequent calls on the platform channel will overwrite the existing value.
-        std::optional<std::string> share_text_ = std::nullopt;
-        std::optional<std::string> share_uri_ = std::nullopt;
-        std::optional<std::string> share_subject_ = std::nullopt;
-        std::optional<std::string> share_title_ = std::nullopt;
-        std::vector<std::string> paths_ = {};
-        std::vector<std::string> mime_types_ = {};
-    };
+  // Present here to keep |std::string| in memory until data request callback
+  // from |IDataTransferManager| takes place.
+  // Subsequent calls on the platform channel will overwrite the existing value.
+  std::optional<std::string> share_text_ = std::nullopt;
+  std::optional<std::string> share_uri_ = std::nullopt;
+  std::optional<std::string> share_subject_ = std::nullopt;
+  std::optional<std::string> share_title_ = std::nullopt;
+  std::vector<std::string> paths_ = {};
+  std::vector<std::string> mime_types_ = {};
+};
 
 } // namespace share_plus_windows
 

--- a/packages/share_plus/share_plus/windows/vector.h
+++ b/packages/share_plus/share_plus/windows/vector.h
@@ -65,8 +65,8 @@ __declspec(noreturn) __declspec(noinline) inline void ThrowHR(HRESULT hr,
   ThrowHR(hr);
 }
 
-__declspec(noreturn) __declspec(noinline) inline void ThrowHR(
-    HRESULT hr, wchar_t const *message) {
+__declspec(noreturn) __declspec(noinline) inline void
+ThrowHR(HRESULT hr, wchar_t const *message) {
   using ::Microsoft::WRL::Wrappers::HStringReference;
 
   ThrowHR(hr, HStringReference(message).Get());


### PR DESCRIPTION
## Description

Fixes file access issues on Windows when the app is packaged using MSIX and runs in a sandboxed environment.

When packaged as MSIX, direct access to certain file system paths (e.g. the app's temporary folder) is restricted, which caused file sharing to fail in some scenarios or resulted in the file not getting attached to the Share UI. This update ensures that file paths are resolved correctly and that shared files are accessed only through sandbox-safe locations.

The change is limited to the Windows MSIX packaging case and does not affect behavior on other platforms or non-sandboxed Windows builds.

## Related Issues

<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [ ] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [ ] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [ ] No, this is *not* a breaking change.

