### PR TITLE
refactor(share_plus): use win32's RtlGetVersion instead of manual lookup

### DIFF
--- a/packages/share_plus/share_plus/lib/src/windows_version_helper.dart
+++ b/packages/share_plus/share_plus/lib/src/windows_version_helper.dart
@@ -1,5 +1,6 @@
-import 'dart:io';
 import 'dart:ffi';
+import 'dart:io';
+
 import 'package:ffi/ffi.dart';
 import 'package:win32/win32.dart';
 
@@ -18,24 +19,9 @@ class VersionHelper {
 
   VersionHelper._() {
     if (Platform.isWindows) {
-      final pointer = calloc<OSVERSIONINFOEX>();
-      pointer.ref
-        ..dwOSVersionInfoSize = sizeOf<OSVERSIONINFOEX>()
-        ..dwBuildNumber = 0
-        ..dwMajorVersion = 0
-        ..dwMinorVersion = 0
-        ..dwPlatformId = 0
-        ..szCSDVersion = ''
-        ..wServicePackMajor = 0
-        ..wServicePackMinor = 0
-        ..wSuiteMask = 0
-        ..wProductType = 0;
-      final rtlGetVersion = DynamicLibrary.open('ntdll.dll')
-          .lookupFunction<
-            Void Function(Pointer<OSVERSIONINFOEX>),
-            void Function(Pointer<OSVERSIONINFOEX>)
-          >('RtlGetVersion');
-      rtlGetVersion(pointer);
+      final pointer = calloc<OSVERSIONINFOEX>()
+        ..ref.dwOSVersionInfoSize = sizeOf<OSVERSIONINFOEX>();
+      RtlGetVersion(pointer.cast());
       isWindows10RS5OrGreater =
           pointer.ref.dwBuildNumber >= kWindows10RS5BuildNumber;
       calloc.free(pointer);


### PR DESCRIPTION
## Description

Simplifies the Windows version check in `VersionHelper` by replacing the manual lookup for `RtlGetVersion` API with the one provided by `package:win32`.

This also removes the redundant zero-initialization of all `OSVERSIONINFOEX` fields — `calloc` already zero-initializes allocated memory, so only `dwOSVersionInfoSize` needs to be set explicitly as required by the API.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

