### PR TITLE
fix(network_info_plus): fix memory leak and use GUID.toNative() helper

### DIFF
--- a/packages/network_info_plus/network_info_plus/lib/src/network_info_plus_windows.dart
+++ b/packages/network_info_plus/network_info_plus/lib/src/network_info_plus_windows.dart
@@ -5,8 +5,8 @@ import 'dart:ffi';
 
 import 'package:ffi/ffi.dart';
 import 'package:network_info_plus/src/windows_structs.dart';
-import 'package:win32/win32.dart';
 import 'package:network_info_plus_platform_interface/network_info_plus_platform_interface.dart';
+import 'package:win32/win32.dart';
 
 typedef WlanQuery =
     String? Function(
@@ -62,10 +62,12 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
       }
 
       for (var i = 0; i < ppInterfaceList.value.ref.dwNumberOfItems; i++) {
-        final pInterfaceGuid = calloc<GUID>()
-          ..ref.setGUID(
-            ppInterfaceList.value.ref.InterfaceInfo[i].InterfaceGuid.toString(),
-          );
+        final pInterfaceGuid = ppInterfaceList
+            .value
+            .ref
+            .InterfaceInfo[i]
+            .InterfaceGuid
+            .toNative();
 
         const opCode = WLAN_INTF_OPCODE(
           7,
@@ -98,7 +100,8 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
       }
       return null;
     } finally {
-      WlanFreeMemory(ppInterfaceList);
+      WlanFreeMemory(ppInterfaceList.value);
+      free(ppInterfaceList);
       closeHandle();
     }
   }
@@ -194,18 +197,18 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
         try {
           GetAdaptersAddresses(
             family,
-            GET_ADAPTERS_ADDRESSES_FLAGS(0),
+            const GET_ADAPTERS_ADDRESSES_FLAGS(0),
             null,
             ulSize,
           );
           pIpAdapterAddress = HeapAlloc(
             GetProcessHeap().value,
-            HEAP_FLAGS(0),
+            const HEAP_FLAGS(0),
             ulSize.value,
           ).cast();
           GetAdaptersAddresses(
             family,
-            GET_ADAPTERS_ADDRESSES_FLAGS(0),
+            const GET_ADAPTERS_ADDRESSES_FLAGS(0),
             pIpAdapterAddress,
             ulSize,
           );
@@ -247,18 +250,18 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
         try {
           GetAdaptersAddresses(
             AF_INET,
-            GET_ADAPTERS_ADDRESSES_FLAGS(0),
+            const GET_ADAPTERS_ADDRESSES_FLAGS(0),
             null,
             ulSize,
           );
           pIpAdapterAddress = HeapAlloc(
             GetProcessHeap().value,
-            HEAP_FLAGS(0),
+            const HEAP_FLAGS(0),
             ulSize.value,
           ).cast();
           GetAdaptersAddresses(
             AF_INET,
-            GET_ADAPTERS_ADDRESSES_FLAGS(0),
+            const GET_ADAPTERS_ADDRESSES_FLAGS(0),
             pIpAdapterAddress,
             ulSize,
           );
@@ -325,18 +328,18 @@ class NetworkInfoPlusWindowsPlugin extends NetworkInfoPlatform {
         try {
           GetAdaptersAddresses(
             AF_INET,
-            GET_ADAPTERS_ADDRESSES_FLAGS(0x80),
+            const GET_ADAPTERS_ADDRESSES_FLAGS(0x80),
             null,
             ulSize,
           );
           pIpAdapterAddress = HeapAlloc(
             GetProcessHeap().value,
-            HEAP_FLAGS(0),
+            const HEAP_FLAGS(0),
             ulSize.value,
           ).cast();
           GetAdaptersAddresses(
             AF_INET,
-            GET_ADAPTERS_ADDRESSES_FLAGS(0x80),
+            const GET_ADAPTERS_ADDRESSES_FLAGS(0x80),
             pIpAdapterAddress,
             ulSize,
           );


### PR DESCRIPTION
## Description

This PR brings several improvements to the Windows implementation of `network_info_plus`:

- Fixes `WlanFreeMemory` call where `ppInterfaceList` was incorrectly passed directly instead of `ppInterfaceList.value` (the pointer allocated by `WlanEnumInterfaces`). The outer pointer is now also correctly released with `free()`.
- Replaces the manual `calloc<GUID>()` + `setGUID()` pattern with the more efficient `GUID.toNative()` helper from `package:win32`, simplifying GUID pointer creation.
- Uses `const` for `GET_ADAPTERS_ADDRESSES_FLAGS` and `HEAP_FLAGS` literals to fix analyzer issues

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

