### PR TITLE
test(connectivity_plus): update android version boundary to accommodate API 24 emulator behavior

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
+++ b/packages/connectivity_plus/connectivity_plus/example/integration_test/connectivity_plus_test.dart
@@ -22,23 +22,23 @@ void main() {
       expect(result, isNotNull);
     });
 
-    testWidgets('connectivity on Android newer than 5 (API 21) should be wifi',
+    testWidgets('connectivity on Android newer than 7 (API 24) should be wifi',
         (WidgetTester tester) async {
       final result = await connectivity.checkConnectivity();
 
       expect(result, [ConnectivityResult.wifi]);
     },
         skip: !Platform.isAndroid ||
-            Platform.operatingSystemVersion.contains('5.0.2'));
+            Platform.operatingSystemVersion.contains('7.0'));
 
-    testWidgets('connectivity on Android 5 (API 21) should be mobile',
+    testWidgets('connectivity on Android 7 (API 24) should be mobile',
         (WidgetTester tester) async {
       final result = await connectivity.checkConnectivity();
 
       expect(result, [ConnectivityResult.mobile]);
     },
         skip: !Platform.isAndroid ||
-            !Platform.operatingSystemVersion.contains('5.0.2'));
+            !Platform.operatingSystemVersion.contains('7.0'));
 
     testWidgets('connectivity on MacOS should be ethernet',
         (WidgetTester tester) async {


### PR DESCRIPTION
## Description
This PR resolves the pre-existing integration test failures on Android API Level 24 by updating the operating system version skip threshold from 5 to 7.
On emulators running API levels lower than 25 (Android 7.1), the environment does not automatically provision a simulated Wi-Fi access point (`AndroidWifi`). Because the suite tests for an active Wi-Fi connection, this limitation causes fail on legacy test matrices (such as our API 24 runner).

## Related Issues
See also this explanation from #3849


## Checklist
- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?
- [x] No, this is *not* a breaking change.

