### PR TITLE
fix(sensors_plus): resolve lint issues found during melos analyze

### DIFF
--- a/packages/sensors_plus/sensors_plus/lib/sensors_plus.dart
+++ b/packages/sensors_plus/sensors_plus/lib/sensors_plus.dart
@@ -67,7 +67,6 @@ Stream<MagnetometerEvent> magnetometerEventStream({
 
 /// Returns a broadcast stream of events from the device barometer at the
 /// given sampling frequency.
-@override
 Stream<BarometerEvent> barometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {

--- a/packages/sensors_plus/sensors_plus/lib/src/sensors_plus_web.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/sensors_plus_web.dart
@@ -34,7 +34,6 @@ Stream<MagnetometerEvent> get magnetometerEvents {
 
 /// Returns a broadcast stream of events from the device accelerometer at the
 /// given sampling frequency.
-@override
 Stream<AccelerometerEvent> accelerometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
@@ -43,7 +42,6 @@ Stream<AccelerometerEvent> accelerometerEventStream({
 
 /// Returns a broadcast stream of events from the device gyroscope at the
 /// given sampling frequency.
-@override
 Stream<GyroscopeEvent> gyroscopeEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
@@ -52,7 +50,6 @@ Stream<GyroscopeEvent> gyroscopeEventStream({
 
 /// Returns a broadcast stream of events from the device accelerometer with
 /// gravity removed at the given sampling frequency.
-@override
 Stream<UserAccelerometerEvent> userAccelerometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
@@ -61,7 +58,6 @@ Stream<UserAccelerometerEvent> userAccelerometerEventStream({
 
 /// Returns a broadcast stream of events from the device magnetometer at the
 /// given sampling frequency.
-@override
 Stream<MagnetometerEvent> magnetometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
@@ -70,7 +66,6 @@ Stream<MagnetometerEvent> magnetometerEventStream({
 
 /// Returns a broadcast stream of events from the device barometer at the
 /// given sampling frequency.
-@override
 Stream<BarometerEvent> barometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {

--- a/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
+++ b/packages/sensors_plus/sensors_plus/lib/src/web_sensors.dart
@@ -22,6 +22,7 @@ class WebSensorsPlugin extends SensorsPlatform {
   }) {
     try {
       initSensor();
+      // ignore: invalid_runtime_check_with_js_interop_types
     } on DOMException catch (e) {
       if (onError != null) {
         onError();

--- a/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
+++ b/packages/sensors_plus/sensors_plus_platform_interface/test/sensors_plus_platform_interface_test.dart
@@ -13,7 +13,6 @@ final MethodChannelSensors methodChannel = MethodChannelSensors();
 
 /// Returns a broadcast stream of events from the device accelerometer at the
 /// given sampling frequency.
-@override
 Stream<AccelerometerEvent> accelerometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
@@ -22,7 +21,6 @@ Stream<AccelerometerEvent> accelerometerEventStream({
 
 /// Returns a broadcast stream of events from the device gyroscope at the
 /// given sampling frequency.
-@override
 Stream<GyroscopeEvent> gyroscopeEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
@@ -31,7 +29,6 @@ Stream<GyroscopeEvent> gyroscopeEventStream({
 
 /// Returns a broadcast stream of events from the device accelerometer with
 /// gravity removed at the given sampling frequency.
-@override
 Stream<UserAccelerometerEvent> userAccelerometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
@@ -41,7 +38,6 @@ Stream<UserAccelerometerEvent> userAccelerometerEventStream({
 
 /// Returns a broadcast stream of events from the device magnetometer at the
 /// given sampling frequency.
-@override
 Stream<MagnetometerEvent> magnetometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {
@@ -50,7 +46,6 @@ Stream<MagnetometerEvent> magnetometerEventStream({
 
 /// Returns a broadcast stream of events from the device magnetometer at the
 /// given sampling frequency.
-@override
 Stream<BarometerEvent> barometerEventStream({
   Duration samplingPeriod = SensorInterval.normalInterval,
 }) {


### PR DESCRIPTION
## Description
- Fix incorrect method overrides.
- Add `invalid_runtime_check_with_js_interop_types` suppression in `web_sensors.dart`.

## Related Issues
- Fix #3844 

## Checklist
- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing. i run the `flutter test` on `packages\sensors_plus\sensors_plus`
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR. The analyze does not report error

```
D:\...\sensors_plus\sensors_plus>flutter test
00:05 +5: All tests passed!

D:\...\sensors_plus\sensors_plus>flutter analyze
Analyzing sensors_plus...
No issues found! (ran in 1.7s)

melos run analyze
melos run analyze
  └> melos exec -c 5 -- \
       dart analyze . --fatal-infos
     └> RUNNING

$ melos exec
  └> dart analyze . --fatal-infos
     └> RUNNING (in 25 packages)

------------------------------------------------------------------------------------------------------------------------
...
[sensors_plus]: Analyzing ....
[sensors_plus]: No issues found!
[sensors_plus_example]: Analyzing ....
[sensors_plus_example]: No issues found!
[sensors_plus_platform_interface]: Analyzing ....
[sensors_plus_platform_interface]: No issues found!
...
```


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?
- [x] No, this is *not* a breaking change.

