### PR TITLE
feat(share_plus): Avoid exceptions on iPads with no sharePositionOrigin

### DIFF
--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -262,12 +262,14 @@ For more information check the [CoreFoundationKeys](https://developer.apple.com/
 
 #### iPad
 
-`share_plus` requires iPad users to provide the `sharePositionOrigin` parameter.
+On iPad, the share sheet is presented as a popover that anchors to a source
+rectangle. Provide the `sharePositionOrigin` parameter so the popover points at
+the widget the user interacted with.
 
-Without it, `share_plus` will not work on iPads and may cause a crash or
-leave the UI unresponsive.
-
-To avoid that problem, provide the `sharePositionOrigin`.
+If `sharePositionOrigin` is not provided, the popover falls back to anchoring at the
+center of the screen. (In earlier versions, omitting it could cause a crash or
+leave the UI unresponsive.) Providing an accurate origin is still recommended
+for the best user experience.
 
 For example:
 

--- a/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
@@ -417,32 +417,32 @@ activityTypesForStrings(NSArray<NSString *> *activityTypeStrings) {
 
   activityViewController.popoverPresentationController.sourceView =
       controller.view;
-  BOOL isCoordinateSpaceOfSourceView =
-      CGRectContainsRect(controller.view.frame, origin);
 
   // Check if this is actually an iPad
   BOOL isIpad = ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad);
 
   // Before Xcode 26 hasPopoverPresentationController is true for iPads and false for iPhones.
-  // Since Xcode 26 is true both for iPads and iPhones, so additional check was added above.
-  BOOL hasPopoverPresentationController =
-      [activityViewController popoverPresentationController] != NULL;
-  if (isIpad && hasPopoverPresentationController &&
-      (!isCoordinateSpaceOfSourceView || CGRectIsEmpty(origin))) {
-    NSString *sharePositionIssue = [NSString
-        stringWithFormat:
-            @"sharePositionOrigin: argument must be set, %@ must be non-zero "
-            @"and within coordinate space of source view: %@",
-            NSStringFromCGRect(origin),
-            NSStringFromCGRect(controller.view.bounds)];
+  // Since Xcode 26 it is true for both iPads and iPhones, so we only configure popover on iPad.
+  UIPopoverPresentationController *popover =
+      activityViewController.popoverPresentationController;
+  BOOL hasPopoverPresentationController = (popover != NULL);
 
-    result([FlutterError errorWithCode:@"error"
-                               message:sharePositionIssue
-                               details:nil]);
-    return;
-  }
-
-  if (!CGRectIsEmpty(origin)) {
+  CGRect sourceRect = origin;
+  if (isIpad && hasPopoverPresentationController) {
+    // Flutter sends sharePositionOrigin in global (window) coordinates.
+    // Convert to the source view's coordinate space for sourceRect.
+    if (controller.view.window && !CGRectIsEmpty(origin)) {
+      sourceRect = [controller.view convertRect:origin fromView:nil];
+    }
+    // On iPad, popover requires a non-empty sourceRect. Use center of the view
+    // when no valid origin was provided or conversion isn't possible.
+    if (CGRectIsEmpty(sourceRect)) {
+      CGRect bounds = controller.view.bounds;
+      sourceRect = CGRectMake(CGRectGetMidX(bounds) - 1.0,
+                              CGRectGetMidY(bounds) - 1.0, 2.0, 2.0);
+    }
+    popover.sourceRect = sourceRect;
+  } else if (!CGRectIsEmpty(origin)) {
     activityViewController.popoverPresentationController.sourceRect = origin;
   }
 

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -76,7 +76,7 @@ class ShareParams {
   final XFile? previewThumbnail;
 
   /// The optional [sharePositionOrigin] parameter can be used to specify a global
-  /// origin rect to achor the share sheet to a widget user interacts with on iPads and Macs.  
+  /// origin rect to anchor the share sheet to a widget user interacts with on iPads and Macs.
   /// It has no effect on other devices.
   ///
   /// If this parameter not provided on iPads the popover anchors to the center of the screen
@@ -245,6 +245,8 @@ enum CupertinoActivityType {
   addToHomeScreen;
 
   String get value {
-    return toString().split('.').last;
+    return toString()
+        .split('.')
+        .last;
   }
 }

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -245,8 +245,6 @@ enum CupertinoActivityType {
   addToHomeScreen;
 
   String get value {
-    return toString()
-        .split('.')
-        .last;
+    return toString().split('.').last;
   }
 }

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -76,8 +76,11 @@ class ShareParams {
   final XFile? previewThumbnail;
 
   /// The optional [sharePositionOrigin] parameter can be used to specify a global
-  /// origin rect for the share sheet to popover from on iPads and Macs. It has no effect
-  /// on other devices.
+  /// origin rect to achor the share sheet to a widget user interacts with on iPads and Macs.  
+  /// It has no effect on other devices.
+  ///
+  /// If this parameter not provided on iPads the popover anchors to the center of the screen
+  /// instead of throwing. Providing an accurate rect is still recommended for better UX.
   ///
   /// * Supported platforms: iPad and Mac
   ///   Parameter ignored on other platforms.


### PR DESCRIPTION
## Description
- Convert sharePositionOrigin from window to source view coordinates
- Use center fallback when no valid origin is provided on iPad
- iPhone behavior unchanged
- Closes: #3768 

## Changes
- **iPad – coordinate handling:** Convert `sharePositionOrigin` from window to source view coordinates using `convertRect:fromView:nil` before setting `sourceRect`
- **iPad – no origin fallback:** Use a center-of-view fallback rect instead of returning a `FlutterError` when no valid origin is provided
- **iPhone:** Unchanged behavior

## Backwards compatibility
- iPhone: No change
- iPad without `sharePositionOrigin`: Previously could crash; now works (center fallback)
- iPad with `sharePositionOrigin`: Popover now anchors correctly; no API changes


## Description

Fixes share sheet crash on iPad (iOS 17–26) when `sharePositionOrigin` is missing or in the wrong coordinate space.

## Related Issues

- [Related issue](https://github.com/fluttercommunity/plus_plugins/issues/3645)
- [Code already merged](https://github.com/fluttercommunity/plus_plugins/pull/3699)

## Checklist

- [X] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [X] No, this is *not* a breaking change.

### Changes
- **iPad – coordinate handling:** Convert `sharePositionOrigin` from window to source view coordinates using `convertRect:fromView:nil` before setting `sourceRect`
- **iPad – no origin fallback:** Use a center-of-view fallback rect instead of returning a `FlutterError` when no valid origin is provided
- **iPhone:** Unchanged behavior

### Backwards compatibility
- iPhone: No change
- iPad without `sharePositionOrigin`: Previously could crash; now works (center fallback)
- iPad with `sharePositionOrigin`: Popover now anchors correctly; no API changes

