### PR TITLE
fix(connectivity_plus): prevent Linux client leaks

### DIFF
--- a/packages/connectivity_plus/connectivity_plus/lib/src/connectivity_plus_linux.dart
+++ b/packages/connectivity_plus/connectivity_plus/lib/src/connectivity_plus_linux.dart
@@ -21,13 +21,15 @@ class ConnectivityPlusLinuxPlugin extends ConnectivityPlatform {
   @override
   Future<List<ConnectivityResult>> checkConnectivity() async {
     final client = createClient();
-    await client.connect();
-    final connectivity = _getConnectivity(client);
-    await client.close();
-    return connectivity;
+    try {
+      await client.connect();
+      return _getConnectivity(client);
+    } finally {
+      await client.close();
+    }
   }
 
-  NetworkManagerClient? _client;
+  _NetworkManagerClientSession? _clientSession;
   StreamController<List<ConnectivityResult>>? _controller;
 
   /// Returns a Stream of ConnectivityResults changes.
@@ -69,14 +71,31 @@ class ConnectivityPlusLinuxPlugin extends ConnectivityPlatform {
   }
 
   Future<void> _startListenConnectivity() async {
-    _client ??= createClient();
-    await _client!.connect();
-    _addConnectivity(_client!);
-    _client!.propertiesChanged.listen((properties) {
-      if (properties.contains('Connectivity')) {
-        _addConnectivity(_client!);
+    final session =
+        _clientSession ??= _NetworkManagerClientSession(createClient());
+    try {
+      await session.connected;
+
+      if (!identical(_clientSession, session)) {
+        return;
       }
-    });
+
+      final client = session.client;
+      _addConnectivity(client);
+      session.propertiesChangedSubscription =
+          client.propertiesChanged.listen((properties) {
+        if (identical(_clientSession, session) &&
+            properties.contains('Connectivity')) {
+          _addConnectivity(client);
+        }
+      });
+    } catch (_) {
+      if (identical(_clientSession, session)) {
+        _clientSession = null;
+      }
+      await session.close();
+      rethrow;
+    }
   }
 
   void _addConnectivity(NetworkManagerClient client) {
@@ -84,11 +103,37 @@ class ConnectivityPlusLinuxPlugin extends ConnectivityPlatform {
   }
 
   Future<void> _stopListenConnectivity() async {
-    await _client?.close();
-    _client = null;
+    final session = _clientSession;
+    _clientSession = null;
+    await session?.close();
   }
 
   @visibleForTesting
   // ignore: prefer_function_declarations_over_variables
   NetworkManagerClientFactory createClient = () => NetworkManagerClient();
+}
+
+class _NetworkManagerClientSession {
+  _NetworkManagerClientSession(this.client) : connected = client.connect();
+
+  final NetworkManagerClient client;
+  final Future<void> connected;
+  StreamSubscription<List<String>>? propertiesChangedSubscription;
+
+  Future<void>? _closeFuture;
+
+  Future<void> close() => _closeFuture ??= _close();
+
+  Future<void> _close() async {
+    try {
+      await connected;
+    } catch (_) {
+      // Connection errors are reported by the listener setup.
+    }
+    try {
+      await propertiesChangedSubscription?.cancel();
+    } finally {
+      await client.close();
+    }
+  }
 }

--- a/packages/connectivity_plus/connectivity_plus/test/connectivity_plus_linux_test.dart
+++ b/packages/connectivity_plus/connectivity_plus/test/connectivity_plus_linux_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:connectivity_plus/src/connectivity_plus_linux.dart';
 import 'package:connectivity_plus_platform_interface/connectivity_plus_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -101,6 +103,19 @@ void main() {
         completion(equals([ConnectivityResult.none])));
   });
 
