### PR TITLE
feat(share_plus): add support for action_attach_data

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -66,6 +66,7 @@ internal class Share(
         val paths = (arguments["paths"] as List<*>?)?.filterIsInstance<String>()
         val mimeTypes = (arguments["mimeTypes"] as List<*>?)?.filterIsInstance<String>()
         val fileUris = paths?.let { getUrisForPaths(paths) }
+        val attach = arguments["attach"] as Boolean? ?: false
 
         // Create Share Intent
         val shareIntent = Intent()
@@ -89,10 +90,17 @@ internal class Share(
                     } else {
                         "*/*"
                     }
-                    shareIntent.apply {
-                        action = Intent.ACTION_SEND
-                        type = mimeType
-                        putExtra(Intent.EXTRA_STREAM, fileUris.first())
+                    if (attach) {
+                        shareIntent.apply {
+                            action = Intent.ACTION_ATTACH_DATA
+                            setDataAndType(fileUris.first(), mimeType)
+                        }
+                    } else {
+                        shareIntent.apply {
+                            action = Intent.ACTION_SEND
+                            type = mimeType
+                            putExtra(Intent.EXTRA_STREAM, fileUris.first())
+                        }
                     }
                 }
 

--- a/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
+++ b/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
@@ -41,4 +41,17 @@ void main() {
     );
     expect(SharePlus.instance.share(params), isNotNull);
   });
+
+  testWidgets('Can attachXFile created using File.fromData()',
+      (WidgetTester tester) async {
+    final bytes = Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8]);
+    final XFile file =
+        XFile.fromData(bytes, name: 'image.jpg', mimeType: 'image/jpeg');
+
+    final params = ShareParams(
+      files: [file],
+      attach: true,
+    );
+    expect(SharePlus.instance.share(params), isNotNull);
+  }, skip: !Platform.isAndroid);
 }

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -209,6 +209,21 @@ class MyHomePageState extends State<MyHomePage> {
                     foregroundColor: Theme.of(context).colorScheme.onPrimary,
                     backgroundColor: Theme.of(context).colorScheme.primary,
                   ),
+                  onPressed: () {
+                    _onShareXFileFromAssets(context, attach: true);
+                  },
+                  child: const Text('Attach XFile from Assets'),
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+            Builder(
+              builder: (BuildContext context) {
+                return ElevatedButton(
+                  style: ElevatedButton.styleFrom(
+                    foregroundColor: Theme.of(context).colorScheme.onPrimary,
+                    backgroundColor: Theme.of(context).colorScheme.primary,
+                  ),
                   onPressed: fileName.isEmpty || text.isEmpty
                       ? null
                       : () => _onShareTextAsXFile(context),
@@ -293,7 +308,10 @@ class MyHomePageState extends State<MyHomePage> {
     scaffoldMessenger.showSnackBar(getResultSnackBar(shareResult));
   }
 
-  void _onShareXFileFromAssets(BuildContext context) async {
+  void _onShareXFileFromAssets(
+    BuildContext context, {
+    bool attach = false,
+  }) async {
     final box = context.findRenderObject() as RenderBox?;
     final scaffoldMessenger = ScaffoldMessenger.of(context);
     try {
@@ -311,6 +329,7 @@ class MyHomePageState extends State<MyHomePage> {
           sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
           downloadFallbackEnabled: true,
           excludedCupertinoActivities: excludedCupertinoActivityType,
+          attach: attach,
         ),
       );
       scaffoldMessenger.showSnackBar(getResultSnackBar(shareResult));

--- a/packages/share_plus/share_plus/lib/share_plus.dart
+++ b/packages/share_plus/share_plus/lib/share_plus.dart
@@ -99,6 +99,12 @@ class SharePlus {
       );
     }
 
+    if (params.attach && (params.files?.length ?? 0) != 1) {
+      throw ArgumentError(
+        'Exactly one file must be provided when attach is true.',
+      );
+    }
+
     return _platform.share(params);
   }
 }

--- a/packages/share_plus/share_plus/test/share_plus_test.dart
+++ b/packages/share_plus/share_plus/test/share_plus_test.dart
@@ -56,6 +56,25 @@ void main() {
       );
     });
 
