### PR TITLE
fix(share_plus): avoid iOS 26 share sheet crash for non-image files

### DIFF
--- a/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
+++ b/packages/share_plus/share_plus/ios/share_plus/Sources/share_plus/FPPSharePlusPlugin.m
@@ -247,7 +247,19 @@ activityTypesForStrings(NSArray<NSString *> *activityTypeStrings) {
     }
 
     // https://stackoverflow.com/questions/60563773/ios-13-share-sheet-changing-subtitle-item-description
-    metadata.originalURL = [NSURL fileURLWithPath:description];
+    // The fake file URL above is a long-standing trick used to surface the
+    // file size/extension as a subtitle in the share sheet. iOS 26 introduced
+    // stricter validation of LPLinkMetadata.originalURL: when the share sheet
+    // tries to fetch link metadata (SHSheetActivityItemsManager) for the
+    // bogus URL — for example when sharing .docx files — it crashes with
+    // "*** -[__NSArrayM insertObject:atIndex:]: object cannot be nil".
+    // Skip the fake URL on iOS 26+ and accept the loss of the subtitle in
+    // exchange for not crashing. See issue #3784.
+    if (@available(iOS 26.0, *)) {
+      // Leave metadata.originalURL nil.
+    } else {
+      metadata.originalURL = [NSURL fileURLWithPath:description];
+    }
     if (_mimeType && [_mimeType hasPrefix:@"image/"]) {
       UIImage *image = [UIImage imageWithContentsOfFile:_path];
       metadata.imageProvider = [[NSItemProvider alloc]


### PR DESCRIPTION
Fixes #3784.

## What's wrong

Pre-iOS 26 the plugin used a fake file URL trick to display the file size and extension as a subtitle in the iOS share sheet:

```objc
// description = "DOCX • 500 KB"
metadata.originalURL = [NSURL fileURLWithPath:description];
```

This worked because pre-iOS 26 versions of `LinkPresentation` accepted any `NSURL` and only used it for display lookup.

iOS 26 tightened validation of `LPLinkMetadata.originalURL`. When `SHSheetActivityItemsManager` asynchronously fetches link metadata for the bogus URL — reproducible when sharing `.docx` files — `LPLinkPreview` returns a `nil` or incomplete metadata object, and `_updateMetadataItemForActivityItem:withFetchedMetadata:` crashes inserting it into an `NSMutableArray`:

```
*** -[__NSArrayM insertObject:atIndex:]: object cannot be nil
SHSheetActivityItemsManager -[SHSheetActivityItemsManager _updateMetadataItemForActivityItem:withFetchedMetadata:]
SHSheetActivityItemsManager -[SHSheetActivityItemsManager _fetchMetadataForActivityItem:withHandler:]
```

## Fix

Gate the fake-URL trick on iOS < 26 with `@available(iOS 26.0, *)`. On iOS 26 and later, leave `originalURL` unset (defaults to `nil`). The share sheet still works — the title and image preview both still render — but the size/extension subtitle that the fake URL was producing is no longer shown on iOS 26+.

That tradeoff matches what the reporter on #3784 already suggested:

> Setting `metadata.originalURL = nil` instead of the fake path may help.

PDFs and plain text are unaffected, and pre-iOS 26 behaviour is unchanged.

## Test plan

- [ ] Manually verify on an iOS 26.x device or simulator: share a `.docx` file, confirm no crash.
- [ ] Manually verify on an iOS 17 device or simulator: share a `.docx` file, confirm subtitle still shows (\"DOCX • 500 KB\").
- [ ] Manually verify on iOS 17 and iOS 26: image sharing still produces a thumbnail preview (`metadata.imageProvider` path is unaffected).

I do not currently have an iOS 26 simulator to run the repro myself; opening as a draft so a maintainer or CI can validate the iOS 26 behaviour before this is marked ready.

## Risks

- iOS 26+ users lose the file size subtitle in the share sheet. The title and image preview are unaffected. This matches the reporter's expectation in the issue.
- If a future iOS version reintroduces support for arbitrary `originalURL` values, this gate could be removed; for now `iOS 26.0` is the safe lower bound based on the reproduction in #3784.

## Related

- #3768 — separate iOS 26 crash with `sharePositionOrigin` (PR #3769).
- #3645 — `sharePositionOrigin must be set` crash.