### PR TITLE
chore(connectivity_plus): replace deprecated config in gradle 8

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/android/build.gradle
@@ -1,5 +1,5 @@
-group 'dev.fluttercommunity.plus.connectivity'
-version '1.0-SNAPSHOT'
+group = 'dev.fluttercommunity.plus.connectivity'
+version = '1.0-SNAPSHOT'
 
 buildscript {
     repositories {
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'dev.fluttercommunity.plus.connectivity'
+    namespace = 'dev.fluttercommunity.plus.connectivity'
     compileSdk = flutter.compileSdkVersion
 
     compileOptions {
@@ -31,10 +31,10 @@ android {
     }
 
     defaultConfig {
-        minSdk 21
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        minSdk = 21
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-    lintOptions {
+    lint {
         disable 'InvalidPackage'
     }
 

--- a/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/example/android/app/build.gradle
@@ -27,41 +27,41 @@ if (flutterVersionName == null) {
 }
 
 android {
+    namespace = 'io.flutter.plugins.connectivityexample'
     compileSdk = flutter.compileSdkVersion
-
-    namespace 'io.flutter.plugins.connectivityexample'
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-    }
-
-    lintOptions {
-        disable 'InvalidPackage'
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {
-        applicationId "io.flutter.plugins.connectivityexample"
-        minSdk flutter.minSdkVersion
-        targetSdk flutter.targetSdkVersion
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        applicationId = "io.flutter.plugins.connectivityexample"
+        minSdk = flutter.minSdkVersion
+        targetSdk = flutter.targetSdkVersion
+        versionCode = flutterVersionCode.toInteger()
+        versionName = flutterVersionName
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    lint {
+        disable 'InvalidPackage'
     }
 
     buildTypes {
         release {
-            signingConfig signingConfigs.debug
+            signingConfig = signingConfigs.debug
         }
     }
 }
 
 flutter {
-    source '../..'
+    source = '../..'
 }
 
 dependencies {
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test:runner:1.6.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/packages/connectivity_plus/connectivity_plus/example/android/build.gradle
+++ b/packages/connectivity_plus/connectivity_plus/example/android/build.gradle
@@ -5,14 +5,14 @@ allprojects {
     }
 }
 
-rootProject.buildDir = '../build'
+rootProject.layout.buildDirectory.value(layout.projectDirectory.dir('../build'))
 subprojects {
-    project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.layout.buildDirectory.value(rootProject.layout.buildDirectory.dir(project.name))
 }
 subprojects {
     project.evaluationDependsOn(':app')
 }
 
 tasks.register("clean", Delete) {
-    delete rootProject.buildDir
+    delete rootProject.layout.buildDirectory
 }


### PR DESCRIPTION
## Description

This PR prepares `connectivity_plus` for the upcoming Gradle 9 migration by resolving deprecation warnings in the build scripts. Some of these changes follow the same patterns used in #3858.

### Testing & Environment
This PR was tested and built successfully locally. Because it requires running `melos bootstrap` within the repository (which depends on Dart 3.10), **Flutter 3.38.1** was used for the verification process.

### Key Changes
For clarity and ease of review, here is a breakdown of the modifications:

#### 1. Groovy Property Assignment Syntax
Updated Gradle property assignments to conform to the Groovy DSL requirements. Fixed the deprecation warning: 
  > `Properties should be assigned using the 'propName = value' syntax. Setting a property via the Gradle-generated 'propName value' or 'propName(value)' syntax in Groovy DSL has been deprecated.`

#### 2. Modernized Lint Configuration
Migrated the `lintOptions` block to the modern `lint` block. `lintOptions` was [deprecated in AGP 7.2](https://developer.android.com/reference/tools/gradle-api/7.2/com/android/build/api/dsl/LintOptions).

#### 3. Resolved Dependency Conflict
Fixed an unresolved dependency conflict between `integration_test` and the example app test runner that caused the following Android Studio warning:
```
Unresolved dependencies
Cannot find a version of 'androidx.test:runner' that satisfies the version constraints:
   Dependency path 'android:app:unspecified' --> 'androidx.test:runner:1.6.2'
   Constraint path 'android:app:unspecified' --> 'androidx.test:runner:{strictly 1.2.0}' because of the following reason: version resolved in configuration ':app:debugRuntimeClasspath' by consistent resolution
   Dependency path 'android:app:unspecified' --> 'androidx.test.espresso:espresso-core:3.6.1' (runtime) --> 'androidx.test:runner:1.6.1'
```

#### 4. Replaced Deprecated Build Directory Reference
Replaced `project.buildDir` with `project.layout.buildDirectory` to match modern Gradle API standards.

#### 5. Unified NDK Version
Added `ndkVersion = flutter.ndkVersion` to resolve NDK version mismatches. Fix the following build warning:
```
Your project is configured with Android NDK 27.0.12077973, but the following plugin(s) depend on a different Android NDK version:
integration_test requires Android NDK 28.2.13676358
Fix this issue by using the highest Android NDK version (they are backward compatible).
```
Android NDK versions are backward compatible, and the project builds and runs successfully after this change.
`flutter.ndkVersion` is available for version higher 3.3.0, while this package specify Flutter version 3.7.0 or higher. See this [Flutter 3.3.0 release notes](https://docs.flutter.dev/release/release-notes/release-notes-3.3.0) and [PR for the revelant change](https://github.com/flutter/flutter/pull/101315)

## Related Issues
- Partly fix ##3864

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing. *the tests failing probably the one I mentioned in another PR.*
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?
- [x] No, this is *not* a breaking change.

