### PR TITLE
fix(share_plus): resolve js interop lint and maintain minimum sdk

### DIFF
--- a/packages/share_plus/share_plus/lib/src/share_plus_web.dart
+++ b/packages/share_plus/share_plus/lib/src/share_plus_web.dart
@@ -48,6 +48,7 @@ class SharePlusWebPlugin extends SharePlatform {
 
     try {
       await _navigator.share(data).toDart;
+      // ignore: invalid_runtime_check_with_js_interop_types
     } on DOMException catch (e) {
       if (e.name case 'AbortError') {
         return _resultDismissed;


### PR DESCRIPTION
## Description
- Add `invalid_runtime_check_with_js_interop_types` suppression in `web_share.dart`.

## Related Issues
- Related to #3844
- If this PR and #3845 are merged, the `melos run analyze` workflow issue will be fully resolved.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing. i run the `flutter test` on `packages\share_plus\share_plus`
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR. 
```
D:\...\share_plus\share_plus>flutter test
00:08 +11 ~4: 4 skipped tests.
00:08 +11 ~4: All other tests passed!

D:\...\share_plus\share_plus>flutter analyze
Analyzing share_plus...
No issues found! (ran in 2.4s)

melos run analyze
  └> melos exec -c 5 -- \
       dart analyze . --fatal-infos
     └> RUNNING

$ melos exec
  └> dart analyze . --fatal-infos
     └> RUNNING (in 25 packages)

------------------------------------------------------------------------------------------------------------------------
...
[share_plus]: Analyzing ....
[share_plus]: No issues found!
[share_plus_example]: Analyzing ....
[share_plus_example]: No issues found!
[share_plus_platform_interface]: Analyzing ....
[share_plus_platform_interface]: No issues found!
...
```

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?
- [x] No, this is *not* a breaking change.

