### PR TITLE
ci(all): Drop Android 5 (SDK 22) from test matrix, update test matrix

### DIFF
--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 29, 32, 36 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 29, 32, 36 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 29, 32, 36 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 29, 32, 36 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 29, 32, 36 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 29, 32, 36 ]
 
     steps:
       - name: "Checkout repository"

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        android-api-level: [ 22, 26, 31, 34 ]
+        android-api-level: [ 24, 29, 32, 36 ]
 
     steps:
       - name: "Checkout repository"


### PR DESCRIPTION
## Description

Since recent Flutter versions don't support Android 5 anymore, it makes no sense to run tests against it.
Updating the set of versions to run integration tests.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

