### PR TITLE
refactor(package_info_plus): use win32's built-in structs and helpers

### DIFF
--- a/packages/package_info_plus/package_info_plus/lib/src/file_attribute.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/file_attribute.dart
@@ -4,23 +4,6 @@ import 'dart:io';
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
-base class FILEATTRIBUTEDATA extends Struct {
-  @DWORD()
-  external int dwFileAttributes;
-
-  external FILETIME ftCreationTime;
-
-  external FILETIME ftLastAccessTime;
-
-  external FILETIME ftLastWriteTime;
-
-  @DWORD()
-  external int nFileSizeHigh;
-
-  @DWORD()
-  external int nFileSizeLow;
-}
-
 class FileAttributes {
   final String filePath;
 
@@ -43,7 +26,7 @@ class FileAttributes {
     }
 
     final lptstrFilename = filePath.toPcwstr();
-    final lpFileInformation = calloc<FILEATTRIBUTEDATA>();
+    final lpFileInformation = calloc<WIN32_FILE_ATTRIBUTE_DATA>();
 
     try {
       final result = GetFileAttributesEx(
@@ -55,29 +38,15 @@ class FileAttributes {
         throw WindowsException(result.error.toHRESULT());
       }
 
-      final FILEATTRIBUTEDATA fileInformation = lpFileInformation.ref;
+      final WIN32_FILE_ATTRIBUTE_DATA fileInformation = lpFileInformation.ref;
 
       return (
-        creationTime: fileTimeToDartDateTime(fileInformation.ftCreationTime),
-        lastWriteTime: fileTimeToDartDateTime(fileInformation.ftLastWriteTime),
+        creationTime: fileInformation.ftCreationTime.toDateTime(),
+        lastWriteTime: fileInformation.ftLastWriteTime.toDateTime(),
       );
     } finally {
       free(lptstrFilename);
       free(lpFileInformation);
     }
-  }
-
-  static DateTime? fileTimeToDartDateTime(FILETIME? fileTime) {
-    if (fileTime == null) return null;
-
-    final high = fileTime.dwHighDateTime;
-    final low = fileTime.dwLowDateTime;
-
-    final fileTime64 = (high << 32) + low;
-
-    final windowsTimeMillis = fileTime64 ~/ 10000;
-    final unixTimeMillis = windowsTimeMillis - 11644473600000;
-
-    return DateTime.fromMillisecondsSinceEpoch(unixTimeMillis);
   }
 }

--- a/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
+++ b/packages/package_info_plus/package_info_plus/lib/src/file_version_info.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 // Inspired by:
-// - github.com/chromium/chromium/src/base/file_version_info_win.cc
-// - github.com/timsneath/win32/example/filever.dart
+// - github.com/chromium/chromium/blob/main/base/file_version_info_win.cc
+// - github.com/halildurmus/win32/blob/main/examples/filever.dart
 
 import 'dart:ffi';
 import 'dart:io';


### PR DESCRIPTION
## Description

Replaces the custom `FILEATTRIBUTEDATA` struct and `fileTimeToDartDateTime` helper with `WIN32_FILE_ATTRIBUTE_DATA` and `FILETIME.toDateTime()` already provided by `package:win32`, removing duplicated logic and reducing maintenance overhead.

Also fixes the URLs for the reference files in `file_version_info.dart`.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

