### PR TITLE
docs(connectivity_plus): Add missing info about Xcode 26.1.1 requirement, deduplicate headers

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -29,6 +29,7 @@ This plugin allows Flutter apps to discover network connectivity types that can 
 - Java 17
 - Android Gradle Plugin >=8.12.1
 - Gradle wrapper >=8.13
+- Xcode >= 26.1.1
 
 ## Usage
 

--- a/packages/connectivity_plus/connectivity_plus/README.md
+++ b/packages/connectivity_plus/connectivity_plus/README.md
@@ -101,9 +101,9 @@ class _MyWidgetState extends State<MyWidget> {
 }
 ```
 
-## Platform Support
+## Supported ConnectivityResult values per platform
 
-The following table shows which `ConnectivityResult` values are supported per platform.
+The following table shows which `ConnectivityResult` values can be returned on every of supported platforms.
 
 |           | Android | iOS | Web | macOS | Windows | Linux |
 |-----------|:-------:|:---:|:---:|:-----:|:-------:|:-----:|
@@ -114,8 +114,7 @@ The following table shows which `ConnectivityResult` values are supported per pl
 | vpn       | :white_check_mark: |                    |                    |                    | :white_check_mark: | :white_check_mark: |
 | satellite | :white_check_mark: | :white_check_mark: |                    |                    |                    |                    |
 | other     | :white_check_mark: | :white_check_mark: |                    | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-
-_`none` is supported on all platforms by default._
+| none      | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: |
 
 ### Android
 


### PR DESCRIPTION
## Description

With recent release of connectivity_plus information about Xcode requirement 26.1.1 to support satellite connection type check was missing from the README. This PR adds this information.
Additionally, where was a report #3788 about duplicate headers in the text. This is also changed in this PR.

## Related Issues

Closes #3788

