### PR TITLE
feat(package_info_plus)!: Migrate Android plugin to built-in Kotlin

### DIFF
--- a/packages/package_info_plus/package_info_plus/android/build.gradle
+++ b/packages/package_info_plus/package_info_plus/android/build.gradle
@@ -23,7 +23,6 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
 
 android {
     namespace 'dev.fluttercommunity.plus.packageinfo'
@@ -32,10 +31,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = 17
     }
 
     defaultConfig {
@@ -49,5 +44,11 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/packages/package_info_plus/package_info_plus/example/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/example/pubspec.yaml
@@ -4,7 +4,8 @@ version: 1.2.3+4
 publish_to: "none"
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
+  sdk: ">=3.12.0-0 <4.0.0"
+  flutter: ">=3.44.0-0.0.pre"
 
 dependencies:
   clock: ^1.1.1

--- a/packages/package_info_plus/package_info_plus/pubspec.yaml
+++ b/packages/package_info_plus/package_info_plus/pubspec.yaml
@@ -47,5 +47,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=3.10.0 <4.0.0"
-  flutter: ">=3.38.1"
+  sdk: ">=3.12.0-0 <4.0.0"
+  flutter: ">=3.44.0-0.0.pre"


### PR DESCRIPTION
## Description
Move the Android plugin to Flutter's built-in Kotlin setup and remove the old `kotlin-android` wiring. This keeps the plugin aligned with the supported Android build path before the old KGP flow becomes a build problem.

## Related Issues
None.

## Checklist
- [x] I read the Contributor Guide and followed the process outlined there for submitting PRs.
- [x] I titled the PR using Conventional Commits.
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] I ran the available validation for this change: `flutter pub get` and the example build on the Flutter 3.44 line.
- [x] I checked the app side with `flutter analyze`; it only reports the pre-existing infos.

## Breaking Change
Yes, this raises the minimum Flutter/Dart floor for the package release.
