### PR TITLE
chore(release): prepare for release

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
+++ b/packages/connectivity_plus/connectivity_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.1
+
+ - **DOCS**(connectivity_plus): Add missing info about Xcode 26.1.1 requirement, deduplicate headers ([#3792](https://github.com/fluttercommunity/plus_plugins/issues/3792)). ([ba6e6b94](https://github.com/fluttercommunity/plus_plugins/commit/ba6e6b94f673bb479a5891b8ca0fc5fd7b2345bc))
+
 ## 7.1.0
 
  - **FIX**(connectivity_plus): Register broadcast receiver with correct flag, bump minSDK to 21 ([#3781](https://github.com/fluttercommunity/plus_plugins/issues/3781)). ([93135ff2](https://github.com/fluttercommunity/plus_plugins/commit/93135ff28cd3a8241445d084927b8ca18d73fe58))

--- a/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  connectivity_plus: ^7.1.0
+  connectivity_plus: ^7.1.1
 
 dev_dependencies:
   flutter_driver:

--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: connectivity_plus
 description: Flutter plugin for discovering the state of the network (WiFi & mobile/cellular) connectivity on Android and iOS.
-version: 7.1.0
+version: 7.1.1
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/connectivity_plus/connectivity_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/connectivity_plus

--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 13.0.0
+
+> Note: This release has breaking changes.
+>
+> Due to an update of win32 to 6.0.0, package requirements were also changed to match this update:
+>
+> Minimum Flutter version is 3.41.6
+> Minimum Dart version is 3.11.0
+> Min iOS is 13.0
+> Min MacOS is 10.15
+>
+> Since this release was already breaking, the rest of the dependencies were also updated to the latest possible versions.
+
+ - **BREAKING** **FEAT**(device_info_plus): Bump win32 from 5.15.0 to 6.0.0 ([#3791](https://github.com/fluttercommunity/plus_plugins/issues/3791)). ([5f93878b](https://github.com/fluttercommunity/plus_plugins/commit/5f93878bcc85b1dc5f90968119d87ef2cc6c8dce))
+
 ## 12.4.0
 
  - **FEAT**(device_info_plus): Add iOS device identifiers for 2026 models ([#3776](https://github.com/fluttercommunity/plus_plugins/issues/3776)). ([5dbe0a95](https://github.com/fluttercommunity/plus_plugins/commit/5dbe0a95ea3ce76acd6a57f8d33ae47761dd228c))

--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -3,11 +3,10 @@
 > Note: This release has breaking changes.
 >
 > Due to an update of win32 to 6.0.0, package requirements were also changed to match this update:
->
-> Minimum Flutter version is 3.41.6
-> Minimum Dart version is 3.11.0
-> Min iOS is 13.0
-> Min MacOS is 10.15
+> - Minimum Flutter version is 3.41.6
+> - Minimum Dart version is 3.11.0
+> - Min iOS is 13.0
+> - Min macOS is 10.15
 >
 > Since this release was already breaking, the rest of the dependencies were also updated to the latest possible versions.
 

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the device_info_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus: ^12.4.0
+  device_info_plus: ^13.0.0
 
 dev_dependencies:
   flutter_driver:

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 12.4.0
+version: 13.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/device_info_plus/device_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus
@@ -29,7 +29,7 @@ flutter:
         dartPluginClass: DeviceInfoPlusWindowsPlugin
 
 dependencies:
-  device_info_plus_platform_interface: ^7.0.3
+  device_info_plus_platform_interface: ^8.0.0
   ffi: ^2.2.0
   file: ^7.0.1
   flutter:

--- a/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 8.0.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **FEAT**(device_info_plus): Bump win32 from 5.15.0 to 6.0.0 ([#3791](https://github.com/fluttercommunity/plus_plugins/issues/3791)). ([5f93878b](https://github.com/fluttercommunity/plus_plugins/commit/5f93878bcc85b1dc5f90968119d87ef2cc6c8dce))
+
 ## 7.0.3
 
  - **FIX**(device_info_plus): Specify correct Dart and Flutter version requirements ([#3597](https://github.com/fluttercommunity/plus_plugins/issues/3597)). ([6ebc0ead](https://github.com/fluttercommunity/plus_plugins/commit/6ebc0ead68df477f06c6d4738a69a9e56223cf47))

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_platform_interface
 description: A common platform interface for the device_info_plus plugin.
-version: 7.0.3
+version: 8.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 8.0.0
+
+> Note: This release has breaking changes.
+>
+> Due to an update of win32 to 6.0.0, package requirements were also changed to match this update:
+>
+> Minimum Flutter version is 3.41.6
+> Minimum Dart version is 3.11.0
+> Min iOS is 13.0
+> Min MacOS is 10.15
+>
+> Since this release was already breaking, the rest of the dependencies were also updated to the latest possible versions.
+
+ - **BREAKING** **FEAT**(network_info_plus): Bump win32 from 5.15.0 to 6.0.0 ([#3761](https://github.com/fluttercommunity/plus_plugins/issues/3761)). ([582b93f2](https://github.com/fluttercommunity/plus_plugins/commit/582b93f29c4e5a7734edc3ecc28380af5fc86dba))
+
 ## 7.0.0
 
 > Note: This release has breaking changes.

--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -3,11 +3,10 @@
 > Note: This release has breaking changes.
 >
 > Due to an update of win32 to 6.0.0, package requirements were also changed to match this update:
->
-> Minimum Flutter version is 3.41.6
-> Minimum Dart version is 3.11.0
-> Min iOS is 13.0
-> Min MacOS is 10.15
+> - Minimum Flutter version is 3.41.6
+> - Minimum Dart version is 3.11.0
+> - Min iOS is 13.0
+> - Min macOS is 10.15
 >
 > Since this release was already breaking, the rest of the dependencies were also updated to the latest possible versions.
 

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus: ^7.0.0
+  network_info_plus: ^8.0.0
   permission_handler: ^12.0.0+1
 
 dev_dependencies:

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 7.0.0
+version: 8.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/network_info_plus/network_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/network_info_plus
@@ -39,7 +39,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.17.0
-  network_info_plus_platform_interface: ^2.0.2
+  network_info_plus_platform_interface: ^3.0.0
   nm: ^0.5.0
   win32: ^6.0.0
 

--- a/packages/network_info_plus/network_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **FEAT**(network_info_plus): Bump win32 from 5.15.0 to 6.0.0 ([#3761](https://github.com/fluttercommunity/plus_plugins/issues/3761)). ([582b93f2](https://github.com/fluttercommunity/plus_plugins/commit/582b93f29c4e5a7734edc3ecc28380af5fc86dba))
+
 ## 2.0.2
 
  - **REFACTOR**(all): Use range of flutter_lints for broader compatibility ([#3371](https://github.com/fluttercommunity/plus_plugins/issues/3371)). ([8a303add](https://github.com/fluttercommunity/plus_plugins/commit/8a303add3dee1acb8bac5838246490ed8a0fe408))

--- a/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus_platform_interface
 description: A common platform interface for the network_info_plus plugin.
-version: 2.0.2
+version: 3.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -3,11 +3,10 @@
 > Note: This release has breaking changes.
 >
 > Due to an update of win32 to 6.0.0, package requirements were also changed to match this update:
->
-> Minimum Flutter version is 3.41.6
-> Minimum Dart version is 3.11.0
-> Min iOS is 13.0
-> Min MacOS is 10.15
+> - Minimum Flutter version is 3.41.6
+> - Minimum Dart version is 3.11.0
+> - Min iOS is 13.0
+> - Min macOS is 10.15
 >
 > Since this release was already breaking, the rest of the dependencies were also updated to the latest possible versions.
 

--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 10.0.0
+
+> Note: This release has breaking changes.
+>
+> Due to an update of win32 to 6.0.0, package requirements were also changed to match this update:
+>
+> Minimum Flutter version is 3.41.6
+> Minimum Dart version is 3.11.0
+> Min iOS is 13.0
+> Min MacOS is 10.15
+>
+> Since this release was already breaking, the rest of the dependencies were also updated to the latest possible versions.
+
+ - **BREAKING** **FEAT**(package_info_plus): Bump win32 from 5.15.0 to 6.0.0 ([#3760](https://github.com/fluttercommunity/plus_plugins/issues/3760)). ([f0da4b91](https://github.com/fluttercommunity/plus_plugins/commit/f0da4b919cec0aaebbdc8daf8c4475e6bc0ae2ec))
+
 ## 9.0.1
 
  - **DOCS**(package_info_plus): add installerStore values documentation ([#3721](https://github.com/fluttercommunity/plus_plugins/issues/3721)). ([0534cd2d](https://github.com/fluttercommunity/plus_plugins/commit/0534cd2d1ea55d68c4452e8d5a0ee211b0c641ac))

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -11,11 +11,11 @@ dependencies:
   flutter:
     sdk: flutter
   http: ">=0.13.5 <2.0.0"
-  package_info_plus: ^9.0.1
+  package_info_plus: ^10.0.0
 
 dev_dependencies:
   build_runner: ^2.3.3
-  device_info_plus: ^12.4.0
+  device_info_plus: ^13.0.0
   integration_test:
     sdk: flutter
   flutter_driver:

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 9.0.1
+version: 10.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/package_info_plus/package_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/package_info_plus
@@ -36,7 +36,7 @@ dependencies:
     sdk: flutter
   http: ^1.6.0
   meta: ^1.17.0
-  package_info_plus_platform_interface: ^3.2.1
+  package_info_plus_platform_interface: ^4.0.0
   path: ^1.9.1
   web: ^1.1.1
   win32: ^6.0.0

--- a/packages/package_info_plus/package_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **FEAT**(package_info_plus): Bump win32 from 5.15.0 to 6.0.0 ([#3760](https://github.com/fluttercommunity/plus_plugins/issues/3760)). ([f0da4b91](https://github.com/fluttercommunity/plus_plugins/commit/f0da4b919cec0aaebbdc8daf8c4475e6bc0ae2ec))
+
 ## 3.2.1
 
  - **FIX**(package_info_plus): incorrect install time on macOS when app sandbox disabled ([#3638](https://github.com/fluttercommunity/plus_plugins/issues/3638)). ([2cf9297b](https://github.com/fluttercommunity/plus_plugins/commit/2cf9297b4e3ce5cc71d22539ca7d0dfc82ac819b))

--- a/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_platform_interface
 description: A common platform interface for the package_info_plus plugin.
-version: 3.2.1
+version: 4.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -3,11 +3,10 @@
 > Note: This release has breaking changes.
 >
 > Due to an update of win32 to 6.0.0, package requirements were also changed to match this update:
->
-> Minimum Flutter version is 3.41.6
-> Minimum Dart version is 3.11.0
-> Min iOS is 13.0
-> Min MacOS is 10.15
+> - Minimum Flutter version is 3.41.6
+> - Minimum Dart version is 3.11.0
+> - Min iOS is 13.0
+> - Min macOS is 10.15
 >
 > Since this release was already breaking, the rest of the dependencies were also updated to the latest possible versions.
 

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 13.0.0
+
+> Note: This release has breaking changes.
+>
+> Due to an update of win32 to 6.0.0, package requirements were also changed to match this update:
+>
+> Minimum Flutter version is 3.41.6
+> Minimum Dart version is 3.11.0
+> Min iOS is 13.0
+> Min MacOS is 10.15
+>
+> Since this release was already breaking, the rest of the dependencies were also updated to the latest possible versions.
+
+ - **BREAKING** **FEAT**(share_plus): Bump win32 from 5.15.0 to 6.0.0 ([#3762](https://github.com/fluttercommunity/plus_plugins/issues/3762)). ([0e3eb918](https://github.com/fluttercommunity/plus_plugins/commit/0e3eb918e77fcc500b6124167a905f026ffc374a))
+
 ## 12.0.2
 
  - **FIX**(share_plus): Avoid crash on iOS during file and text sharing in add-to-app scenario ([#3738](https://github.com/fluttercommunity/plus_plugins/issues/3738)). ([ae6330bb](https://github.com/fluttercommunity/plus_plugins/commit/ae6330bbf579fe411b503be84fcfc202d2496625))

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the share_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  share_plus: ^12.0.2
+  share_plus: ^13.0.0
   image_picker: ^1.1.2
   file_selector: ^1.0.3
 

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 12.0.2
+version: 13.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/share_plus/share_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus
@@ -35,7 +35,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  share_plus_platform_interface: ^6.1.0
+  share_plus_platform_interface: ^7.0.0
   file: ^7.0.1
   url_launcher_web: ^2.4.2
   url_launcher_windows: ^3.1.5

--- a/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
+++ b/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 7.0.0
+
+> Note: This release has breaking changes.
+
+ - **BREAKING** **FEAT**(share_plus): Bump win32 from 5.15.0 to 6.0.0 ([#3762](https://github.com/fluttercommunity/plus_plugins/issues/3762)). ([0e3eb918](https://github.com/fluttercommunity/plus_plugins/commit/0e3eb918e77fcc500b6124167a905f026ffc374a))
+
 ## 6.1.0
 
  - **FEAT**(share_plus): Added `excludedCupertinoActivities` share parameter ([#3376](https://github.com/fluttercommunity/plus_plugins/issues/3376)). ([f9fdadb4](https://github.com/fluttercommunity/plus_plugins/commit/f9fdadb41242ad2e36ddbf1ade82be6c5bb78ec4))

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_platform_interface
 description: A common platform interface for the share_plus plugin.
-version: 6.1.0
+version: 7.0.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

Release for packages that use `win32` to upgrade to 6.0.0

Closes #3775

