### PR TITLE
feat(share_plus): launch share target in its own task on Android

### DIFF
--- a/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
+++ b/packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
@@ -131,6 +131,16 @@ internal class Share(
                 Intent.createChooser(shareIntent, title)
             }
 
+        // Launch the destination app in its own task so it appears as a
+        // separate entry in the recents switcher instead of being stacked
+        // on top of the calling app's task. Without this flag the target
+        // (WhatsApp, Telegram, Drive, etc.) inherits the caller's task —
+        // user sees a single recents entry for the caller with the target
+        // visible inside, which is confusing and inconsistent with how
+        // Android share works for most native apps (e.g. Google Keep,
+        // Instagram). See plus_plugins issue #2267.
+        chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+
         // Grant permissions to all apps that can handle the files shared
         if (fileUris != null) {
             val resInfoList = getContext().packageManager.queryIntentActivities(


### PR DESCRIPTION
## Summary

Adds `Intent.FLAG_ACTIVITY_NEW_TASK` to the chooser intent on Android so the destination app (WhatsApp, Telegram, Drive, etc.) launches in its own task instead of being stacked on top of the calling app's task.

## Motivation

Resolves the long-standing UX inconsistency described in:

- **#2267** ([Request]: Specify Intent.FLAG_ACTIVITY_NEW_TASK for sharing) — open since Oct 2023
- **#2682** (can't back to my app after share via QQ Email) — closed, but root cause was the same; maintainer @miquelbeltran [acknowledged](https://github.com/fluttercommunity/plus_plugins/issues/2682#issuecomment-2012213175) the fix mechanism in the comments

Without the flag, the recents switcher shows a single entry for the calling app with the target app visible inside it — inconsistent with how native Android apps (Google Keep, Instagram, etc.) handle share, where target and caller appear as separate recents entries.

Demonstration from #2267 (linked videos): Keep → Drive works correctly; Thunder (using share_plus) → Drive does not.

## Previous attempts

- **#3435** (Jan 2025, `AndroidIntentOptions` with configurable flags) — closed in favor of the refactor in #3404, but the refactor merged without absorbing this feature
- **#3751** (Feb 2026, equivalent one-line fix) — closed 19 seconds after creation by the conventional-commits CI bot rejecting the title; never reopened

This PR uses the same minimal approach as #3751 with a conventional-commits-compliant title.

## Change

One file, ~10 lines (including comment):

```kotlin
// packages/share_plus/share_plus/android/src/main/kotlin/dev/fluttercommunity/plus/share/Share.kt
chooserIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
```

Applied right after `Intent.createChooser(...)` and before the file-permission grant + `startActivity`.

## Trade-off considered

@miquelbeltran's [comment on #2267](https://github.com/fluttercommunity/plus_plugins/issues/2267#issuecomment-1768063127) noted that some apps (e.g. Twitter) do share within the same task and asked for "choice". This PR opts for always-on rather than introducing a new API surface, matching what #3751 attempted. Rationale:

- The same-task behavior is generally considered a UX regression vs. native Android share — most apps that need same-task behavior do so unintentionally.
- An always-on flag has zero API surface change → no migration burden, no deprecation noise.
- If the team prefers opt-in, happy to convert this to a `ShareParams.newTask` (default true) — let me know and I'll push.

## Test plan

- [x] Manual test on Android 11 (OnePlus 6T): share text + image to Telegram and WhatsApp → target apps now appear as separate recents entries (was: single consolidated entry).
- [x] Manual test: back button in target app still returns to caller app correctly.
- [x] Manual test: deep links (`https://...`) inside shared text are preserved and handled by target.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

No API surface change. Behavioral change only: target apps will now appear as separate recents entries (the same way native Android share behaves). Apps that explicitly relied on the previous same-task stacking would need to wrap share calls in a task-affinity workaround — but I'm not aware of any documented case.