### PR TITLE
feat(share_plus): Lower requirements to Dart 3.10 and Flutter 3.38.1

### DIFF
--- a/packages/share_plus/share_plus/README.md
+++ b/packages/share_plus/share_plus/README.md
@@ -26,8 +26,8 @@ Sharing files is not supported on Linux.
 
 ## Requirements
 
-- Flutter >=3.41.0
-- Dart >=3.11.0 <4.0.0
+- Flutter >=3.38.1
+- Dart >=3.10.0 <4.0.0
 - iOS >=13.0
 - macOS >=10.15
 - Java 17

--- a/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
+++ b/packages/share_plus/share_plus/example/integration_test/share_plus_test.dart
@@ -13,32 +13,28 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets('Can launch share', (WidgetTester tester) async {
-    final params = ShareParams(
-      text: 'message',
-      subject: 'title',
-    );
+    final params = ShareParams(text: 'message', subject: 'title');
     // Check isNotNull because we cannot wait for ShareResult
     expect(SharePlus.instance.share(params), isNotNull);
   });
 
   testWidgets('Can launch shareUri', (WidgetTester tester) async {
-    final params = ShareParams(
-      uri: Uri.parse('https://example.com'),
-    );
+    final params = ShareParams(uri: Uri.parse('https://example.com'));
     // Check isNotNull because we cannot wait for ShareResult
     expect(SharePlus.instance.share(params), isNotNull);
   }, skip: !Platform.isAndroid && !Platform.isIOS);
 
