### PR TITLE
chore(android_intent_plus): modernize Android build config according to Gradle 8

### DIFF
--- a/packages/android_intent_plus/android/build.gradle
+++ b/packages/android_intent_plus/android/build.gradle
@@ -1,5 +1,5 @@
-group 'dev.fluttercommunity.plus.androidintent'
-version '1.0-SNAPSHOT'
+group = 'dev.fluttercommunity.plus.androidintent'
+version = '1.0-SNAPSHOT'
 
 buildscript {
     repositories {
@@ -22,20 +22,20 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    namespace 'dev.fluttercommunity.plus.androidintent'
+    namespace = 'dev.fluttercommunity.plus.androidintent'
     compileSdk = flutter.compileSdkVersion
 
     defaultConfig {
-        minSdk 19
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        minSdk = 19
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
-    lintOptions {
+    lint {
         disable 'InvalidPackage'
     }
 

--- a/packages/android_intent_plus/example/android/app/build.gradle
+++ b/packages/android_intent_plus/example/android/app/build.gradle
@@ -23,44 +23,45 @@ if (flutterVersionName == null) {
 }
 
 android {
-    namespace 'io.flutter.plugins.androidintentexample'
+    namespace = 'io.flutter.plugins.androidintentexample'
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_17
-        targetCompatibility JavaVersion.VERSION_17
-    }
-
-    lintOptions {
-        disable 'InvalidPackage'
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     defaultConfig {
-        applicationId "io.flutter.plugins.androidintentexample"
-        minSdk flutter.minSdkVersion
-        targetSdk flutter.targetSdkVersion
+        applicationId = "io.flutter.plugins.androidintentexample"
+        minSdk = flutter.minSdkVersion
+        targetSdk = flutter.targetSdkVersion
 
-        versionCode flutterVersionCode.toInteger()
-        versionName flutterVersionName
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        versionCode = flutterVersionCode.toInteger()
+        versionName = flutterVersionName
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    lint {
+        disable 'InvalidPackage'
     }
 
     buildTypes {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.debug
+            signingConfig = signingConfigs.debug
         }
     }
 }
 
 flutter {
-    source '../..'
+    source = '../..'
 }
 
 dependencies {
     implementation 'androidx.core:core-ktx:1.13.1'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test:runner:1.6.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test:runner:1.2.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
 }

--- a/packages/android_intent_plus/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/android_intent_plus/example/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="io.flutter.plugins.androidintentexample">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
   <!--

--- a/packages/android_intent_plus/example/android/build.gradle
+++ b/packages/android_intent_plus/example/android/build.gradle
@@ -5,14 +5,14 @@ allprojects {
     }
 }
 
-rootProject.buildDir = '../build'
+rootProject.layout.buildDirectory.value(layout.projectDirectory.dir('../build'))
 subprojects {
-    project.buildDir = "${rootProject.buildDir}/${project.name}"
+    project.layout.buildDirectory.value(rootProject.layout.buildDirectory.dir(project.name))
 }
 subprojects {
     project.evaluationDependsOn(':app')
 }
 
 tasks.register("clean", Delete) {
-    delete rootProject.buildDir
+    delete rootProject.layout.buildDirectory
 }


### PR DESCRIPTION
## Description
This PR is part of https://github.com/fluttercommunity/plus_plugins/pull/3867 aimed at removing warnings related to Gradle and unused configurations. The goal is to minimize technical debt ahead of the migration to AGP 9.

Tested locally with Flutter 3.38.1. The only remaining warnings are due to Flutter 3.38.1 using a library version higher than the hardcoded version in the plugin.

In addition to the changes described in the linked PR, this includes:
- removing `package` attribute from manifests for the warning
    ```
    Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
    ```
    This fix aligns with the [Official Android Developer Documentation](https://developer.android.com/guide/topics/manifest/manifest-element):
    > In the Gradle-based build system, starting with AGP 7.3, don't set the package value in the source manifest file directly.

## Related Issues
- Partially fixes https://github.com/fluttercommunity/plus_plugins/issues/3864

## Breaking Change
Does your PR require plugin users to manually update their apps to accommodate your change?
- [x] No, this is *not* a breaking change.

