### PR TITLE
feat(android): Migrate plugins to built-in Kotlin

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/build.gradle
+++ b/packages/device_info_plus/device_info_plus/android/build.gradle
@@ -22,7 +22,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     namespace 'dev.fluttercommunity.plus.device_info'
@@ -31,10 +30,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = 17
     }
 
     defaultConfig {
@@ -48,5 +43,11 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -19,7 +19,5 @@ flutter:
   uses-material-design: true
 
 environment:
-  sdk: '>=3.10.0 <4.0.0'
-  flutter: '>=3.38.1'
-
-
+  sdk: ">=3.12.0-0 <4.0.0"
+  flutter: ">=3.44.0-0.0.pre"

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -48,5 +48,5 @@ dev_dependencies:
   mockito: ^5.6.4
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.1"
+  sdk: ">=3.12.0-0 <4.0.0"
+  flutter: ">=3.44.0-0.0.pre"

--- a/packages/package_info_plus/package_info_plus/android/build.gradle
+++ b/packages/package_info_plus/package_info_plus/android/build.gradle
@@ -23,7 +23,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     namespace 'dev.fluttercommunity.plus.packageinfo'
@@ -32,10 +31,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = 17
     }
 
     defaultConfig {
@@ -49,5 +44,11 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -4,7 +4,8 @@ version: 1.2.3+4
 publish_to: "none"
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.12.0-0 <4.0.0"
+  flutter: ">=3.44.0-0.0.pre"
 
 dependencies:
   clock: ^1.1.1

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -47,5 +47,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.1"
+  sdk: ">=3.12.0-0 <4.0.0"
+  flutter: ">=3.44.0-0.0.pre"

--- a/packages/sensors_plus/sensors_plus/android/build.gradle
+++ b/packages/sensors_plus/sensors_plus/android/build.gradle
@@ -22,7 +22,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     namespace 'dev.fluttercommunity.plus.sensors'
@@ -31,10 +30,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = 17
     }
 
     defaultConfig {
@@ -47,5 +42,11 @@ android {
 
     dependencies {
       implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/packages/sensors_plus/sensors_plus/pubspec.yaml
+++ b/packages/sensors_plus/sensors_plus/pubspec.yaml
@@ -36,5 +36,5 @@ dev_dependencies:
   flutter_lints: ">=4.0.0 <6.0.0"
 
 environment:
-  sdk: ">=3.3.0 <4.0.0"
-  flutter: ">=3.19.0"
+  sdk: ">=3.12.0-0 <4.0.0"
+  flutter: ">=3.44.0-0.0.pre"

--- a/packages/share_plus/share_plus/android/build.gradle
+++ b/packages/share_plus/share_plus/android/build.gradle
@@ -22,7 +22,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     namespace 'dev.fluttercommunity.plus.share'
@@ -31,10 +30,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = 17
     }
 
     defaultConfig {
@@ -50,5 +45,11 @@ android {
         implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
         implementation 'androidx.core:core-ktx:1.16.0'
         implementation 'androidx.annotation:annotation:1.9.1'
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -24,5 +24,5 @@ flutter:
     - assets/flutter_logo.png
 
 environment:
-  sdk: '>=3.10.0 <4.0.0'
-  flutter: '>=3.38.1'
+  sdk: ">=3.12.0-0 <4.0.0"
+  flutter: ">=3.44.0-0.0.pre"

--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -51,6 +51,5 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.1"
-
+  sdk: ">=3.12.0-0 <4.0.0"
+  flutter: ">=3.44.0-0.0.pre"


### PR DESCRIPTION
# device_info_plus

## Description
Move the Android plugin to Flutter's built-in Kotlin setup and remove the old `kotlin-android` wiring. This keeps the plugin aligned with the supported Android build path before the old KGP flow becomes a build problem.

## Related Issues
None.

## Checklist
- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using Conventional Commits.
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] I ran the available validation for this change: `flutter pub get` and the example build on the Flutter 3.44 line.
- [x] I checked the app side with `flutter analyze`; it only reports the pre-existing infos.

## Breaking Change
No, this is not a breaking change.

---

# package_info_plus

## Description
Move the Android plugin to Flutter's built-in Kotlin setup and remove the old `kotlin-android` wiring. This keeps the plugin aligned with the supported Android build path before the old KGP flow becomes a build problem.

## Related Issues
None.

## Checklist
- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using Conventional Commits.
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] I ran the available validation for this change: `flutter pub get` and the example build on the Flutter 3.44 line.
- [x] I checked the app side with `flutter analyze`; it only reports the pre-existing infos.

## Breaking Change
No, this is not a breaking change.

---

# sensors_plus

## Description
Move the Android plugin to Flutter's built-in Kotlin setup and remove the old `kotlin-android` wiring. This keeps the plugin aligned with the supported Android build path before the old KGP flow becomes a build problem.

## Related Issues
None.

## Checklist
- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using Conventional Commits.
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] I ran the available validation for this change: `flutter pub get` and the example build on the Flutter 3.44 line.
- [x] I checked the app side with `flutter analyze`; it only reports the pre-existing infos.

## Breaking Change
No, this is not a breaking change.

---

# share_plus

## Description
Move the Android plugin to Flutter's built-in Kotlin setup and remove the old `kotlin-android` wiring. This keeps the plugin aligned with the supported Android build path before the old KGP flow becomes a build problem.

## Related Issues
None.

## Checklist
- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using Conventional Commits.
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] I ran the available validation for this change: `flutter pub get` and the example build on the Flutter 3.44 line.
- [x] I checked the app side with `flutter analyze`; it only reports the pre-existing infos.

## Breaking Change
No, this is not a breaking change.
