### PR TITLE
chore(release): prepare for release

### DIFF
--- a/packages/device_info_plus/device_info_plus/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 13.1.0
+
+ - **FEAT**(device_info_plus): Lower requirements to Dart 3.10 and Flutter 3.38.1 ([#3803](https://github.com/fluttercommunity/plus_plugins/issues/3803)). ([6d73e0d1](https://github.com/fluttercommunity/plus_plugins/commit/6d73e0d1035dd2c6b7fa6691dce4fca31c2a14f6))
+
 ## 13.0.0
 
 > Note: This release has breaking changes.

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the device_info_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  device_info_plus: ^13.0.0
+  device_info_plus: ^13.1.0
 
 dev_dependencies:
   flutter_driver:

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 13.0.0
+version: 13.1.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/device_info_plus/device_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus
@@ -29,7 +29,7 @@ flutter:
         dartPluginClass: DeviceInfoPlusWindowsPlugin
 
 dependencies:
-  device_info_plus_platform_interface: ^8.0.0
+  device_info_plus_platform_interface: ^8.1.0
   ffi: ^2.2.0
   file: ^7.0.1
   flutter:

--- a/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/device_info_plus/device_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.0
+
+ - **FEAT**(device_info_plus): Lower requirements to Dart 3.10 and Flutter 3.38.1 ([#3803](https://github.com/fluttercommunity/plus_plugins/issues/3803)). ([6d73e0d1](https://github.com/fluttercommunity/plus_plugins/commit/6d73e0d1035dd2c6b7fa6691dce4fca31c2a14f6))
+
 ## 8.0.0
 
 > Note: This release has breaking changes.

--- a/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: device_info_plus_platform_interface
 description: A common platform interface for the device_info_plus plugin.
-version: 8.0.0
+version: 8.1.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/network_info_plus/network_info_plus/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.1.0
+
+ - **FEAT**(network_info_plus): Lower requirements to Dart 3.10 and Flutter 3.38.1 ([#3802](https://github.com/fluttercommunity/plus_plugins/issues/3802)). ([63fa060b](https://github.com/fluttercommunity/plus_plugins/commit/63fa060b1a6ec0ce7a6ba02382c313a999c87d8d))
+
 ## 8.0.0
 
 > Note: This release has breaking changes.

--- a/packages/network_info_plus/network_info_plus/example/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/example/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  network_info_plus: ^8.0.0
+  network_info_plus: ^8.1.0
   permission_handler: ^12.0.0+1
 
 dev_dependencies:

--- a/packages/network_info_plus/network_info_plus/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus
 description: Flutter plugin for discovering information (e.g. WiFi details) of the network.
-version: 8.0.0
+version: 8.1.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/network_info_plus/network_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/network_info_plus
@@ -39,7 +39,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   meta: ^1.17.0
-  network_info_plus_platform_interface: ^3.0.0
+  network_info_plus_platform_interface: ^3.1.0
   nm: ^0.5.0
   win32: ^6.0.1
 

--- a/packages/network_info_plus/network_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/network_info_plus/network_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.0
+
+ - **FEAT**(network_info_plus): Lower requirements to Dart 3.10 and Flutter 3.38.1 ([#3802](https://github.com/fluttercommunity/plus_plugins/issues/3802)). ([63fa060b](https://github.com/fluttercommunity/plus_plugins/commit/63fa060b1a6ec0ce7a6ba02382c313a999c87d8d))
+
 ## 3.0.0
 
 > Note: This release has breaking changes.

--- a/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
+++ b/packages/network_info_plus/network_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: network_info_plus_platform_interface
 description: A common platform interface for the network_info_plus plugin.
-version: 3.0.0
+version: 3.1.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/package_info_plus/package_info_plus/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 10.1.0
+
+ - **FEAT**(package_info_plus): Lower requirements to Dart 3.10 and Flutter 3.38.1 ([#3804](https://github.com/fluttercommunity/plus_plugins/issues/3804)). ([bed26b5c](https://github.com/fluttercommunity/plus_plugins/commit/bed26b5cf14bded2d7000f5cca3dffdeb157686c))
+
 ## 10.0.0
 
 > Note: This release has breaking changes.

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -11,11 +11,11 @@ dependencies:
   flutter:
     sdk: flutter
   http: ">=0.13.5 <2.0.0"
-  package_info_plus: ^10.0.0
+  package_info_plus: ^10.1.0
 
 dev_dependencies:
   build_runner: ^2.3.3
-  device_info_plus: ^13.0.0
+  device_info_plus: ^13.1.0
   integration_test:
     sdk: flutter
   flutter_driver:

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus
 description: Flutter plugin for querying information about the application package, such as CFBundleVersion on iOS or versionCode on Android.
-version: 10.0.0
+version: 10.1.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/package_info_plus/package_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/package_info_plus
@@ -36,7 +36,7 @@ dependencies:
     sdk: flutter
   http: ^1.6.0
   meta: ^1.17.0
-  package_info_plus_platform_interface: ^4.0.0
+  package_info_plus_platform_interface: ^4.1.0
   path: ^1.9.1
   web: ^1.1.1
   win32: ^6.0.1

--- a/packages/package_info_plus/package_info_plus_platform_interface/CHANGELOG.md
+++ b/packages/package_info_plus/package_info_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.1.0
+
+ - **FEAT**(package_info_plus): Lower requirements to Dart 3.10 and Flutter 3.38.1 ([#3804](https://github.com/fluttercommunity/plus_plugins/issues/3804)). ([bed26b5c](https://github.com/fluttercommunity/plus_plugins/commit/bed26b5cf14bded2d7000f5cca3dffdeb157686c))
+
 ## 4.0.0
 
 > Note: This release has breaking changes.

--- a/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: package_info_plus_platform_interface
 description: A common platform interface for the package_info_plus plugin.
-version: 4.0.0
+version: 4.1.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 

--- a/packages/share_plus/share_plus/CHANGELOG.md
+++ b/packages/share_plus/share_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 13.1.0
+
+ - **FEAT**(share_plus): Lower requirements to Dart 3.10 and Flutter 3.38.1 ([#3801](https://github.com/fluttercommunity/plus_plugins/issues/3801)). ([d965e00e](https://github.com/fluttercommunity/plus_plugins/commit/d965e00e5082d4e32e25cacad0b193a735d51c5f))
+
 ## 13.0.0
 
 > Note: This release has breaking changes.

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -4,7 +4,7 @@ description: Demonstrates how to use the share_plus plugin.
 dependencies:
   flutter:
     sdk: flutter
-  share_plus: ^13.0.0
+  share_plus: ^13.1.0
   image_picker: ^1.1.2
   file_selector: ^1.0.3
 

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus
 description: Flutter plugin for sharing content via the platform share UI, using the ACTION_SEND intent on Android and UIActivityViewController on iOS.
-version: 13.0.0
+version: 13.1.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/share_plus/share_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/share_plus
@@ -35,7 +35,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  share_plus_platform_interface: ^7.0.0
+  share_plus_platform_interface: ^7.1.0
   file: ^7.0.1
   url_launcher_web: ^2.4.2
   url_launcher_windows: ^3.1.5

--- a/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
+++ b/packages/share_plus/share_plus_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.1.0
+
+ - **FEAT**(share_plus): Lower requirements to Dart 3.10 and Flutter 3.38.1 ([#3801](https://github.com/fluttercommunity/plus_plugins/issues/3801)). ([d965e00e](https://github.com/fluttercommunity/plus_plugins/commit/d965e00e5082d4e32e25cacad0b193a735d51c5f))
+
 ## 7.0.0
 
 > Note: This release has breaking changes.

--- a/packages/share_plus/share_plus_platform_interface/pubspec.yaml
+++ b/packages/share_plus/share_plus_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: share_plus_platform_interface
 description: A common platform interface for the share_plus plugin.
-version: 7.0.0
+version: 7.1.0
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/
 


### PR DESCRIPTION
## Description

Relaxing requirements for Dart and Flutter via upgrade to `win32: 6.0.1`