### PR TITLE
feat(share_plus): added ability to share with package name

### DIFF
--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 12.1.0
+ - **FEAT**(share_plus): Eligible user to share files via specific package name with their extras
+
 ## 12.0.1
 
  - **FIX**(share_plus): Avoid crash on iOS 26 on iPhones with no sharePositionOrigin param([#3699](https://github.com/fluttercommunity/plus_plugins/issues/3699)). ([42b079bd](https://github.com/fluttercommunity/plus_plugins/commit/42b079bd5fa56c9983a5a4fcf351190884f5c540))

--- a/packages/share_plus/share_plus/android/build.gradle
+++ b/packages/share_plus/share_plus/android/build.gradle
@@ -26,7 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     namespace 'dev.fluttercommunity.plus.share'
-    compileSdk = flutter.compileSdkVersion
+    compileSdk = 35
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17

--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -66,6 +66,8 @@ internal class Share(
         val paths = (arguments["paths"] as List<*>?)?.filterIsInstance<String>()
         val mimeTypes = (arguments["mimeTypes"] as List<*>?)?.filterIsInstance<String>()
         val fileUris = paths?.let { getUrisForPaths(paths) }
+        val packageName = arguments["packageName"] as String?
+        val extras = (arguments["extras"] as List<*>?)?.filterIsInstance<Map<String, String>>()
 
         // Create Share Intent
         val shareIntent = Intent()
@@ -76,6 +78,8 @@ internal class Share(
                 putExtra(Intent.EXTRA_TEXT, uri ?: text)
                 if (!subject.isNullOrBlank()) putExtra(Intent.EXTRA_SUBJECT, subject)
                 if (!title.isNullOrBlank()) putExtra(Intent.EXTRA_TITLE, title)
+                if (!packageName.isNullOrBlank()) setPackage(packageName)
+                extras?.forEach { item -> putExtra(item.keys.first(), item.values.first()) }
             }
         } else {
             when {
@@ -109,6 +113,8 @@ internal class Share(
                 if (!text.isNullOrBlank()) putExtra(Intent.EXTRA_TEXT, text)
                 if (!subject.isNullOrBlank()) putExtra(Intent.EXTRA_SUBJECT, subject)
                 if (!title.isNullOrBlank()) putExtra(Intent.EXTRA_TITLE, title)
+                if (!packageName.isNullOrBlank()) setPackage(packageName)
+                extras?.forEach { item -> putExtra(item.keys.first(), item.values.first()) }
                 addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
             }
         }

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -194,6 +194,27 @@ class MyHomePageState extends State<MyHomePage> {
                     foregroundColor: Theme.of(context).colorScheme.onPrimary,
                     backgroundColor: Theme.of(context).colorScheme.primary,
                   ),
+                  onPressed: text.isEmpty && imagePaths.isEmpty
+                      ? null
+                      : () => _onShareWithResult(
+                            context,
+                            packageName: 'com.whatsapp',
+                            extras: [
+                              {"jid": "628111555333@s.whatsapp.net"}
+                            ],
+                          ),
+                  child: const Text('Share to Specific Package Name'),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                  ),
                   onPressed: () {
                     _onShareXFileFromAssets(context);
                   },
@@ -242,7 +263,11 @@ class MyHomePageState extends State<MyHomePage> {
     }
   }
 
-  void _onShareWithResult(BuildContext context) async {
+  void _onShareWithResult(
+    BuildContext context, {
+    String? packageName,
+    List<Map<String, dynamic>>? extras,
+  }) async {
     // A builder is used to retrieve the context immediately
     // surrounding the ElevatedButton.
     //
@@ -267,6 +292,8 @@ class MyHomePageState extends State<MyHomePage> {
           files: files,
           sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
           excludedCupertinoActivities: [CupertinoActivityType.airDrop],
+          packageName: packageName,
+          extras: extras,
         ),
       );
     } else if (uri.isNotEmpty) {
@@ -277,6 +304,8 @@ class MyHomePageState extends State<MyHomePage> {
           title: title.isEmpty ? null : title,
           sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
           excludedCupertinoActivities: excludedCupertinoActivityType,
+          packageName: packageName,
+          extras: extras,
         ),
       );
     } else {
@@ -287,6 +316,8 @@ class MyHomePageState extends State<MyHomePage> {
           title: title.isEmpty ? null : title,
           sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
           excludedCupertinoActivities: excludedCupertinoActivityType,
+          packageName: packageName,
+          extras: extras,
         ),
       );
     }

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -4,7 +4,8 @@ description: Demonstrates how to use the share_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  share_plus: ^12.0.1
+  share_plus:
+    path: ../
   image_picker: ^1.1.2
   file_selector: ^1.0.3
 
@@ -24,5 +25,5 @@ flutter:
     - assets/flutter_logo.png
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
-  flutter: '>=3.22.0'
+  sdk: ">=3.4.0 <4.0.0"
+  flutter: ">=3.22.0"

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -36,7 +36,10 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   share_plus_platform_interface:
-    path: ../share_plus_platform_interface
+    hosted:
+      name: share_plus_platform_interface
+      url: http://pub.dev.internal
+    version: 6.2.0-package-name-rc.1
   file: ">=6.1.4 <8.0.0"
   url_launcher_web: ^2.3.2
   url_launcher_windows: ^3.1.2

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 12.0.1
+version: 12.1.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/share_plus/share_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus
@@ -35,7 +35,8 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  share_plus_platform_interface: ^6.1.0
+  share_plus_platform_interface:
+    path: ../share_plus_platform_interface
   file: ">=6.1.4 <8.0.0"
   url_launcher_web: ^2.3.2
   url_launcher_windows: ^3.1.2
@@ -53,4 +54,3 @@ dev_dependencies:
 environment:
   sdk: ">=3.4.0 <4.0.0"
   flutter: ">=3.22.0"
-

--- a/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
+++ b/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.0
+- **FEAT**(share_plus): packageName, allow user to share files to specific packages name
+- **FEAT**(share_plus): extras, allow user to share files with specific packages name add their extras
+
 ## 6.1.0
 
  - **FEAT**(share_plus): Added `excludedCupertinoActivities` share parameter ([#3376](https://github.com/fluttercommunity/plus_plugins/issues/3376)). ([f9fdadb4](https://github.com/fluttercommunity/plus_plugins/commit/f9fdadb41242ad2e36ddbf1ade82be6c5bb78ec4))

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -74,6 +74,14 @@ class MethodChannelShare extends SharePlatform {
       map['excludedCupertinoActivities'] = excludedActivityTypes;
     }
 
+    if (params.packageName != null) {
+      map['packageName'] = params.packageName;
+    }
+
+    if (params.extras != null) {
+      map['extras'] = params.extras;
+    }
+
     return map;
   }
 

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -142,6 +142,10 @@ class ShareParams {
   ///   Parameter ignored on other platforms.
   final List<CupertinoActivityType>? excludedCupertinoActivities;
 
+  final String? packageName;
+
+  final List<Map<String, dynamic>>? extras;
+
   ShareParams({
     this.text,
     this.subject,
@@ -154,6 +158,8 @@ class ShareParams {
     this.downloadFallbackEnabled = true,
     this.mailToFallbackEnabled = true,
     this.excludedCupertinoActivities,
+    this.packageName,
+    this.extras,
   });
 }
 

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_platform_interface
 description: A common platform interface for the share_plus plugin.
-version: 6.1.0
+version: 6.2.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description
Enable to share with specific package name

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

