### PR TITLE
feat(android_intent_plus): Add support of built-in Kotlin

### DIFF
--- a/packages/android_intent_plus/README.md
+++ b/packages/android_intent_plus/README.md
@@ -20,8 +20,8 @@ This plugin allows Flutter apps to launch arbitrary intents when the platform is
 - Dart >=3.1.0 <4.0.0
 - Java 17
 - Kotlin 2.2.0
-- Android Gradle Plugin >=8.12.1
-- Gradle wrapper >=8.13
+- Android Gradle Plugin >=8.13.0
+- Gradle wrapper >=8.14
 
 ## Usage
 

--- a/packages/android_intent_plus/android/build.gradle
+++ b/packages/android_intent_plus/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.12.1'
+        classpath 'com.android.tools.build:gradle:8.13.0'
     }
 }
 

--- a/packages/android_intent_plus/android/gradle.properties
+++ b/packages/android_intent_plus/android/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
+android.builtInKotlin=false

--- a/packages/android_intent_plus/example/android/app/build.gradle
+++ b/packages/android_intent_plus/example/android/app/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id "com.android.application"
-    id "kotlin-android"
     id "dev.flutter.flutter-gradle-plugin"
 }
 

--- a/packages/android_intent_plus/example/android/gradle.properties
+++ b/packages/android_intent_plus/example/android/gradle.properties
@@ -1,2 +1,6 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/packages/android_intent_plus/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/android_intent_plus/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Oct 02 17:46:54 EEST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/packages/android_intent_plus/example/android/settings.gradle
+++ b/packages/android_intent_plus/example/android/settings.gradle
@@ -18,8 +18,7 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.12.1" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.0" apply false
+    id "com.android.application" version "8.13.0" apply false
 }
 
 include ":app"


### PR DESCRIPTION
There is no actual migration and it is just an example app had Kotlin plugin dependency.
Closes #3935 