### PR TITLE
feat(device_info_plus): Add support of built-in Kotlin

### DIFF
--- a/packages/device_info_plus/device_info_plus/android/build.gradle.kts
+++ b/packages/device_info_plus/device_info_plus/android/build.gradle.kts
@@ -24,10 +24,15 @@ allprojects {
 
 plugins {
     id("com.android.library")
-    id("kotlin-android")
 }
 
-kotlin {
+val agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toInt()
+
+if (agpMajor < 9) {
+    apply(plugin = "org.jetbrains.kotlin.android")
+}
+
+project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java) {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
@@ -43,7 +48,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 19
+        minSdk = 21
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/device_info_plus/device_info_plus/example/android/app/build.gradle.kts
+++ b/packages/device_info_plus/device_info_plus/example/android/app/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.android.application")
+    id("kotlin-android")
     id("dev.flutter.flutter-gradle-plugin")
 }
 

--- a/packages/device_info_plus/device_info_plus/example/android/app/build.gradle.kts
+++ b/packages/device_info_plus/device_info_plus/example/android/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     id("dev.flutter.flutter-gradle-plugin")
 }
 
@@ -25,6 +24,7 @@ android {
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName
+        ndkVersion = flutter.ndkVersion
     }
 
     lint {

--- a/packages/device_info_plus/device_info_plus/example/android/gradle.properties
+++ b/packages/device_info_plus/device_info_plus/example/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/packages/device_info_plus/device_info_plus/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/device_info_plus/device_info_plus/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Oct 05 15:15:38 CEST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/device_info_plus/device_info_plus/example/android/settings.gradle.kts
+++ b/packages/device_info_plus/device_info_plus/example/android/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.12.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")


### PR DESCRIPTION
## Description

Backwards compatible support of built-in Kotlin as per https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors#supporting-flutter-versions-earlier-than-3-44

Additionally updated example app to not show warnings about versions of Gradle, Kotlin or NDK.

## Related Issues

Closes #3835


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

