### PR TITLE
fix(connectivity_plus): correct minimum Flutter version to match Dart SDK constraint

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/pubspec.yaml
+++ b/packages/connectivity_plus/connectivity_plus/pubspec.yaml
@@ -10,9 +10,9 @@ topics:
 
 environment:
   sdk: ">=3.2.0 <4.0.0"
-  # Flutter versions prior to 3.7 did not support the
-  # sharedDarwinSource option.
-  flutter: ">=3.7.0"
+  # Dart >=3.2.0 first shipped with Flutter 3.16.0, so that is the
+  # lowest Flutter version that can satisfy the SDK constraint above.
+  flutter: ">=3.16.0"
 
 flutter:
   plugin:


### PR DESCRIPTION
While testing the local build environment for `connectivity_plus` I hit the same mismatch reported in #3866. The package declares:

```yaml
environment:
  sdk: ">=3.2.0 <4.0.0"
  flutter: ">=3.7.0"
```

But Dart 3.2.0 first shipped with Flutter 3.16.0 — Flutter 3.7.0 bundles Dart 2.19. So pinning the documented minimum Flutter version fails the SDK constraint:

```
SDK Version : 3.7.0 has Dart SDK 2.19.0 does not meet the project constraints of >=3.2.0 <4.0.0.
```

This bumps the Flutter floor to `3.16.0` so it matches the Dart SDK constraint that is already required. No real configuration is dropped: there is no Flutter release between 3.7 and 3.16 that ships Dart >=3.2, so nobody could actually build against the old floor anyway. I also updated the stale comment (it referenced the long-satisfied `sharedDarwinSource` 3.7 requirement).

Scoped to `connectivity_plus`, which is the package the issue demonstrates and the only one whose stated Flutter floor admits a real release that violates its Dart constraint — the sibling packages already pair their floors correctly. Per CONTRIBUTING I left the version and CHANGELOG for the maintainers.

Closes #3866