### PR TITLE
fix: CI failures

### DIFF
--- a/.github/workflows/all_plugins.yaml
+++ b/.github/workflows/all_plugins.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -60,7 +60,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -92,7 +92,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
 
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
@@ -113,7 +113,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
 
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh

--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 

--- a/.github/workflows/android_intent_plus.yaml
+++ b/.github/workflows/android_intent_plus.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 

--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
@@ -89,7 +89,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -101,7 +101,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -119,7 +119,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -132,7 +132,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -146,7 +146,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Install UPower"
@@ -160,7 +160,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Install UPower"
@@ -176,7 +176,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -188,7 +188,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -202,7 +202,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"

--- a/.github/workflows/connectivity_plus.yaml
+++ b/.github/workflows/connectivity_plus.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
@@ -89,7 +89,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -101,7 +101,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -119,7 +119,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -131,7 +131,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -145,7 +145,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -157,7 +157,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -173,7 +173,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -185,7 +185,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -199,7 +199,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"

--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -130,7 +130,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -144,7 +144,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -156,7 +156,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -170,7 +170,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -182,7 +182,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -196,7 +196,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"

--- a/.github/workflows/network_info_plus.yaml
+++ b/.github/workflows/network_info_plus.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -130,7 +130,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -144,7 +144,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -156,7 +156,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -170,7 +170,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -182,7 +182,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -196,7 +196,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"

--- a/.github/workflows/package_info_plus.yaml
+++ b/.github/workflows/package_info_plus.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -88,7 +88,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -100,7 +100,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -118,7 +118,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -130,7 +130,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -144,7 +144,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -156,7 +156,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -170,7 +170,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -182,7 +182,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -196,7 +196,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -208,7 +208,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"

--- a/.github/workflows/sensors_plus.yaml
+++ b/.github/workflows/sensors_plus.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
 
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -85,7 +85,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -97,7 +97,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Start Simulator"
@@ -115,7 +115,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"

--- a/.github/workflows/share_plus.yaml
+++ b/.github/workflows/share_plus.yaml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: |
           ./.github/workflows/scripts/install-tools.sh
@@ -49,7 +49,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -66,7 +66,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -87,7 +87,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -99,7 +99,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -117,7 +117,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -129,7 +129,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -143,7 +143,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -156,7 +156,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -170,7 +170,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"
@@ -182,7 +182,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Bootstrap Workspace"
@@ -196,7 +196,7 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
-      - uses: flutter-actions/setup-flutter@v4
+      - uses: subosito/flutter-action@v2
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh
       - name: "Build Example"


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for several plugins to use a different action for setting up Flutter. Specifically, it replaces the usage of `flutter-actions/setup-flutter@v4` with `subosito/flutter-action@v2` across multiple workflow YAML files. This change standardizes the Flutter setup process and may improve reliability or compatibility with current tooling.

**CI/CD Workflow Updates:**

* Replaced `flutter-actions/setup-flutter@v4` with `subosito/flutter-action@v2` for setting up Flutter in `.github/workflows/all_plugins.yaml`, `.github/workflows/android_alarm_manager_plus.yaml`, `.github/workflows/android_intent_plus.yaml`, `.github/workflows/battery_plus.yaml`, `.github/workflows/connectivity_plus.yaml`, and `.github/workflows/device_info_plus.yaml`.

No other workflow logic or steps were changed; only the Flutter setup action was updated. This should be a safe and straightforward improvement to CI consistency.