### PR TITLE
ci(device_info_plus): migrate android workflows to ubuntu-24.04 and kvm

### DIFF
--- a/.github/workflows/device_info_plus.yaml
+++ b/.github/workflows/device_info_plus.yaml
@@ -44,7 +44,7 @@ jobs:
           working-directory: ./packages/device_info_plus
 
   android_example_build:
-    runs-on: macos-15-intel
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -57,7 +57,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-15-intel
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -67,6 +67,11 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - uses: flutter-actions/setup-flutter@v4
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh


### PR DESCRIPTION
## Description
This PR migrates the Android workflows for `device_info_plus` from `macos-15-intel` to `ubuntu-24.04` environment.

### The Problem
Currently, the repo utilize macOS runner which make android build takes more time and android integration tests running on API level 36 consistently time out and fail across the repository's packages. This PR serves as one part of a plan to migrate all nine packages to `ubuntu-24.04` to resolve this issue.

### Consideration and Reference
* This aligns with the [android-emulator-runner README.md](https://github.com/ReactiveCircus/android-emulator-runner), which references the official [GitHub Blog regarding hardware-accelerated Android virtualization on Linux](https://github.blog/changelog/2023-02-23-hardware-accelerated-android-virtualization-on-actions-windows-and-linux-larger-hosted-runners/):
  > "...Testing on a 4-core machine with hardware acceleration is around 2-3 times faster than not using hardware acceleration and around 2 times faster than using MacOS."
* The community has reported substantial performance improvements on Linux runners compared to macOS instances (see the [Kiwix Android migration PR](https://github.com/kiwix/kiwix-android/pull/3786) and [GitHub Runner Images Issue #1336](https://github.com/actions/runner-images/issues/1336#issuecomment-1310421187).

### Benchmark & Validation Data on `android_example_build`
The table below presents the total runtime of the workflow job for build. Control baseline were retrieved from the repo historical runtime logs, compared against two validation runs on the Linux environment on my other branch:

| No | Package Name | Control (`macos-15-intel`) | Test 1 (`ubuntu-24.04`) | Test 2 (`ubuntu-24.04`) |
| :--- | :--- | :---: | :---: | :---: |
| 1 | `android_alarm_manager_plus` | 10m 2s | 5m 31s | 5m 23s |
| 2 | `android_intent_plus` | 10m 57s | 4m 30s | 4m 19s |
| 3 | `battery_plus` | 13m 1s | 4m 46s | 4m 33s |
| 4 | `connectivity_plus` | 17m 21s | 4m 24s | 4m 24s |
| 5 | `device_info_plus` | 12m 1s | 4m 53s | 4m 40s |
| 6 | `network_info_plus` | 12m 2s | 4m 48s | 4m 55s |
| 7 | `package_info_plus` | 8m 14s | 4m 41s | 4m 41s |
| 8 | `sensors_plus` | 6m 6s | 4m 25s | 4m 41s |
| 9 | `share_plus` | 12m 6s | 5m 21s | 5m 22s |

### Benchmark on integration test targeting API Level 36
Because the current macOS CI baseline consistently times out (30m+) or fails to boot the API 36 image entirely, no repo historical runtime logs are retrieved. On `ubuntu-24.04` with KVM enabled, API 36 consistently runs to completion. This represents a **>70% reduction in integration test times** where it previously fail.
| No | Package Name | Job Link (Test 1 Verification) | Test 1 Duration | Test 2 Duration |
| :--- | :--- | :---: | :---: | :---: |
| 1 | `android_alarm_manager_plus` | [Job Log](https://github.com/mdmahendri/plus_plugins/actions/runs/26567035443/job/78264250547) | 8m 30s | 8m 18s |
| 2 | `android_intent_plus` | [Job Log](https://github.com/mdmahendri/plus_plugins/actions/runs/26567035387/job/78264250658) | 3m 4s | 3m 15s |
| 3 | `battery_plus` | [Job Log](https://github.com/mdmahendri/plus_plugins/actions/runs/26567035396/job/78264250673) | 7m 28s | 7m 13s |
| 4 | `connectivity_plus` | [Job Log](https://github.com/mdmahendri/plus_plugins/actions/runs/26567035390/job/78264250609) | 7m 24s | 7m 24s |
| 5 | `device_info_plus` | [Job Log](https://github.com/mdmahendri/plus_plugins/actions/runs/26567035419/job/78264250712) | 7m 6s | 7m 27s |
| 6 | `network_info_plus` | [Job Log](https://github.com/mdmahendri/plus_plugins/actions/runs/26567035349/job/78264250446) | 7m 43s | 7m 23s |
| 7 | `package_info_plus` | [Job Log](https://github.com/mdmahendri/plus_plugins/actions/runs/26567035386/job/78264250733) | 7m 23s | 7m 33s |
| 8 | `sensors_plus` | [Job Log](https://github.com/mdmahendri/plus_plugins/actions/runs/26567035350/job/78264250532) | 7m 25s | 7m 8s |
| 9 | `share_plus` | [Job Log](https://github.com/mdmahendri/plus_plugins/actions/runs/26567035420/job/78264250706) | 8m 0s | 8m 11s |

## Related Issues
No tracking issue is open, but ongoing pull requests show persistent fails and timeouts during the AVD stage. This creates confusion for contributors diagnosing whether a test failure stems from their code changes or the infrastructure itself. Fixing this workflow provide better tooling for all future contributions.

## Checklist
- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing. (CI/Workflow infrastructure update only).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR. (CI/Workflow infrastructure update only).

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?
- [x] No, this is *not* a breaking change.