### PR TITLE
fix(share_plus): relax win32 dependency constraint

### DIFF
--- a/packages/share_plus/share_plus/pubspec.yaml
+++ b/packages/share_plus/share_plus/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   url_launcher_platform_interface: ^2.3.2
   ffi: ^2.2.0
   web: ^1.1.1
-  win32: ^6.0.1
+  win32: ">=5.15.0 <7.0.0"
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

This PR relaxes the `win32` dependency constraint in `share_plus` from `^6.0.1` to `>=5.15.0 <7.0.0`.

The current constraint requires `win32` 6.x, which prevents `share_plus` from resolving alongside packages that still depend on `win32` 5.x, such as recent `file_picker` versions. This change allows both `win32` 5.15.x and 6.x, improving dependency compatibility without changing plugin behavior.

## Related Issues

No related issue.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.
