### PR TITLE
docs(all): update local tooling requirements and use correct style guide url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,8 +50,7 @@ Please follow this steps when working on the PlusPlugins.
 - [git](https://git-scm.com) (used for source version control).
 - An ssh client (used to authenticate with GitHub).
 - An IDE such as [Android Studio](https://developer.android.com/studio) or [Visual Studio Code](https://code.visualstudio.com/).
-- [`flutter_plugin_tools`](https://pub.dev/packages/flutter_plugin_tools) locally activated.
-- [`tuneup`](https://pub.dev/packages/tuneup) locally activated.
+- [`flutter_plugin_tools`](https://pub.dev/packages/flutter_plugin_tools) globally activated.
 
 ## 2. Forking & cloning the repository
 
@@ -177,7 +176,7 @@ file.
 We gladly accept contributions via GitHub pull requests.
 
 Please follow the
-[Flutter style guide](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo) and
+[Flutter style guide](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md) and
 [design principles](https://flutter.dev/design-principles/) before
 working on anything non-trivial. These guidelines are intended to
 keep the code consistent and avoid common pitfalls.

--- a/melos.yaml
+++ b/melos.yaml
@@ -24,7 +24,6 @@ scripts:
     description: |
       Run all static analysis checks
       - Analyze the project for Dart analysis issues.
-      - Requires `pub global activate tuneup`.
 
   analyze:
     run: |
@@ -38,7 +37,7 @@ scripts:
     run: dart pub global run flutter_plugin_tools format
     description: |
       activate flutter_plugin_tools
-       - Requires `flutter_plugin_tools` (`pub global activate flutter_plugin_tools`).
+       - Requires `flutter_plugin_tools` (`flutter pub global activate flutter_plugin_tools`).
        - Requires `clang-format` (can be installed via Brew on macOS).
 
   build:all:


### PR DESCRIPTION
## Description

- Clarify that flutter_plugin_tools requires global activation
- Remove tuneup from prerequisite list as it is archived and no longer used by melos analyze
- Replace redirect link for Flutter style guide

## Related Issues

No issue reported, as this is improvement on contributing guide

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- All existing and new tests are passing. **this is doc related and should not introduce a new bug**
- The analyzer (`flutter analyze`) does not report any problems on my PR. **this is doc related and should not introduce a new bug**

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?
- [x] No, this is *not* a breaking change.

