### PR TITLE
fix(package_info_plus): support AGP 9 / built-in Kotlin

### DIFF
--- a/packages/package_info_plus/package_info_plus/android/build.gradle
+++ b/packages/package_info_plus/package_info_plus/android/build.gradle
@@ -23,7 +23,19 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+// Built-in Kotlin migration (AGP 9): AGP 9 removes support for applying the Kotlin Gradle
+// Plugin (KGP) directly and provides built-in Kotlin instead. Apply KGP only when built-in
+// Kotlin is NOT active — i.e. on AGP < 9, or when `android.builtInKotlin` is disabled (the
+// Flutter transition default, which Flutter still sets to false even on AGP 9). This keeps the
+// plugin building across both the legacy-KGP and built-in-Kotlin paths, and stops applying KGP
+// once the host enables built-in Kotlin on AGP 9+.
+// https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+def builtInKotlin = providers.gradleProperty('android.builtInKotlin').map { it.toBoolean() }.orElse(agpMajor >= 9).get()
+if (agpMajor < 9 || !builtInKotlin) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     namespace 'dev.fluttercommunity.plus.packageinfo'
@@ -32,10 +44,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = 17
     }
 
     defaultConfig {
@@ -49,5 +57,14 @@ android {
 
     dependencies {
         implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    }
+}
+
+// Replaces the deprecated `kotlinOptions { jvmTarget = ... }` block, which is removed alongside
+// KGP under built-in Kotlin. The `kotlin` extension is registered by KGP on AGP < 9 and by
+// built-in Kotlin on AGP 9+, so this configures the Kotlin compiler on both.
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }

--- a/packages/package_info_plus/package_info_plus/example/android/app/build.gradle
+++ b/packages/package_info_plus/package_info_plus/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 
@@ -31,10 +30,6 @@ android {
         targetCompatibility JavaVersion.VERSION_17
     }
 
-    kotlinOptions {
-        jvmTarget = 17
-    }
-
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
     }
@@ -57,6 +52,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig signingConfigs.debug
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 


### PR DESCRIPTION
## Summary

AGP 9 removes support for *applying* the Kotlin Gradle Plugin (KGP). `package_info_plus`'s Android module applies `kotlin-android` directly, so apps that depend on it fail to build under AGP 9, and Flutter 3.44+ already emits a warning:

> `WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): … package_info_plus`
> `Future versions of Flutter will fail to build if your app uses plugins that apply KGP.`

This migrates `package_info_plus` to [Flutter's built-in Kotlin](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors) in a backwards-compatible way. Closes #3881.

## Changes

- **Conditional KGP application** — apply `kotlin-android` only when built-in Kotlin is *not* active, i.e. on AGP < 9 **or** when `android.builtInKotlin=false` (the Flutter transition default, which Flutter still sets to false even on AGP 9). This keeps the plugin building on both the legacy-KGP and built-in-Kotlin paths.
- **`compilerOptions` DSL** — replace the deprecated `kotlinOptions { jvmTarget }` block with `kotlin { compilerOptions { jvmTarget = … } }`, which works under both KGP and built-in Kotlin.
- **Example app** — migrated to built-in Kotlin (`kotlin-android` removed, `compilerOptions` DSL).

No change to the supported SDK range, `compileSdk` (already `flutter.compileSdkVersion`), the Kotlin version (already 2.2.0 — sufficient for built-in Kotlin on AGP 9), or runtime behavior. Build-configuration only; no public API change.

## Verification

Built the example app with Flutter 3.44.2 in each relevant configuration:

| Toolchain | `android.builtInKotlin` | Result |
|---|---|---|
| AGP 8.12.1 / Gradle 8.13 | `false` | ✅ builds; plugin applies KGP (legacy path) |
| AGP 9.0.1 / Gradle 9.1.0 | `false` | ✅ builds; KGP applied via Flutter's transition shim |
| AGP 9.0.1 / Gradle 9.1.0 | `true`  | ✅ `package_info_plus` is KGP-free and configures cleanly under built-in Kotlin |

Under built-in Kotlin the plugin no longer appears in Flutter's KGP warning.

## Notes

- The guard reads `android.builtInKotlin`, so it automatically tracks whatever Kotlin mode the host app is in — no action required from existing consumers.
- Per the repo's Melos/conventional-commit workflow, no `CHANGELOG.md` edit is included; the changelog entry is derived from the `fix(package_info_plus): …` commit.
