### PR TITLE
fix(android_alarm_manager_plus): catch NPE in AlarmService

### DIFF
--- a/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmService.java
+++ b/packages/android_alarm_manager_plus/android/src/main/java/dev/fluttercommunity/plus/androidalarmmanager/AlarmService.java
@@ -148,7 +148,13 @@ public class AlarmService extends JobIntentService {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && !manager.canScheduleExactAlarms()) {
         Log.e(TAG, "Can`t schedule exact alarm due to revoked SCHEDULE_EXACT_ALARM permission");
       } else {
-        PendingIntent showPendingIntent = createShowPendingIntent(context, requestCode, params);
+        PendingIntent showPendingIntent;
+        try {
+          showPendingIntent = createShowPendingIntent(context, requestCode, params);
+        } catch (NullPointerException ex) {
+          Log.e(TAG, "Can`t schedule exact alarm because pending intent could not be created.", ex);
+          return;
+        }
         AlarmManagerCompat.setAlarmClock(
             manager, startMillis,
             showPendingIntent, pendingIntent);


### PR DESCRIPTION
## Description
On Android 11 phones with aggressive battery optimizations (e.g. Huawei and OnePlus), the app might be started in a sandboxed mode when receiving the reboot event.

In that sandbox, the resolution of the app's launch class name might fail with a NullPointerException, which in turn leads to a crash.

This fix avoids the crash, turning it into an error-log message instead.

The change is motivated by the following crash stacktrace received via Crashlytics for several Huawei and OnePlus phones on Android 11:
```
Fatal Exception: java.lang.RuntimeException: Unable to start receiver dev.fluttercommunity.plus.androidalarmmanager.RebootBroadcastReceiver: java.lang.NullPointerException: class name is null
       at android.app.ActivityThread.handleReceiver(ActivityThread.java:4047)
       at android.app.ActivityThread.access$1400(ActivityThread.java:239)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1926)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:223)
       [...]

Caused by java.lang.NullPointerException: class name is null
       at android.content.ComponentName.<init>(ComponentName.java:103)
       at android.content.Intent.setClassName(Intent.java:10044)
       at android.app.ApplicationPackageManager.getLaunchIntentForPackage(ApplicationPackageManager.java:252)
       at dev.fluttercommunity.plus.androidalarmmanager.AlarmService.createShowPendingIntent(AlarmService.java:362)
       at dev.fluttercommunity.plus.androidalarmmanager.AlarmService.scheduleAlarm(AlarmService.java:151)
       at dev.fluttercommunity.plus.androidalarmmanager.AlarmService.reschedulePersistentAlarms(AlarmService.java:338)
       at dev.fluttercommunity.plus.androidalarmmanager.RebootBroadcastReceiver.onReceive(RebootBroadcastReceiver.java:37)
       at android.app.ActivityThread.handleReceiver(ActivityThread.java:4038)
       [...]
```

## Related Issues

No related issues

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [X] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [X] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [X] All existing and new tests are passing.
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [X] No, this is *not* a breaking change.

