### PR TITLE
docs: add open source app examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ support for more platforms and better maintenance.
 
 [Feedback](https://github.com/fluttercommunity/plus_plugins/issues) and [Pull Requests](https://github.com/fluttercommunity/plus_plugins/pulls) are most welcome!
 
+## Used by open source apps
+
+Some open source Flutter apps that depend on these plugins include:
+
+- [LocalSend](https://github.com/localsend/localsend/blob/main/app/pubspec.yaml) depends on `connectivity_plus`, `device_info_plus`, `network_info_plus`, and `package_info_plus`.
+- [AppFlowy](https://github.com/AppFlowy-IO/AppFlowy/blob/main/frontend/appflowy_flutter/pubspec.yaml) depends on `connectivity_plus`, `device_info_plus`, `package_info_plus`, and `share_plus`.
+- [Immich](https://github.com/immich-app/immich/blob/main/mobile/pubspec.yaml) depends on `connectivity_plus`, `device_info_plus`, `network_info_plus`, `package_info_plus`, and `share_plus`.
+- [Ente Photos](https://github.com/ente/ente/blob/main/mobile/apps/photos/pubspec.yaml) depends on `android_intent_plus`, `connectivity_plus`, `device_info_plus`, `package_info_plus`, and `share_plus`.
+
 ## Plugins
 
 **Table of contents:**


### PR DESCRIPTION
## Description

Adds a short "Used by open source apps" section to the root README with links to the relevant `pubspec.yaml` files.

The wording uses "depends on" since the examples were verified from dependency declarations.

AI assistance disclosure: I used OpenAI Codex to help draft this docs-only change, then manually reviewed the linked sources and final diff before submitting.

## Related Issues

- Related #2683

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [ ] All existing and new tests are passing. Docs-only change; not run.
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR. Docs-only change; not run.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.