+  test('checkConnectivity closes the client after an error', () async {
+    final linux = ConnectivityPlusLinuxPlugin();
+    final client = MockNetworkManagerClient();
+    when(client.connect()).thenAnswer((_) async {});
+    when(client.close()).thenAnswer((_) async {});
+    when(client.connectivity).thenThrow(StateError('Failed to read state'));
+    linux.createClient = () => client;
+
+    await expectLater(linux.checkConnectivity(), throwsStateError);
+
+    verify(client.close()).called(1);
+  });
+
   test('connectivity changes', () {
     final linux = ConnectivityPlusLinuxPlugin();
     linux.createClient = () {
@@ -121,5 +136,102 @@ void main() {
           [ConnectivityResult.wifi],
           [ConnectivityResult.none]
         ]));
+  });
+
+  test('canceling the last listener cancels the property subscription',
+      () async {
+    final linux = ConnectivityPlusLinuxPlugin();
+    final client = MockNetworkManagerClient();
+    final propertiesChanged = StreamController<List<String>>.broadcast();
+    final clientClosed = Completer<void>();
+    addTearDown(propertiesChanged.close);
+    when(client.connect()).thenAnswer((_) async {});
+    when(client.close()).thenAnswer((_) async {
+      clientClosed.complete();
+    });
+    when(client.connectivity).thenReturn(NetworkManagerConnectivityState.full);
+    when(client.primaryConnectionType).thenReturn('wireless');
+    when(client.propertiesChanged).thenAnswer((_) => propertiesChanged.stream);
+    linux.createClient = () => client;
+
+    final initialEvent = Completer<void>();
+    final subscription = linux.onConnectivityChanged.listen((_) {
+      initialEvent.complete();
+    });
+    await initialEvent.future;
+    expect(propertiesChanged.hasListener, isTrue);
+
+    await subscription.cancel();
+    await clientClosed.future;
+
+    expect(propertiesChanged.hasListener, isFalse);
+    verify(client.close()).called(1);
+  });
+
+  test('canceling while connecting does not reuse the closing client',
+      () async {
+    final linux = ConnectivityPlusLinuxPlugin();
+    final clients = <MockNetworkManagerClient>[];
+    final connectCompleters = <Completer<void>>[];
+    final closeCompleters = <Completer<void>>[];
+    final closeCalledCompleters = <Completer<void>>[];
+    linux.createClient = () {
+      final client = MockNetworkManagerClient();
+      final connectCompleter = Completer<void>();
+      final closeCompleter = Completer<void>();
+      final closeCalledCompleter = Completer<void>();
+      when(client.connect()).thenAnswer((_) => connectCompleter.future);
+      when(client.close()).thenAnswer((_) {
+        closeCalledCompleter.complete();
+        return closeCompleter.future;
+      });
+      when(client.connectivity)
+          .thenReturn(NetworkManagerConnectivityState.full);
+      when(client.primaryConnectionType).thenReturn('wireless');
+      when(client.propertiesChanged)
+          .thenAnswer((_) => Stream<List<String>>.empty());
+      clients.add(client);
+      connectCompleters.add(connectCompleter);
+      closeCompleters.add(closeCompleter);
+      closeCalledCompleters.add(closeCalledCompleter);
+      return client;
+    };
+
+    final errors = <Object>[];
+    await runZonedGuarded(
+      () async {
+        final firstSubscription = linux.onConnectivityChanged.listen((_) {});
+        await firstSubscription.cancel();
+
+        final secondSubscription = linux.onConnectivityChanged.listen((_) {});
+
+        closeCompleters.first.complete();
+
+        for (final completer in connectCompleters) {
+          completer.complete();
+        }
+        await Future.wait(
+          connectCompleters.map((completer) => completer.future),
+        );
+
+        await secondSubscription.cancel();
+        for (final completer in closeCompleters) {
+          if (!completer.isCompleted) {
+            completer.complete();
+          }
+        }
+        await Future.wait(
+          closeCalledCompleters.map((completer) => completer.future),
+        );
+      },
+      (error, stackTrace) {
+        errors.add(error);
+      },
+    );
+
+    expect(errors, isEmpty);
+    expect(clients, hasLength(2));
+    verify(clients.first.close()).called(1);
+    verify(clients.last.close()).called(1);
   });
 }


### PR DESCRIPTION
## Description

Fix the Linux `NetworkManagerClient` lifecycle when connectivity listeners are canceled and immediately re-subscribed.

`StreamController.broadcast` does not wait for an asynchronous `onCancel` callback. The previous implementation accessed the shared `_client` on both sides of `await` calls, so a new listener could reuse a client that was still closing, while an older listener setup could later dereference a cleared client. Closing a `NetworkManagerClient` before its pending connection finishes can also leave the subsequently opened system D-Bus connection unclosed. In addition, the `propertiesChanged` subscription was not retained or canceled.

This change:

- owns each client, connection future, and property subscription in one session;
- detaches the current session synchronously before asynchronous cleanup;
- waits for an in-flight connection before closing its client;
- ignores callbacks from stale sessions and cancels property subscriptions;
- closes one-shot clients in `checkConnectivity` on error paths as well.

The regression tests deterministically cover error cleanup, property-subscription cleanup, and cancellation/re-subscription while a connection is pending.

## Related Issues

None.

## Checklist

- [x] I read the [Contributor Guide](https://github.com/fluttercommunity/plus_plugins/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] I titled the PR using [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0).
- [x] I did not modify the `CHANGELOG.md` nor the plugin version in `pubspec.yaml` files.
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate that with a `!` in the title as explained in [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0)).
- [x] No, this is *not* a breaking change.

## Validation

- Scoped formatting check for all `connectivity_plus` packages
- Scoped analyzer for `connectivity_plus`, `connectivity_plus_platform_interface`, and the example
- Unit tests for `connectivity_plus` and `connectivity_plus_platform_interface`
- Linux example debug build
- Linux `NetworkManager` integration smoke test
