### PR TITLE
chore(device_info_plus): resolve ci

### DIFF
--- a/packages/device_info_plus/device_info_plus/example/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/example/pubspec.yaml
@@ -1,5 +1,6 @@
 name: device_info_plus_example
 description: Demonstrates how to use the device_info_plus plugin.
+version: 1.0.0+1
 
 dependencies:
   flutter:

--- a/packages/device_info_plus/device_info_plus/pubspec.yaml
+++ b/packages/device_info_plus/device_info_plus/pubspec.yaml
@@ -1,7 +1,7 @@
 name: device_info_plus
 description: Flutter plugin providing detailed information about the device
   (make, model, etc.), and Android or iOS version the app is running on.
-version: 13.1.0
+version: 13.1.0+1
 homepage: https://github.com/fluttercommunity/plus_plugins
 repository: https://github.com/fluttercommunity/plus_plugins/tree/main/packages/device_info_plus/device_info_plus
 issue_tracker: https://github.com/fluttercommunity/plus_plugins/labels/device_info_plus


### PR DESCRIPTION
CP: https://github.com/fluttercommunity/plus_plugins/issues/3835
### Plugin

device_info_plus

### Use case

Starting with Android Gradle Plugin (AGP) 9.0, support for applying the Kotlin Gradle Plugin (KGP) has been removed. Because this plugin applies KGP, it causes a compilation error that prevents my app from building. Here is an example of the error https://github.com/flutter/flutter/issues/181383.

Flutter has temporarily added support to allow KGP while apps and plugins migrate to AGP 9.0+, but this support will be removed in a future version of Flutter.

Please migrate this plugin to use built-in Kotlin to ensure your plugin users can successfully build their apps in future versions of Flutter.

Here is the Flutter [migration guide for plugin authors](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors).

Please be respectful and mindful of the plugin repository's rules and code of conduct when reporting issues and interacting with plugin authors.

For reference, see the [Flutter Code of Conduct](https://github.com/flutter/flutter/blob/master/CODE_OF_CONDUCT.md).

### Proposal

Please migrate to Flutter's request.