### PR TITLE
fix(sensors_plus): Resolve incorrect cleanup method call

### DIFF
--- a/packages/sensors_plus/sensors_plus/ios/sensors_plus/Sources/sensors_plus/FPPStreamHandlerPlus.swift
+++ b/packages/sensors_plus/sensors_plus/ios/sensors_plus/Sources/sensors_plus/FPPStreamHandlerPlus.swift
@@ -235,7 +235,7 @@ class FPPMagnetometerStreamHandlerPlus: NSObject, MotionStreamHandler {
     }
 
     func onCancel(withArguments arguments: Any?) -> FlutterError? {
-        _motionManager.stopDeviceMotionUpdates()
+        _motionManager.stopMagnetometerUpdates()
         return nil
     }
 


### PR DESCRIPTION
## Description

I'm using this plugin in my app, and I was testing my app on iOS and noticed that the console rapidly printed `Communicating on a dead channel.`
So after debugging, I figured out that `FPPMagnetometerStreamHandlerPlus.onCancel` was incorrectly calling `_motionManager.stopDeviceMotionUpdates()` instead of `_motionManager.stopMagnetometerUpdates()`.

## Related Issues

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

