### PR TITLE
ci(android_alarm_manager_plus): migrate android workflows to ubuntu-24.04 and kvm

### DIFF
--- a/.github/workflows/android_alarm_manager_plus.yaml
+++ b/.github/workflows/android_alarm_manager_plus.yaml
@@ -40,7 +40,7 @@ jobs:
           working-directory: ./packages/android_alarm_manager_plus
 
   android_example_build:
-    runs-on: macos-15-intel
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     steps:
       - name: "Checkout repository"
@@ -53,7 +53,7 @@ jobs:
         run: ./.github/workflows/scripts/build-examples.sh android ./lib/main.dart
 
   android_integration_test:
-    runs-on: macos-15-intel
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -63,6 +63,11 @@ jobs:
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - uses: flutter-actions/setup-flutter@v4
       - name: "Install Tools"
         run: ./.github/workflows/scripts/install-tools.sh


### PR DESCRIPTION
## Description
This is part of migration across the repository's packages. For the full description, please refer to the pull request #3847 