+    test(
+        'share throws ArgumentError if attach is true but no files are provided',
+        () async {
+      expect(
+        () => sharePlus.share(ShareParams(files: [], attach: true)),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test(
+        'share throws ArgumentError if attach is true and more then one file is provided',
+        () async {
+      expect(
+        () => sharePlus.share(
+            ShareParams(files: [XFile('path'), XFile('path')], attach: true)),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
     test('share calls platform share method with correct params', () async {
       final params = ShareParams(text: 'text');
       final result = await sharePlus.share(params);

--- a/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/method_channel/method_channel_share.dart
@@ -41,6 +41,7 @@ class MethodChannelShare extends SharePlatform {
       if (params.subject != null) 'subject': params.subject,
       if (params.title != null) 'title': params.title,
       if (params.uri != null) 'uri': params.uri.toString(),
+      'attach': params.attach,
     };
 
     if (params.sharePositionOrigin != null) {

--- a/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
+++ b/packages/share_plus/share_plus_platform_interface/lib/platform_interface/share_plus_platform.dart
@@ -142,6 +142,13 @@ class ShareParams {
   ///   Parameter ignored on other platforms.
   final List<CupertinoActivityType>? excludedCupertinoActivities;
 
+  /// Whether to attach or share data. Will open ACTION_ATTACH_DATA intent on Android instead of ACTION_SEND.
+  /// Requires exactly on file to be provided.
+  ///
+  /// * Supported platforms: Android
+  ///   Parameter ignored on other platforms.
+  final bool attach;
+
   ShareParams({
     this.text,
     this.subject,
@@ -154,6 +161,7 @@ class ShareParams {
     this.downloadFallbackEnabled = true,
     this.mailToFallbackEnabled = true,
     this.excludedCupertinoActivities,
+    this.attach = false,
   });
 }
 

--- a/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
+++ b/packages/share_plus/share_plus_platform_interface/test/share_plus_platform_interface_test.dart
@@ -76,6 +76,7 @@ void main() {
       'originWidth': 3.0,
       'originHeight': 4.0,
       'excludedCupertinoActivities': ['airDrop'],
+      'attach': false,
     }));
 
     await sharePlatform.share(
@@ -93,6 +94,7 @@ void main() {
       'originY': 2.0,
       'originWidth': 3.0,
       'originHeight': 4.0,
+      'attach': false,
     }));
 
     await withFile('tempfile-83649a.png', (File fd) async {
@@ -116,6 +118,24 @@ void main() {
           'originY': 2.0,
           'originWidth': 3.0,
           'originHeight': 4.0,
+          'attach': false,
+        },
+      ));
+    });
+
+    await withFile('tempfile-83649a.png', (File fd) async {
+      await sharePlatform.share(
+        ShareParams(
+          files: [XFile(fd.path)],
+          attach: true,
+        ),
+      );
+      verify(mockChannel.invokeMethod<String>(
+        'share',
+        <String, dynamic>{
+          'paths': [fd.path],
+          'mimeTypes': ['image/png'],
+          'attach': true,
         },
       ));
     });
@@ -127,6 +147,7 @@ void main() {
       verify(mockChannel.invokeMethod<String>('share', <String, dynamic>{
         'paths': [fd.path],
         'mimeTypes': ['image/png'],
+        'attach': false,
       }));
     });
   });
@@ -141,6 +162,7 @@ void main() {
       verify(mockChannel.invokeMethod<String>('share', <String, dynamic>{
         'paths': [fd.path],
         'mimeTypes': ['*/*'],
+        'attach': false,
       }));
     });
   });
@@ -194,6 +216,7 @@ void main() {
       'originY': 2.0,
       'originWidth': 3.0,
       'originHeight': 4.0,
+      'attach': false,
     }));
     expect(result, success);
 
@@ -206,6 +229,7 @@ void main() {
       verify(mockChannel.invokeMethod<String>('share', <String, dynamic>{
         'paths': [fd.path],
         'mimeTypes': ['image/png'],
+        'attach': false,
       }));
       expect(result, success);
     });


### PR DESCRIPTION
## Description

Adds ACTION_ATTACH_DATA intent support to share_plus.

I first thought this will be a feature for android_intent_plus but came to a different conclusion after I started work on it.

## Related Issues

- Implements https://github.com/fluttercommunity/plus_plugins/issues/3772

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

