### PR TITLE
ci(battery_plus): migrate android workflows to ubuntu-24.04 and kvm

### DIFF
--- a/.github/workflows/battery_plus.yaml
+++ b/.github/workflows/battery_plus.yaml
@@ -44,7 +44,7 @@ jobs:
           working-directory: ./packages/battery_plus
 
   android_example_build:
-    runs-on: macos-15-intel
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -57,7 +57,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-15-intel
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -67,6 +67,11 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - uses: flutter-actions/setup-flutter@v4
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh


### PR DESCRIPTION
## Description
This is part of migration across the repository's packages. For the full description, please refer to the pull request #3847 