### PR TITLE
fix(device_info_plus): close registry keys and use win32's RtlGetVersion

### DIFF
--- a/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
+++ b/packages/device_info_plus/device_info_plus/lib/src/device_info_plus_windows.dart
@@ -22,20 +22,6 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
 
   WindowsDeviceInfo? _cache;
 
-  // In a well-meaning but somewhat misguided attempt to reduce apps from using
-  // version numbers for feature detection, most version number APIs don't give
-  // expected results on Windows 8 and above. RtlGetVersion is reliable and
-  // stable, but as a kernel API is documented in the Windows DDK (Driver
-  // Development Kit), rather than the SDK. As such, it's not included in
-  // package:win32, so we have to manually define it here.
-  //
-  // ignore: non_constant_identifier_names
-  void Function(Pointer<OSVERSIONINFOEX>) RtlGetVersion =
-      DynamicLibrary.open('ntdll.dll').lookupFunction<
-        Void Function(Pointer<OSVERSIONINFOEX>),
-        void Function(Pointer<OSVERSIONINFOEX>)
-      >('RtlGetVersion');
-
   /// Returns a [WindowsDeviceInfo] with information about the device.
   @override
   Future<BaseDeviceInfo> deviceInfo() {
@@ -68,14 +54,16 @@ class DeviceInfoPlusWindowsPlugin extends DeviceInfoPlatform {
       final registeredOwner =
           currentVersionKey.getString('RegisteredOwner') ?? '';
       final releaseId = currentVersionKey.getString('ReleaseId') ?? '';
+      currentVersionKey.close();
 
       final sqmClientKey = LOCAL_MACHINE.open(r'SOFTWARE\Microsoft\SQMClient');
       final machineId = sqmClientKey.getString('MachineId') ?? '';
+      sqmClientKey.close();
 
       GetSystemInfo(systemInfo);
 
       // Use `RtlGetVersion` from `ntdll.dll` to get the Windows version.
-      RtlGetVersion(osVersionInfo);
+      RtlGetVersion(osVersionInfo.cast());
 
       // Handle [productName] for Windows 11 separately (as per Raymond Chen's comment).
       // https://stackoverflow.com/questions/69460588/how-can-i-find-the-windows-product-name-in-windows-11


### PR DESCRIPTION
## Description

- Closes `currentVersionKey` and `sqmClientKey` registry keys after use to prevent memory leaks and other potential issues
- Replaces the manual lookup for `RtlGetVersion` API with the one provided by `package:win32`

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

