### PR TITLE
feat(share_plus): Add support of built-in Kotlin

### DIFF
--- a/packages/share_plus/share_plus/android/build.gradle.kts
+++ b/packages/share_plus/share_plus/android/build.gradle.kts
@@ -3,7 +3,7 @@ version = "1.0-SNAPSHOT"
 
 buildscript {
     val kotlinVersion = "2.2.0"
-    
+
     repositories {
         google()
         mavenCentral()
@@ -25,10 +25,15 @@ allprojects {
 
 plugins {
     id("com.android.library")
-    id("kotlin-android")
 }
 
-kotlin {
+val agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.substringBefore('.').toInt()
+
+if (agpMajor < 9) {
+    apply(plugin = "org.jetbrains.kotlin.android")
+}
+
+project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension::class.java) {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
@@ -44,7 +49,7 @@ android {
     }
 
     defaultConfig {
-        minSdk = 19
+        minSdk = 21
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/packages/share_plus/share_plus/example/android/app/build.gradle.kts
+++ b/packages/share_plus/share_plus/example/android/app/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 android {
     namespace = "io.flutter.plugins.shareexample"
     compileSdk = flutter.compileSdkVersion
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17

--- a/packages/share_plus/share_plus/example/android/gradle.properties
+++ b/packages/share_plus/share_plus/example/android/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
+android.newDsl=false
+android.builtInKotlin=false

--- a/packages/share_plus/share_plus/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/share_plus/share_plus/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/share_plus/share_plus/example/android/settings.gradle.kts
+++ b/packages/share_plus/share_plus/example/android/settings.gradle.kts
@@ -20,7 +20,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.12.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.2.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.2.20" apply false
 }
 
 include(":app")

--- a/packages/share_plus/share_plus/example/pubspec.yaml
+++ b/packages/share_plus/share_plus/example/pubspec.yaml
@@ -5,8 +5,8 @@ dependencies:
   flutter:
     sdk: flutter
   share_plus: ^13.1.0
-  image_picker: ^1.1.2
-  file_selector: ^1.0.3
+  image_picker: ^1.2.2
+  file_selector: ^1.1.0
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
## Description

Same as #3889 + example dependencies updates to get rid of warnings like
```
warning: [options] source value 8 is obsolete and will be removed in a future release
```

## Related Issues

Closes #3831 and #3834

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