-  testWidgets('Can shareXFile created using File.fromData()',
-      (WidgetTester tester) async {
+  testWidgets('Can shareXFile created using File.fromData()', (
+    WidgetTester tester,
+  ) async {
     final bytes = Uint8List.fromList([1, 2, 3, 4, 5, 6, 7, 8]);
-    final XFile file =
-        XFile.fromData(bytes, name: 'image.jpg', mimeType: 'image/jpeg');
-
-    final params = ShareParams(
-      files: [file],
-      text: 'message',
+    final XFile file = XFile.fromData(
+      bytes,
+      name: 'image.jpg',
+      mimeType: 'image/jpeg',
     );
+
+    final params = ShareParams(files: [file], text: 'message');
     expect(SharePlus.instance.share(params), isNotNull);
   });
 }

--- a/packages/share_plus/share_plus/example/lib/excluded_activity_type.dart
+++ b/packages/share_plus/share_plus/example/lib/excluded_activity_type.dart
@@ -44,8 +44,9 @@ class _ExcludedActivityTypePageState
               final List<CupertinoActivityType> tempSelected = [];
               for (final String type in selected) {
                 tempSelected.add(
-                  CupertinoActivityType.values
-                      .firstWhere((e) => e.value == type),
+                  CupertinoActivityType.values.firstWhere(
+                    (e) => e.value == type,
+                  ),
                 );
               }
               Navigator.pop(context, tempSelected);

--- a/packages/share_plus/share_plus/example/lib/image_previews.dart
+++ b/packages/share_plus/share_plus/example/lib/image_previews.dart
@@ -23,10 +23,12 @@ class ImagePreviews extends StatelessWidget {
 
     final imageWidgets = <Widget>[];
     for (var i = 0; i < imagePaths.length; i++) {
-      imageWidgets.add(_ImagePreview(
-        imagePaths[i],
-        onDelete: onDelete != null ? () => onDelete!(i) : null,
-      ));
+      imageWidgets.add(
+        _ImagePreview(
+          imagePaths[i],
+          onDelete: onDelete != null ? () => onDelete!(i) : null,
+        ),
+      );
     }
 
     return SingleChildScrollView(
@@ -50,10 +52,7 @@ class _ImagePreview extends StatelessWidget {
       child: Stack(
         children: <Widget>[
           ConstrainedBox(
-            constraints: const BoxConstraints(
-              maxWidth: 200,
-              maxHeight: 200,
-            ),
+            constraints: const BoxConstraints(maxWidth: 200, maxHeight: 200),
             child: kIsWeb ? Image.network(imagePath) : Image.file(imageFile),
           ),
           Positioned(
@@ -61,9 +60,10 @@ class _ImagePreview extends StatelessWidget {
             child: Padding(
               padding: const EdgeInsets.all(8.0),
               child: FloatingActionButton(
-                  backgroundColor: Colors.red,
-                  onPressed: onDelete,
-                  child: const Icon(Icons.delete)),
+                backgroundColor: Colors.red,
+                onPressed: onDelete,
+                child: const Icon(Icons.delete),
+              ),
             ),
           ),
         ],

--- a/packages/share_plus/share_plus/example/lib/main.dart
+++ b/packages/share_plus/share_plus/example/lib/main.dart
@@ -58,10 +58,7 @@ class MyHomePageState extends State<MyHomePage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Share Plus Plugin Demo'),
-        elevation: 4,
-      ),
+      appBar: AppBar(title: const Text('Share Plus Plugin Demo'), elevation: 4),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(24),
         child: Column(
@@ -143,7 +140,8 @@ class MyHomePageState extends State<MyHomePage> {
                     extensions: <String>['jpg', 'jpeg', 'png', 'gif'],
                   );
                   final file = await openFile(
-                      acceptedTypeGroups: <XTypeGroup>[typeGroup]);
+                    acceptedTypeGroups: <XTypeGroup>[typeGroup],
+                  );
                   if (file != null) {
                     setState(() {
                       imagePaths.add(file.path);
@@ -316,9 +314,7 @@ class MyHomePageState extends State<MyHomePage> {
       );
       scaffoldMessenger.showSnackBar(getResultSnackBar(shareResult));
     } catch (e) {
-      scaffoldMessenger.showSnackBar(
-        SnackBar(content: Text('Error: $e')),
-      );
+      scaffoldMessenger.showSnackBar(SnackBar(content: Text('Error: $e')));
     }
   }
 
@@ -345,9 +341,7 @@ class MyHomePageState extends State<MyHomePage> {
 
       scaffoldMessenger.showSnackBar(getResultSnackBar(shareResult));
     } catch (e) {
-      scaffoldMessenger.showSnackBar(
-        SnackBar(content: Text('Error: $e')),
-      );
+      scaffoldMessenger.showSnackBar(SnackBar(content: Text('Error: $e')));
     }
   }
 
@@ -359,7 +353,7 @@ class MyHomePageState extends State<MyHomePage> {
         children: [
           Text("Share result: ${result.status}"),
           if (result.status == ShareResultStatus.success)
-            Text("Shared to: ${result.raw}")
+            Text("Shared to: ${result.raw}"),
         ],
       ),
     );

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
     - assets/flutter_logo.png
 
 environment:
-  sdk: '>=3.4.0 <4.0.0'
-  flutter: '>=3.22.0'
+  sdk: '>=3.10.0 <4.0.0'
+  flutter: '>=3.38.1'

--- a/packages/share_plus/share_plus/example/test_driver/share_plus_test.dart
+++ b/packages/share_plus/share_plus/example/test_driver/share_plus_test.dart
@@ -9,8 +9,10 @@ import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final driver = await FlutterDriver.connect();
-  final data =
-      await driver.requestData(null, timeout: const Duration(minutes: 1));
+  final data = await driver.requestData(
+    null,
+    timeout: const Duration(minutes: 1),
+  );
   await driver.close();
   final Map<String, dynamic> result = jsonDecode(data);
   exit(result['result'] == 'true' ? 0 : 1);

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   url_launcher_platform_interface: ^2.3.2
   ffi: ^2.2.0
   web: ^1.1.1
-  win32: ^6.0.0
+  win32: ^6.0.1
 
 dev_dependencies:
   flutter_test:
@@ -51,6 +51,6 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
 environment:
-  sdk: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.1"
 

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -21,5 +21,5 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
 environment:
-  sdk: ">=3.11.0 <4.0.0"
-  flutter: ">=3.41.0"
+  sdk: ">=3.10.0 <4.0.0"
+  flutter: ">=3.38.1"


### PR DESCRIPTION
## Description

With release of win32 6.0.1 it is possible to lower the required Dart and Flutter versions.

Part of #3796 
