### PR TITLE
feat(device_info_plus): Add new device identifiers for 2026 models

### DIFF
--- a/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/DeviceIdentifiers.m
+++ b/packages/device_info_plus/device_info_plus/ios/device_info_plus/Sources/device_info_plus/DeviceIdentifiers.m
@@ -105,6 +105,8 @@
     return @"iPhone 17 Pro Max";
   } else if ([identifier isEqualToString:@"iPhone18,4"]) {
     return @"iPhone Air";
+  } else if ([identifier isEqualToString:@"iPhone18,5"]) {
+    return @"iPhone 17e";
     // iPads
   } else if ([identifier isEqualToString:@"iPad4,1"] ||
              [identifier isEqualToString:@"iPad4,2"] ||
@@ -146,6 +148,12 @@
   } else if ([identifier isEqualToString:@"iPad14,10"] ||
              [identifier isEqualToString:@"iPad14,11"]) {
     return @"iPad Air 13-Inch M2";
+  } else if ([identifier isEqualToString:@"iPad16,8"] ||
+             [identifier isEqualToString:@"iPad16,9"]) {
+    return @"iPad Air 11-inch (M4)";
+  } else if ([identifier isEqualToString:@"iPad16,10"] ||
+             [identifier isEqualToString:@"iPad16,11"]) {
+    return @"iPad Air 13-inch (M4)";
   } else if ([identifier isEqualToString:@"iPad2,5"] ||
              [identifier isEqualToString:@"iPad2,6"] ||
              [identifier isEqualToString:@"iPad2,7"]) {

--- a/packages/device_info_plus/device_info_plus/macos/device_info_plus/Sources/device_info_plus/DeviceIdentifiers.swift
+++ b/packages/device_info_plus/device_info_plus/macos/device_info_plus/Sources/device_info_plus/DeviceIdentifiers.swift
@@ -58,6 +58,13 @@ func getMacModelName(modelNumber: String) -> String {
     case "Mac16,1", "Mac16,6", "Mac16,8": return "MacBook Pro (14-inch, 2024)"
     case "Mac16,5", "Mac16,7": return "MacBook Pro (16-inch, 2024)"
     case "Mac17,2": return "MacBook Pro (14-inch, 2025)"
+    case "Mac17,3": return "MacBook Air (13-inch, 2026)"
+    case "Mac17,4": return "MacBook Air (15-inch, 2026)"
+    case "Mac17,6", "Mac17,8": return "MacBook Pro (16-inch, 2026)"
+    case "Mac17,7", "Mac17,9": return "MacBook Pro (14-inch, 2026)"
+
+    // MacBook Neo
+    case "Mac17,5": return "MacBook Neo"
 
     // iMac models (2013 and later)
     case "iMac13,1": return "iMac (21.5-inch, 2013)"


### PR DESCRIPTION
## Description

<!-- Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. -->

Add device identifiers for the new Apple models released on March 11, 2026
https://www.apple.com/newsroom/2026/03/macbook-neo-iphone-17e-ipad-air-with-m4-and-more-are-now-available/

- iPhone 17e
- iPad Air 11-inch (M4)
- iPad Air 13-inch (M4)
- MacBook Air (13-inch, 2026)
- MacBook Air (15-inch, 2026)
- MacBook Pro (14-inch, 2026)
- MacBook Pro (16-inch, 2026)
- MacBook Neo

## Related Issues

<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

