### PR TITLE
fix: (device_info_plus): Migrate Plugin to Built-in Kotlin

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/build.gradle
+++ b/packages/device_info_plus/device_info_plus/android/build.gradle
@@ -2,7 +2,7 @@ group 'dev.fluttercommunity.plus.device_info'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '2.2.0'
+    ext.kotlin_version = '2.2.20'
     repositories {
         google()
         mavenCentral()
@@ -22,7 +22,7 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
 
 android {
     namespace 'dev.fluttercommunity.plus.device_info'
@@ -33,9 +33,7 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = 17
-    }
+    
 
     defaultConfig {
         minSdk 19
@@ -48,5 +46,10 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    }
+}
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/packages/device_info_plus/device_info_plus/example/android/app/build.gradle
+++ b/packages/device_info_plus/device_info_plus/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -25,14 +24,10 @@ if (flutterVersionName == null) {
 android {
     namespace 'io.flutter.plugins.deviceinfoexample.example'
     compileSdk = flutter.compileSdkVersion
-
+    ndkVersion = "28.2.13676358"
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = 17
     }
 
     sourceSets {
@@ -59,7 +54,11 @@ android {
         }
     }
 }
-
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+    }
+}
 flutter {
     source '../..'
 }

--- a/packages/device_info_plus/device_info_plus/example/android/gradle.properties
+++ b/packages/device_info_plus/device_info_plus/example/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/packages/device_info_plus/device_info_plus/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/device_info_plus/device_info_plus/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 05 15:15:38 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/device_info_plus/device_info_plus/example/android/settings.gradle
+++ b/packages/device_info_plus/device_info_plus/example/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Description

<!-- Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change. -->

## Related Issues

<!-- Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/fluttercommunity/plus_plugins/issues). Indicate, which of these issues are resolved or fixed by this PR.

e.g.
- Fix #<ticket number>
- Related #<ticket number>
-->

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

